### PR TITLE
fix: update GTS stream to Fedora 42

### DIFF
--- a/public/stream-versions.yml
+++ b/public/stream-versions.yml
@@ -12,7 +12,7 @@ lts:
   hwe: "6.16.8-1"
 
 gts:
-  base: "Fedora 41"
+  base: "Fedora 42"
   gnome: "48.6-1"
   kernel: "6.16.8-200"
   mesa: "25.1.9-1"

--- a/scripts/update-stream-versions.js
+++ b/scripts/update-stream-versions.js
@@ -22,7 +22,7 @@ const REPOS = {
 // Base OS mapping for each stream
 const BASE_OS_MAP = {
   lts: "CentOS Stream 10",
-  gts: "Fedora 41",
+  gts: "Fedora 42",
   stable: "Fedora 42"
 }
 


### PR DESCRIPTION
## 🐛 Bug Fix

This PR fixes the incorrect Fedora version displayed for the GTS stream.

### Problem
The GTS stream has been running Fedora 42 since release `gts-20251028` (as confirmed in the [ublue-os/bluefin releases](https://github.com/ublue-os/bluefin/releases/tag/gts-20251028)), but the website was still showing "Fedora 41".

### Root Cause
The automated update script (`scripts/update-stream-versions.js`) correctly extracts package versions (kernel, GNOME, Mesa, etc.) from release changelogs, but uses a **hardcoded mapping** for base OS versions in `BASE_OS_MAP`. This mapping had an outdated value: `gts: "Fedora 41"`.

### Changes Made
1. **Updated `public/stream-versions.yml`**: Changed GTS base from "Fedora 41" to "Fedora 42"
2. **Fixed `scripts/update-stream-versions.js`**: Updated `BASE_OS_MAP.gts` from "Fedora 41" to "Fedora 42"

### Why This Matters
Without fixing the update script, the automated workflow (runs Mondays and Wednesdays at 0 UTC) would revert the YAML file back to "Fedora 41" on the next run. This PR fixes both the current data **and** the root cause.

### Verification
- ✅ GTS release notes confirm Fedora 42: [gts-20251028](https://github.com/ublue-os/bluefin/releases/tag/gts-20251028) shows "F42.20251028"
- ✅ Other package versions (GNOME 48.6-1, kernel 6.16.8-200) match current releases
- ✅ Automated updates will now maintain correct Fedora 42 value