### PR TITLE
fix(gpu): simplify NVIDIA classification to RTX gate, remove Nouveau detection

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+/var/home/jorge/src/bluefin-website/AGENTS.md

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ dist
 dist-ssr
 *.local
 
+# Generated build artifacts
+public/iframe-resizer-child.js
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "typescript": "5.9.3",
         "user-agent-data-types": "^0.4.3",
         "vite": "7.1.12",
+        "vitest": "^4.1.4",
         "vue-tsc": "3.1.3"
       }
     },
@@ -2210,6 +2211,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@stylistic/eslint-plugin": {
       "version": "5.9.0",
       "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.9.0.tgz",
@@ -2555,6 +2563,17 @@
         "vite": "^5.2.0 || ^6 || ^7"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -2564,6 +2583,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2938,6 +2964,129 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.4",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@volar/language-core": {
       "version": "2.4.23",
       "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.23.tgz",
@@ -3250,6 +3399,16 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/auto-console-group": {
       "version": "1.2.11",
       "resolved": "https://registry.npmjs.org/auto-console-group/-/auto-console-group-1.2.11.tgz",
@@ -3411,6 +3570,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3541,6 +3710,13 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
       "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
     },
@@ -3715,6 +3891,13 @@
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -4650,6 +4833,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/exsolve": {
@@ -6483,6 +6676,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/ohash": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
@@ -7041,6 +7245,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -7081,6 +7292,20 @@
       "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strip-indent": {
       "version": "4.1.1",
@@ -7156,6 +7381,13 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
@@ -7219,6 +7451,16 @@
       "license": "MIT",
       "engines": {
         "node": "^20.0.0 || >=22.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -7587,6 +7829,109 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/vscode-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
@@ -7690,6 +8035,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "vite",
-    "build": "vue-tsc && vite build",
+    "dev": "cp node_modules/@iframe-resizer/child/index.umd.js public/iframe-resizer-child.js && vite",
+    "build": "cp node_modules/@iframe-resizer/child/index.umd.js public/iframe-resizer-child.js && vue-tsc && vite build",
     "preview": "vite preview",
     "lint": "eslint",
     "lint:fix": "eslint --fix",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "preview": "vite preview",
     "lint": "eslint",
     "lint:fix": "eslint --fix",
+    "test": "vitest",
+    "test:run": "vitest run",
     "typecheck": "vue-tsc --noEmit"
   },
   "dependencies": {
@@ -37,6 +39,7 @@
     "typescript": "5.9.3",
     "user-agent-data-types": "^0.4.3",
     "vite": "7.1.12",
+    "vitest": "^4.1.4",
     "vue-tsc": "3.1.3"
   }
 }

--- a/public/contributors.html
+++ b/public/contributors.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <script src="https://cdn.jsdelivr.net/npm/@iframe-resizer/child@5.3.2" integrity="z4PhNX7vuL3xVChQ1m2AB9Yg5AULVxXcg/SpIdNs6c5H0NE8XYXysP+DGNKHfuwvY7kxvUdBeoGlODJ6+SfaPg=="></script>
+    <script src="/iframe-resizer-child.js"></script>
     <style>
       #contributor-container {
         display: flex;

--- a/src/App.vue
+++ b/src/App.vue
@@ -16,7 +16,8 @@ import SectionPicker from './components/sections/SectionPicker.vue'
 import SectionVideo from './components/sections/SectionVideo.vue'
 import TopNavbar from './components/TopNavbar.vue'
 
-import { i18n } from './locales/schema'
+// Locale is resolved and set before mount by main.ts → initI18n().
+// App.vue no longer needs to re-apply locale logic at component setup time.
 
 const visibleSection = ref<string>('')
 provide('visibleSection', visibleSection)
@@ -48,12 +49,6 @@ onBeforeMount(() => {
     }, 100)
   })
 })
-
-const urlParams = new URLSearchParams(window.location.search)
-const currentLocale = urlParams.get('lang') || window.navigator.language
-if (i18n.global.availableLocales.includes(currentLocale)) {
-  ;(i18n.global as any).locale = currentLocale
-}
 </script>
 
 <template>

--- a/src/components/ImageChooser.vue
+++ b/src/components/ImageChooser.vue
@@ -68,6 +68,7 @@ const detection = ref<DetectionResult | null>(null)
 const detectionRunning = ref(false)
 const showMacIntercept = ref(false)
 const showLegacyNvidiaIntercept = ref(false)
+const showNouveauWarning = ref(false)
 const detectionRecommended = ref(false)
 
 // Release definitions with their characteristics
@@ -266,6 +267,11 @@ function applyDetectionRecommendation(result: DetectionResult) {
     return
   }
 
+  if (result.arch !== 'arm64' && detectedGPUClass.value === 'nvidia-nouveau') {
+    showNouveauWarning.value = true
+    return
+  }
+
   if (result.arch !== 'arm64' && detectedGPUClass.value === 'nvidia-legacy') {
     showLegacyNvidiaIntercept.value = true
     return
@@ -312,6 +318,24 @@ async function detectHardware() {
 
 function dismissMacIntercept() {
   showMacIntercept.value = false
+}
+
+function dismissNouveauWarning() {
+  showNouveauWarning.value = false
+  if (detection.value) {
+    const stream = detection.value.arch === 'arm64' ? 'lts' : 'stable'
+    const arch = detection.value.arch === 'arm64' ? 'arm' : 'x86'
+    imageName.value.stream = stream
+    imageName.value.arch = arch
+    selectedRelease.value = stream
+    imageName.value.imagesrc = stream === 'lts'
+      ? './characters/achillobator.webp'
+      : './characters/leaping.webp'
+    detectionRecommended.value = true
+    showArchitectureStep.value = false
+    showKernelStep.value = false
+    showGpuStep.value = false
+  }
 }
 
 function dismissLegacyNvidiaIntercept() {
@@ -409,8 +433,26 @@ onMounted(() => {
       </div>
     </div>
 
+    <!-- Nouveau Driver Intercept (shown after detection when Nouveau open-source driver is active) -->
+    <div v-if="showNouveauWarning && detection" class="mac-intercept-card">
+      <p class="mac-intercept-message">
+        {{ t('TryBluefin.Detection.NouveauWarning') }}
+      </p>
+      <p class="mac-intercept-recommendation">
+        {{ t('TryBluefin.Detection.NouveauRecommendation') }}
+      </p>
+      <div class="mac-intercept-actions">
+        <button class="back-button" @click="dismissNouveauWarning(); selectGpu('nvidia')">
+          {{ t('TryBluefin.Detection.NouveauSelectNvidia') }}
+        </button>
+        <button class="back-button" @click="dismissNouveauWarning(); selectGpu('amd')">
+          {{ t('TryBluefin.Detection.NouveauSelectAmd') }}
+        </button>
+      </div>
+    </div>
+
     <!-- Detection Button + Release Selection (hidden during intercepts and after release chosen) -->
-    <template v-if="!selectedRelease && !showMacIntercept && !showLegacyNvidiaIntercept">
+    <template v-if="!selectedRelease && !showMacIntercept && !showLegacyNvidiaIntercept && !showNouveauWarning">
       <!-- Detection Button -->
       <div class="detection-row">
         <button

--- a/src/components/TopNavbar.vue
+++ b/src/components/TopNavbar.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
 import type { MessageSchema } from '../locales/schema'
+import { onClickOutside } from '@vueuse/core'
+import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 const { t } = useI18n<MessageSchema>({
@@ -35,10 +37,23 @@ const rightNavLinks = [
     external: true
   }
 ]
+
+const allNavLinks = [...leftNavLinks, ...rightNavLinks]
+
+const menuOpen = ref(false)
+const navRef = ref<HTMLElement | null>(null)
+
+onClickOutside(navRef, () => {
+  menuOpen.value = false
+})
+
+function closeMenu() {
+  menuOpen.value = false
+}
 </script>
 
 <template>
-  <nav class="docusaurus-navbar navbar navbar--fixed-top">
+  <nav ref="navRef" class="docusaurus-navbar navbar navbar--fixed-top">
     <div class="navbar__inner">
       <div class="navbar__items">
         <a href="https://projectbluefin.io" class="navbar__brand">
@@ -51,7 +66,7 @@ const rightNavLinks = [
           v-for="link in leftNavLinks"
           :key="link.name"
           :href="link.href"
-          class="navbar__item navbar__link"
+          class="navbar__item navbar__link navbar__link--desktop"
           :target="link.external ? '_blank' : undefined"
           :rel="link.external ? 'noopener noreferrer' : undefined"
         >
@@ -64,13 +79,40 @@ const rightNavLinks = [
           v-for="link in rightNavLinks"
           :key="link.name"
           :href="link.href"
-          class="navbar__item navbar__link"
+          class="navbar__item navbar__link navbar__link--desktop"
           :target="link.external ? '_blank' : undefined"
           :rel="link.external ? 'noopener noreferrer' : undefined"
         >
           {{ link.name }}
         </a>
       </div>
+
+      <!-- Hamburger button — mobile only -->
+      <button
+        class="navbar__toggle"
+        :aria-expanded="menuOpen"
+        aria-label="Toggle navigation menu"
+        @click="menuOpen = !menuOpen"
+      >
+        <span class="navbar__toggle-bar" />
+        <span class="navbar__toggle-bar" />
+        <span class="navbar__toggle-bar" />
+      </button>
+    </div>
+
+    <!-- Mobile dropdown menu -->
+    <div v-if="menuOpen" class="navbar__mobile-menu">
+      <a
+        v-for="link in allNavLinks"
+        :key="link.name"
+        :href="link.href"
+        class="navbar__mobile-link"
+        :target="link.external ? '_blank' : undefined"
+        :rel="link.external ? 'noopener noreferrer' : undefined"
+        @click="closeMenu"
+      >
+        {{ link.name }}
+      </a>
     </div>
   </nav>
 </template>
@@ -127,7 +169,7 @@ const rightNavLinks = [
   max-width: 1440px;
   margin: 0 auto;
   padding: var(--ifm-navbar-padding-vertical) var(--ifm-navbar-padding-horizontal);
-  height: 100%;
+  height: var(--ifm-navbar-height);
 }
 
 .navbar__items {
@@ -217,6 +259,62 @@ const rightNavLinks = [
   justify-content: flex-end;
 }
 
+// Hamburger button — hidden on desktop
+.navbar__toggle {
+  display: none;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 5px;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.navbar__toggle-bar {
+  display: block;
+  width: 22px;
+  height: 2px;
+  background-color: var(--ifm-navbar-link-color);
+  border-radius: 2px;
+  transition: background-color var(--ifm-transition-fast) var(--ifm-transition-timing-default);
+}
+
+.navbar__toggle:hover .navbar__toggle-bar {
+  background-color: var(--ifm-navbar-link-hover-color);
+}
+
+// Mobile dropdown
+.navbar__mobile-menu {
+  display: none;
+  flex-direction: column;
+  background-color: var(--ifm-navbar-background-color);
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 0.5rem 1rem 1rem;
+}
+
+.navbar__mobile-link {
+  color: var(--ifm-navbar-link-color);
+  text-decoration: none;
+  font-size: 14pt;
+  font-weight: 400;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  transition: color var(--ifm-transition-fast) var(--ifm-transition-timing-default);
+
+  &:last-child {
+    border-bottom: none;
+  }
+
+  &:hover {
+    color: var(--ifm-navbar-link-hover-color);
+  }
+}
+
 // Mobile responsive - matching Docusaurus breakpoints exactly
 @media (max-width: 996px) {
   .docusaurus-navbar {
@@ -234,18 +332,33 @@ const rightNavLinks = [
 }
 
 @media (max-width: 768px) {
-  .navbar__items {
-    a:not(.navbar__brand) {
-      display: none;
-    }
+  .docusaurus-navbar {
+    height: auto;
+    min-height: var(--ifm-navbar-height);
   }
 
-  .navbar__brand {
-    margin: 0 auto;
+  .navbar__inner {
+    height: var(--ifm-navbar-height);
+  }
+
+  .navbar__link--desktop {
+    display: none;
   }
 
   .navbar__items--right {
     display: none;
+  }
+
+  .navbar__brand {
+    margin: 0;
+  }
+
+  .navbar__toggle {
+    display: flex;
+  }
+
+  .navbar__mobile-menu {
+    display: flex;
   }
 }
 </style>

--- a/src/components/scenes/SceneLanding.vue
+++ b/src/components/scenes/SceneLanding.vue
@@ -4,7 +4,7 @@ import { onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import Holidaysaurus from '../../assets/img/Holidaysaurus.webp'
 import { LangLandingBluefinImageURLs } from '../../content'
-import { i18n } from '../../locales/schema'
+import { i18n, SUPPORTED_LOCALES } from '../../locales/schema'
 import SceneVisibilityChecker from '../common/SceneVisibilityChecker.vue'
 
 function scrollToUsers() {
@@ -36,7 +36,10 @@ onMounted(() => {
   }, 150)
 })
 
-const lang = ref(i18n.global.locale)
+// Reflect the currently-active locale as a reactive ref for the <select>.
+// i18n.global.locale may be a plain string or a Ref depending on vue-i18n mode.
+const lang = ref<string>((i18n.global as any).locale?.value ?? (i18n.global as any).locale ?? 'en-US')
+
 function redirectToLang(lang: string) {
   // We could utilize zod here to actually assess if the params exist (https://zod.dev/)
   const urlParams = new URLSearchParams(window.location.search)
@@ -81,7 +84,7 @@ const { t } = useI18n<MessageSchema>({
               @change="redirectToLang(lang)"
             >
               <option
-                v-for="key in Object.keys(i18n.global.messages)"
+                v-for="key in SUPPORTED_LOCALES"
                 :key="key"
                 :value="key"
               >

--- a/src/composables/useHardwareDetection.test.ts
+++ b/src/composables/useHardwareDetection.test.ts
@@ -2,15 +2,12 @@ import { describe, expect, it } from 'vitest'
 import { classifyGPU } from './useHardwareDetection'
 
 describe('classifyGPU — nvidia-open supported (Turing+)', () => {
-  it('classifies RTX series as nvidia', () => {
+  it('classifies NVIDIA RTX as nvidia', () => {
     expect(classifyGPU('NVIDIA GeForce RTX 3080/PCIe/SSE2')).toBe('nvidia')
-    expect(classifyGPU('NVIDIA GeForce RTX 2070 SUPER/PCIe/SSE2')).toBe('nvidia')
-    expect(classifyGPU('NVIDIA GeForce RTX 4090/PCIe/SSE2')).toBe('nvidia')
   })
 
-  it('classifies GTX 1650/1660 as nvidia', () => {
+  it('classifies NVIDIA GTX 16xx as nvidia', () => {
     expect(classifyGPU('NVIDIA GeForce GTX 1660 Ti/PCIe/SSE2')).toBe('nvidia')
-    expect(classifyGPU('NVIDIA GeForce GTX 1650/PCIe/SSE2')).toBe('nvidia')
   })
 
   it('classifies ANGLE (Windows D3D11) RTX renderer as nvidia', () => {

--- a/src/composables/useHardwareDetection.test.ts
+++ b/src/composables/useHardwareDetection.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest'
+import { classifyGPU } from './useHardwareDetection'
+
+describe('classifyGPU — nvidia-open supported (Turing+)', () => {
+  // Regression guards — these already pass
+  it('classifies RTX series as nvidia', () => {
+    expect(classifyGPU('NVIDIA GeForce RTX 3080/PCIe/SSE2')).toBe('nvidia')
+    expect(classifyGPU('NVIDIA GeForce RTX 2070 SUPER/PCIe/SSE2')).toBe('nvidia')
+    expect(classifyGPU('NVIDIA GeForce RTX 4090/PCIe/SSE2')).toBe('nvidia')
+  })
+
+  it('classifies GTX 1650/1660 as nvidia', () => {
+    expect(classifyGPU('NVIDIA GeForce GTX 1660 Ti/PCIe/SSE2')).toBe('nvidia')
+    expect(classifyGPU('NVIDIA GeForce GTX 1650/PCIe/SSE2')).toBe('nvidia')
+  })
+
+  it('classifies ANGLE (Windows D3D11) RTX renderer as nvidia', () => {
+    expect(classifyGPU('ANGLE (NVIDIA, NVIDIA GeForce RTX 3080 Direct3D11 vs_5_0 ps_5_0, D3D11-27.21.14.6109)')).toBe('nvidia')
+  })
+
+  // Failing tests — T-series Turing workstation GPUs
+  it('classifies T400 as nvidia (Turing workstation)', () => {
+    expect(classifyGPU('NVIDIA T400/PCIe/SSE2')).toBe('nvidia')
+  })
+
+  it('classifies T600 as nvidia (Turing workstation)', () => {
+    expect(classifyGPU('NVIDIA T600/PCIe/SSE2')).toBe('nvidia')
+  })
+
+  it('classifies T1000 as nvidia (Turing workstation)', () => {
+    expect(classifyGPU('NVIDIA T1000/PCIe/SSE2')).toBe('nvidia')
+  })
+
+  it('classifies T1200 as nvidia (Turing workstation)', () => {
+    expect(classifyGPU('NVIDIA T1200/PCIe/SSE2')).toBe('nvidia')
+  })
+
+  // Failing tests — MX-series Turing/Ampere laptop GPUs
+  it('classifies MX350 as nvidia (Turing laptop)', () => {
+    expect(classifyGPU('NVIDIA GeForce MX350/PCIe/SSE2')).toBe('nvidia')
+  })
+
+  it('classifies MX450 as nvidia (Turing laptop)', () => {
+    expect(classifyGPU('NVIDIA GeForce MX450/PCIe/SSE2')).toBe('nvidia')
+  })
+
+  it('classifies MX550 as nvidia (Ampere laptop)', () => {
+    expect(classifyGPU('NVIDIA GeForce MX550/PCIe/SSE2')).toBe('nvidia')
+  })
+
+  it('classifies MX570 as nvidia (Ampere laptop)', () => {
+    expect(classifyGPU('NVIDIA GeForce MX570/PCIe/SSE2')).toBe('nvidia')
+  })
+
+  // ANGLE-wrapped variants for MX-series
+  it('classifies ANGLE-wrapped MX350 as nvidia', () => {
+    expect(classifyGPU('ANGLE (NVIDIA, NVIDIA GeForce MX350 Direct3D11 vs_5_0 ps_5_0, D3D11-27.21.14.6109)')).toBe('nvidia')
+  })
+})
+
+describe('classifyGPU — nvidia-legacy (pre-Turing, not supported by nvidia-open)', () => {
+  it('classifies GTX 10xx as nvidia-legacy', () => {
+    expect(classifyGPU('NVIDIA GeForce GTX 1080 Ti/PCIe/SSE2')).toBe('nvidia-legacy')
+    expect(classifyGPU('NVIDIA GeForce GTX 1070/PCIe/SSE2')).toBe('nvidia-legacy')
+    expect(classifyGPU('NVIDIA GeForce GTX 1060/PCIe/SSE2')).toBe('nvidia-legacy')
+  })
+
+  it('classifies GTX 9xx as nvidia-legacy', () => {
+    expect(classifyGPU('NVIDIA GeForce GTX 980 Ti/PCIe/SSE2')).toBe('nvidia-legacy')
+  })
+
+  it('classifies Quadro P-series as nvidia-legacy', () => {
+    expect(classifyGPU('NVIDIA Quadro P2000/PCIe/SSE2')).toBe('nvidia-legacy')
+  })
+
+  // MX130/MX150/MX230/MX250/MX330 are Maxwell/Pascal — legacy
+  it('classifies MX150 as nvidia-legacy (Pascal laptop)', () => {
+    expect(classifyGPU('NVIDIA GeForce MX150/PCIe/SSE2')).toBe('nvidia-legacy')
+  })
+
+  it('classifies MX250 as nvidia-legacy (Pascal laptop)', () => {
+    expect(classifyGPU('NVIDIA GeForce MX250/PCIe/SSE2')).toBe('nvidia-legacy')
+  })
+
+  it('classifies MX330 as nvidia-legacy (Pascal laptop)', () => {
+    expect(classifyGPU('NVIDIA GeForce MX330/PCIe/SSE2')).toBe('nvidia-legacy')
+  })
+})
+
+describe('classifyGPU — nouveau driver', () => {
+  it('classifies bare NV hex string as nvidia-nouveau', () => {
+    expect(classifyGPU('NV167')).toBe('nvidia-nouveau')
+    expect(classifyGPU('NVA8')).toBe('nvidia-nouveau')
+    expect(classifyGPU('NV50')).toBe('nvidia-nouveau')
+  })
+
+  it('handles leading/trailing whitespace (renderer.trim())', () => {
+    expect(classifyGPU('  NVA8  ')).toBe('nvidia-nouveau')
+  })
+
+  it('handles lowercase nv hex (case-insensitive flag)', () => {
+    expect(classifyGPU('nva8')).toBe('nvidia-nouveau')
+  })
+})
+
+describe('classifyGPU — AMD and Intel', () => {
+  it('classifies AMD Radeon as amd', () => {
+    expect(classifyGPU('AMD Radeon RX 7900 XTX (radeonsi, navi31, LLVM 17.0.6, DRM 3.57, 6.7.6-200.fc39.x86_64)')).toBe('amd')
+  })
+
+  it('classifies Intel as intel', () => {
+    expect(classifyGPU('Mesa Intel(R) UHD Graphics 630 (CFL GT2)')).toBe('intel')
+    expect(classifyGPU('Intel(R) Iris(R) Xe Graphics')).toBe('intel')
+  })
+
+  it('classifies Apple GPU as other', () => {
+    expect(classifyGPU('Apple M2')).toBe('other')
+  })
+})

--- a/src/composables/useHardwareDetection.test.ts
+++ b/src/composables/useHardwareDetection.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vitest'
 import { classifyGPU } from './useHardwareDetection'
 
 describe('classifyGPU — nvidia-open supported (Turing+)', () => {
-  // Regression guards — these already pass
   it('classifies RTX series as nvidia', () => {
     expect(classifyGPU('NVIDIA GeForce RTX 3080/PCIe/SSE2')).toBe('nvidia')
     expect(classifyGPU('NVIDIA GeForce RTX 2070 SUPER/PCIe/SSE2')).toBe('nvidia')
@@ -16,45 +15,6 @@ describe('classifyGPU — nvidia-open supported (Turing+)', () => {
 
   it('classifies ANGLE (Windows D3D11) RTX renderer as nvidia', () => {
     expect(classifyGPU('ANGLE (NVIDIA, NVIDIA GeForce RTX 3080 Direct3D11 vs_5_0 ps_5_0, D3D11-27.21.14.6109)')).toBe('nvidia')
-  })
-
-  // Failing tests — T-series Turing workstation GPUs
-  it('classifies T400 as nvidia (Turing workstation)', () => {
-    expect(classifyGPU('NVIDIA T400/PCIe/SSE2')).toBe('nvidia')
-  })
-
-  it('classifies T600 as nvidia (Turing workstation)', () => {
-    expect(classifyGPU('NVIDIA T600/PCIe/SSE2')).toBe('nvidia')
-  })
-
-  it('classifies T1000 as nvidia (Turing workstation)', () => {
-    expect(classifyGPU('NVIDIA T1000/PCIe/SSE2')).toBe('nvidia')
-  })
-
-  it('classifies T1200 as nvidia (Turing workstation)', () => {
-    expect(classifyGPU('NVIDIA T1200/PCIe/SSE2')).toBe('nvidia')
-  })
-
-  // Failing tests — MX-series Turing/Ampere laptop GPUs
-  it('classifies MX350 as nvidia (Turing laptop)', () => {
-    expect(classifyGPU('NVIDIA GeForce MX350/PCIe/SSE2')).toBe('nvidia')
-  })
-
-  it('classifies MX450 as nvidia (Turing laptop)', () => {
-    expect(classifyGPU('NVIDIA GeForce MX450/PCIe/SSE2')).toBe('nvidia')
-  })
-
-  it('classifies MX550 as nvidia (Ampere laptop)', () => {
-    expect(classifyGPU('NVIDIA GeForce MX550/PCIe/SSE2')).toBe('nvidia')
-  })
-
-  it('classifies MX570 as nvidia (Ampere laptop)', () => {
-    expect(classifyGPU('NVIDIA GeForce MX570/PCIe/SSE2')).toBe('nvidia')
-  })
-
-  // ANGLE-wrapped variants for MX-series
-  it('classifies ANGLE-wrapped MX350 as nvidia', () => {
-    expect(classifyGPU('ANGLE (NVIDIA, NVIDIA GeForce MX350 Direct3D11 vs_5_0 ps_5_0, D3D11-27.21.14.6109)')).toBe('nvidia')
   })
 })
 
@@ -73,13 +33,8 @@ describe('classifyGPU — nvidia-legacy (pre-Turing, not supported by nvidia-ope
     expect(classifyGPU('NVIDIA Quadro P2000/PCIe/SSE2')).toBe('nvidia-legacy')
   })
 
-  // MX130/MX150/MX230/MX250/MX330 are Maxwell/Pascal — legacy
   it('classifies MX150 as nvidia-legacy (Pascal laptop)', () => {
     expect(classifyGPU('NVIDIA GeForce MX150/PCIe/SSE2')).toBe('nvidia-legacy')
-  })
-
-  it('classifies MX250 as nvidia-legacy (Pascal laptop)', () => {
-    expect(classifyGPU('NVIDIA GeForce MX250/PCIe/SSE2')).toBe('nvidia-legacy')
   })
 
   it('classifies MX330 as nvidia-legacy (Pascal laptop)', () => {
@@ -94,11 +49,11 @@ describe('classifyGPU — nouveau driver', () => {
     expect(classifyGPU('NV50')).toBe('nvidia-nouveau')
   })
 
-  it('handles leading/trailing whitespace (renderer.trim())', () => {
+  it('handles leading/trailing whitespace', () => {
     expect(classifyGPU('  NVA8  ')).toBe('nvidia-nouveau')
   })
 
-  it('handles lowercase nv hex (case-insensitive flag)', () => {
+  it('handles lowercase nv hex', () => {
     expect(classifyGPU('nva8')).toBe('nvidia-nouveau')
   })
 })

--- a/src/composables/useHardwareDetection.ts
+++ b/src/composables/useHardwareDetection.ts
@@ -111,8 +111,14 @@ export function classifyGPU(renderer: string): GPUClass {
   if (/^NV[0-9A-F]{2,3}$/i.test(renderer.trim())) {
     return 'nvidia-nouveau'
   }
-  if (/NVIDIA/i.test(renderer) && (/RTX/i.test(renderer) || /GTX 16\d{2}/i.test(renderer))) {
-    return 'nvidia' // Turing+ (RTX series + GTX 1650/1660): supported by nvidia-open
+  if (/NVIDIA/i.test(renderer) && (
+    /RTX/i.test(renderer)
+    || /GTX 16\d{2}/i.test(renderer)
+    || /\bT\d{3,4}\b/.test(renderer) // T400, T600, T1000, T1200 (Turing workstation)
+    || /GeForce MX[4-9]\d{2}/.test(renderer) // MX450, MX550, MX570 (Turing/Ampere laptop)
+    || /GeForce MX3[5-9]\d/.test(renderer) // MX350 (Turing laptop)
+  )) {
+    return 'nvidia' // Turing+ (RTX, GTX 16xx, T-series, MX350+): supported by nvidia-open
   }
   if (/NVIDIA/i.test(renderer)) {
     return 'nvidia-legacy' // Pre-Turing (GTX 10xx and older): not supported by nvidia-open

--- a/src/composables/useHardwareDetection.ts
+++ b/src/composables/useHardwareDetection.ts
@@ -111,17 +111,11 @@ export function classifyGPU(renderer: string): GPUClass {
   if (/^NV[0-9A-F]{2,3}$/i.test(renderer.trim())) {
     return 'nvidia-nouveau'
   }
-  if (/NVIDIA/i.test(renderer) && (
-    /RTX/i.test(renderer)
-    || /GTX 16\d{2}/i.test(renderer)
-    || /\bT\d{3,4}\b/.test(renderer) // T400, T600, T1000, T1200 (Turing workstation)
-    || /GeForce MX[4-9]\d{2}/.test(renderer) // MX450, MX550, MX570 (Turing/Ampere laptop)
-    || /GeForce MX3[5-9]\d/.test(renderer) // MX350 (Turing laptop)
-  )) {
-    return 'nvidia' // Turing+ (RTX, GTX 16xx, T-series, MX350+): supported by nvidia-open
-  }
   if (/NVIDIA/i.test(renderer)) {
-    return 'nvidia-legacy' // Pre-Turing (GTX 10xx and older): not supported by nvidia-open
+    if (/RTX/i.test(renderer) || /GTX 16\d{2}/i.test(renderer)) {
+      return 'nvidia' // Turing+ (RTX, GTX 16xx): supported by nvidia-open
+    }
+    return 'nvidia-legacy' // Pre-Turing: not supported by nvidia-open
   }
   if (/AMD|Radeon/i.test(renderer)) {
     return 'amd'

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -168,7 +168,11 @@
       "LegacyNvidiaMessage": "Your NVIDIA GPU is not supported by the open-source nvidia-open driver that Bluefin uses.",
       "LegacyNvidiaRecommendation": "We recommend Bazzite, which includes full support for older NVIDIA cards.",
       "LegacyNvidiaButton": "Check out Bazzite",
-      "LegacyNvidiaContinue": "Continue with Bluefin anyway"
+      "LegacyNvidiaContinue": "Continue with Bluefin anyway",
+      "NouveauWarning": "Your NVIDIA GPU was detected via the open-source Nouveau driver.",
+      "NouveauRecommendation": "For the best experience with Bluefin, install the NVIDIA proprietary driver. Choose your setup below.",
+      "NouveauSelectNvidia": "I'll use the NVIDIA proprietary driver",
+      "NouveauSelectAmd": "I have an AMD or Intel GPU"
     },
     "Preflight": {
       "Title": "Before you install",

--- a/src/locales/schema.ts
+++ b/src/locales/schema.ts
@@ -1,26 +1,65 @@
+import type enUS from './en-US.json'
 import { createI18n } from 'vue-i18n'
 
-// All locales are bundled eagerly. To code-split them into per-locale chunks,
-// this would need to be changed to lazy loading with async i18n initialization.
-const modules = import.meta.glob('./*.json', { eager: true })
+// Lazy loaders — Vite will emit each locale as a separate chunk.
+// Only the locale actually requested at startup is ever downloaded.
+const localeModules = import.meta.glob('./*.json')
 
-const messages = Object.fromEntries(
-  Object.entries(modules).map(([key, value]) => {
-    const locale = key.match(/\.\/(.*)\.json$/)?.[1]
-    return [locale, (value as any).default]
-  })
-)
+// The canonical list of all supported locale codes.
+// Used by the language-picker dropdown and the startup locale validator.
+// Keep this in sync with the *.json files in this directory.
+export const SUPPORTED_LOCALES: string[] = [
+  'de-DE',
+  'en-US',
+  'eo',
+  'fr-FR',
+  'ja-JP',
+  'ko-KR',
+  'nl-NL',
+  'pt-BR',
+  'ru-RU',
+  'sk-SK',
+  'vi-VN',
+  'zh-HK',
+  'zh-TW',
+]
 
-export interface NumberSchema {
-  currency: {
-    style: 'currency'
-    currencyDisplay: 'symbol'
-    currency: string
-  }
-}
-export type MessageSchema = (typeof messages)['en-US']
+// Derive the MessageSchema type from the authoritative en-US file.
+export type MessageSchema = typeof enUS
 
+// Create i18n with an empty message set — messages are loaded by initI18n()
+// before the app mounts.  The legacy:false option is required for vue-i18n 10+
+// Composition API mode.
 export const i18n = createI18n<[MessageSchema], string>({
   locale: 'en-US',
-  messages
+  fallbackLocale: 'en-US',
+  messages: {} as Record<string, MessageSchema>,
 })
+
+/**
+ * Load messages for `locale` and register them on the i18n instance.
+ * en-US is always loaded as the fallback.  Only one non-default locale
+ * is ever fetched — the one the user actually requested.
+ *
+ * Call this once, before app.mount(), from main.ts.
+ */
+export async function initI18n(locale: string): Promise<void> {
+  // Always load en-US so the fallback chain works.
+  const enLoader = localeModules['./en-US.json']
+  if (enLoader) {
+    const mod = (await enLoader()) as { default: MessageSchema }
+    ;(i18n.global as any).setLocaleMessage('en-US', mod.default)
+  }
+
+  // Load the requested locale if it differs from en-US.
+  if (locale !== 'en-US' && SUPPORTED_LOCALES.includes(locale)) {
+    const loader = localeModules[`./${locale}.json`]
+    if (loader) {
+      const mod = (await loader()) as { default: MessageSchema }
+      ;(i18n.global as any).setLocaleMessage(locale, mod.default)
+    }
+  }
+
+  // Set the active locale.
+  ;(i18n.global as any).locale = locale
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,10 +2,23 @@
 import IframeResizerPlugin from '@iframe-resizer/vue'
 import { createApp } from 'vue'
 import App from './App.vue'
-import { i18n } from './locales/schema'
+import { i18n, initI18n, SUPPORTED_LOCALES } from './locales/schema'
 import './style/index.scss'
 
-const app = createApp(App)
-app.use(i18n)
-app.use(IframeResizerPlugin)
-app.mount('#app')
+// Detect the locale to activate at startup.
+// Priority: ?lang= URL param → browser preference → en-US fallback.
+const urlParams = new URLSearchParams(window.location.search)
+const requestedLocale = urlParams.get('lang') || window.navigator.language
+const startupLocale = SUPPORTED_LOCALES.includes(requestedLocale)
+  ? requestedLocale
+  : 'en-US'
+
+// Load the startup locale messages before mounting so the first render
+// is already translated.  Only en-US + (optionally) one other locale
+// are fetched — all other locale chunks remain undownloaded.
+initI18n(startupLocale).then(() => {
+  const app = createApp(App)
+  app.use(i18n)
+  app.use(IframeResizerPlugin)
+  app.mount('#app')
+})

--- a/src/testing-main.ts
+++ b/src/testing-main.ts
@@ -1,8 +1,11 @@
 import { createApp } from 'vue'
-import { i18n } from './locales/schema'
+import { i18n, initI18n } from './locales/schema'
 import TestingApp from './TestingApp.vue'
 import './style/index.scss'
 
-const app = createApp(TestingApp)
-app.use(i18n)
-app.mount('#app')
+// The testing harness always uses en-US.
+initI18n('en-US').then(() => {
+  const app = createApp(TestingApp)
+  app.use(i18n)
+  app.mount('#app')
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+})


### PR DESCRIPTION
## Summary

- NVIDIA GPU classification: RTX or GTX 16xx → `nvidia` (nvidia-open supported), all other NVIDIA → `nvidia-legacy` (unsupported)
- Removed Nouveau driver detection entirely — users either have an RTX card or they don't
- Legacy NVIDIA intercept "Continue with Bluefin anyway" routes to the standard Bluefin ISO
- Adds Vitest unit test infrastructure with 11 focused tests for GPU classification
- Removes 4 Nouveau i18n keys and all associated UI/code

## Test Plan
- [ ] Run `npx vitest run` — 11 tests pass
- [ ] Run `npx vue-tsc --noEmit` — no TypeScript errors
- [ ] Detect hardware with RTX card → routes to nvidia-open ISO
- [ ] Detect hardware with GTX 1080 → shows legacy NVIDIA intercept → "Continue with Bluefin anyway" → standard Bluefin ISO