### PR TITLE
fix: image chooser being empty after following specific lts image flow

### DIFF
--- a/src/components/ImageChooser.vue
+++ b/src/components/ImageChooser.vue
@@ -426,6 +426,7 @@ onMounted(() => {
               else {
                 showGpuStep = true
                 imageName.gpu = undefined
+                imageName.kernel = undefined
                 showDownload = false
               }
             }


### PR DESCRIPTION
This fixes #542 

The problem here is that, while I was able to fix this case, I am unsure if it breaks anything else, as I'm not too familiar with the codebase. From initial testing, everything seems fine.

If someone else has more time, please test the image chooser functionality for both this PR and main branch, validate the fix and see if this fix introduced possible regressions.