### PR TITLE
fix:Link to Homebrew in translation to pt-br

### DIFF
--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -77,7 +77,7 @@
     "Tag": "Execute suas",
     "Title": "Aplicações favoritas",
     "Description": "Bluefin utiliza a loja de aplicativos <a href=\"https://github.com/kolunmi/bazaar\" target=\"_blank\">Bazaar</a>, permitindo a instalação e gerenciamento fáceis de todos os seus aplicativos favoritos do <a href=\"https://flathub.org\" target=\"_blank\">Flathub</a> e uma lista curada de aplicativos que achamos que você vai adorar.",
-    "Additional": "Além disso, a Bluefin vem com o <a href=\"https://docs.brew.sh/Homebrew-on-Linux\">Homebrew</a> e fluxos de trabalho predefinidos com aplicativos em contêineres, tornando a execução de qualquer software uma tarefa simples. Como todo o mundo do software vem em contêineres, usá-los se torna rápido e eficiente! <br><br><strong>Bluefin é desenvolvido na Bluefin.</strong>",
+    "Additional": "Além disso, a Bluefin vem com o <a href=\"https://docs.brew.sh/Homebrew-on-Linux\" target=\"_blank\">Homebrew</a> e fluxos de trabalho predefinidos com aplicativos em contêineres, tornando a execução de qualquer software uma tarefa simples. Como todo o mundo do software vem em contêineres, usá-los se torna rápido e eficiente! <br><br><strong>Bluefin é desenvolvido na Bluefin.</strong>",
     "FlathubButton": "Veja os aplicativos no Flathub"
   },
   "TryBluefin": {

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -77,7 +77,7 @@
     "Tag": "Execute suas",
     "Title": "Aplicações favoritas",
     "Description": "Bluefin utiliza a loja de aplicativos <a href=\"https://github.com/kolunmi/bazaar\" target=\"_blank\">Bazaar</a>, permitindo a instalação e gerenciamento fáceis de todos os seus aplicativos favoritos do <a href=\"https://flathub.org\" target=\"_blank\">Flathub</a> e uma lista curada de aplicativos que achamos que você vai adorar.",
-    "Additional": "Além disso, a Bluefin vem com o [Homebrew](https://docs.brew.sh/Homebrew-on-Linux) e fluxos de trabalho com aplicativos em contêineres, tornando a execução de qualquer software uma tarefa simples. Como todo o mundo do software vem em contêineres, usá-los se torna rápido e eficiente! <br><br><strong>Bluefin é desenvolvido na Bluefin.</strong>",
+    "Additional": "Além disso, a Bluefin vem com o <a href=\"https://docs.brew.sh/Homebrew-on-Linux\">Homebrew</a> e fluxos de trabalho predefinidos com aplicativos em contêineres, tornando a execução de qualquer software uma tarefa simples. Como todo o mundo do software vem em contêineres, usá-los se torna rápido e eficiente! <br><br><strong>Bluefin é desenvolvido na Bluefin.</strong>",
     "FlathubButton": "Veja os aplicativos no Flathub"
   },
   "TryBluefin": {


### PR DESCRIPTION
The text in the Homebrew box was not being rendered as expected. I replaced the markup link style to pure HTML, just escaping the double quotes to render correctly.