### PR TITLE
fix: only display ISO name on larger displays and add GHCR link

### DIFF
--- a/public/image-picker.html
+++ b/public/image-picker.html
@@ -199,6 +199,10 @@
           margin-top:30px;
         }
 
+        .button_label .image-name {
+          display: none;
+        }
+
         .select {
           left: 0;
           right: 0;

--- a/public/image-picker.html
+++ b/public/image-picker.html
@@ -277,7 +277,7 @@
               </span>
             </a>
             <a class="sha256" title="Verify (SHA256)"><i class="fas fa-file"><i class="fas fa-check"></i></i></a>
-            <a class="ghcr-details" title="View details on the GitHub Container registry" target="_blank"><i class="fas fa-box-open"></i></a>
+            <a class="ghcr-details" title="View details on the GitHub Container registry" href="https://github.com/orgs/ublue-os/packages?repo_name=bluefin" target="_blank"><i class="fas fa-box-open"></i></a>
           </div>
           <span class="fine-print">Check out the <a href="https://universal-blue.discourse.group/docs?topic=41" target="_blank">Introduction to Bluefin</a>.<br>
           <span class="dx-only hidden-fade">Check out <a href="https://universal-blue.discourse.group/docs?topic=39" target="_blank">Introduction to Bluefin DX</a>.<br></span>


### PR DESCRIPTION
On smaller displays, the text inside the download button is too long, and messes up the other formatting on the page.
![image](https://github.com/castrojo/bluefin-website/assets/46304672/f51f333d-f102-4680-b057-7f2da2806504)

This PR changes the behaviour to hide the ISO name when the screen size is smaller, but keep the name on larger displays.
<img width="654" alt="image" src="https://github.com/castrojo/bluefin-website/assets/46304672/3d043be8-61fe-4204-933e-caa5ea734461">
<img width="991" alt="image" src="https://github.com/castrojo/bluefin-website/assets/46304672/b7957602-6d9d-45a5-a251-b0997a49e04a">

This also fixes what appeared to be a missing link to the GHCR.  There was an icon in an `<a>` tag that didn't lead to anywhere except a blank new page.