### PR TITLE
docs: update available just recipes on the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,8 @@ npm install
 
 Then, you can use `just` to run the common commands:
 
--   `just dev`: Run the development server
 -   `just build`: Build for production
--   `just preview`: Preview the production build locally
+-   `just serve`: Preview the production build locally
 
 <details>
 <summary>Don't have `just`? Use npm</summary>


### PR DESCRIPTION
Hello!

I was building the website locally using `just` and when trying to run the `dev` recipe, that is currently in the README, the command told me: `Justfile does not contain recipe dev`. After checking the output of `just --list` I realized that there are only two recipes available: `build` and `serve`.

This pull request modifies the README to reflect just that, the two available recipes.
