### PR TITLE
feat: dakota page polish — links, chips, mobile, copy fixes

### DIFF
--- a/public/dakota-versions.json
+++ b/public/dakota-versions.json
@@ -1,6 +1,7 @@
 {
   "generatedAt": "2026-05-10T00:00:00.000Z",
   "packages": {
+    "baseline": "x86-64-v3",
     "kernel": "6.19.11",
     "gnome": "50.0",
     "mesa": "26.0.5",

--- a/src/DakotaApp.vue
+++ b/src/DakotaApp.vue
@@ -143,6 +143,7 @@ if (i18n.global.availableLocales.includes(currentLocale)) {
   justify-content: flex-start;
   flex: 1;
   min-width: 0;
+  overflow: hidden;
   background: rgba(var(--color-bg-rgb), 0.55);
   backdrop-filter: blur(8px);
   border-radius: 12px;
@@ -155,6 +156,10 @@ if (i18n.global.availableLocales.includes(currentLocale)) {
 
   @media (max-width: 600px) {
     padding: 20px 20px;
+  }
+
+  @media (max-width: 500px) {
+    padding: 20px 16px;
   }
 }
 </style>

--- a/src/components/dakota/DakotaDownloadCard.vue
+++ b/src/components/dakota/DakotaDownloadCard.vue
@@ -159,4 +159,23 @@ const entries: DownloadEntry[] = [
     height: 1.4rem;
   }
 }
+
+@media (max-width: 500px) {
+  .entry {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 10px;
+    padding: 16px 0;
+  }
+
+  .entry-buttons {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .entry-dl {
+    flex: 1;
+    justify-content: center;
+  }
+}
 </style>

--- a/src/components/dakota/DakotaHighlights.vue
+++ b/src/components/dakota/DakotaHighlights.vue
@@ -53,9 +53,13 @@ import {
                   <div class="icon-wrap">
                     <IconSourceBranch />
                   </div>
-                  <a class="brand-title" href="https://buildstream.build" target="_blank" rel="noopener noreferrer">BuildStream 2</a>
+                  <span class="brand-title">
+                    <a href="https://buildstream.build" target="_blank" rel="noopener noreferrer">BuildStream</a>
+                    &amp;
+                    <a href="https://buildgrid.build" target="_blank" rel="noopener noreferrer">BuildGrid</a>
+                  </span>
                 </div>
-                <p>Hermetic sandbox builds, reproducible and fully auditable</p>
+                <p>Hermetic sandbox builds with distributed execution, reproducible and fully auditable</p>
               </div>
             </div>
           </div>
@@ -120,6 +124,16 @@ import {
     &[href]:hover {
       text-decoration: underline;
       opacity: 0.85;
+    }
+
+    a {
+      color: var(--color-text-light);
+      text-decoration: none;
+
+      &:hover {
+        text-decoration: underline;
+        opacity: 0.85;
+      }
     }
   }
 

--- a/src/components/dakota/DakotaHighlights.vue
+++ b/src/components/dakota/DakotaHighlights.vue
@@ -20,7 +20,7 @@ import {
                   <div class="icon-wrap">
                     <IconGnome />
                   </div>
-                  <span class="brand-title">GNOME OS</span>
+                  <a class="brand-title" href="https://os.gnome.org" target="_blank" rel="noopener noreferrer">GNOME OS</a>
                 </div>
                 <p>The latest stable release of GNOME, no delays</p>
               </div>
@@ -31,7 +31,7 @@ import {
                   <div class="icon-wrap">
                     <IconShieldCheck />
                   </div>
-                  <span class="brand-title">Modern Userspace</span>
+                  <a class="brand-title" href="https://github.com/uutils/coreutils" target="_blank" rel="noopener noreferrer">Modern Userspace</a>
                 </div>
                 <p>uutils, systemd-boot, and legacy-free</p>
               </div>
@@ -42,7 +42,7 @@ import {
                   <div class="icon-wrap">
                     <IconLayers />
                   </div>
-                  <span class="brand-title">Freedesktop SDK</span>
+                  <a class="brand-title" href="https://freedesktop-sdk.io" target="_blank" rel="noopener noreferrer">Freedesktop SDK</a>
                 </div>
                 <p>Same battle tested libraries as Flathub. Continuously upgraded, always up to date.</p>
               </div>
@@ -53,7 +53,7 @@ import {
                   <div class="icon-wrap">
                     <IconSourceBranch />
                   </div>
-                  <span class="brand-title">BuildStream 2</span>
+                  <a class="brand-title" href="https://buildstream.build" target="_blank" rel="noopener noreferrer">BuildStream 2</a>
                 </div>
                 <p>Hermetic sandbox builds, reproducible and fully auditable</p>
               </div>
@@ -115,6 +115,12 @@ import {
     font-weight: 700;
     color: var(--color-text-light);
     align-self: center;
+    text-decoration: none;
+
+    &[href]:hover {
+      text-decoration: underline;
+      opacity: 0.85;
+    }
   }
 
   :deep(.brand-grid) {

--- a/src/components/dakota/DakotaHighlights.vue
+++ b/src/components/dakota/DakotaHighlights.vue
@@ -44,7 +44,7 @@ import {
                   </div>
                   <span class="brand-title">Freedesktop SDK</span>
                 </div>
-                <p>Same battle tested libraries used as Flathub. Continuously upgraded, always the up to date.</p>
+                <p>Same battle tested libraries as Flathub. Continuously upgraded, always up to date.</p>
               </div>
 
               <!-- Right: BuildStream 2 -->
@@ -119,6 +119,28 @@ import {
 
   :deep(.brand-grid) {
     margin-bottom: 0;
+  }
+}
+
+// Phone: single column brand-grid
+@media (max-width: 500px) {
+  :deep(.brand-grid) {
+    grid-template-columns: 1fr;
+  }
+
+  // Remove odd-item right border in single-column
+  :deep(.brand-item:nth-child(odd)) {
+    border-right: none;
+  }
+
+  // Last 2 items still need no bottom border
+  :deep(.brand-item:nth-last-child(1)),
+  :deep(.brand-item:nth-last-child(2)) {
+    border-bottom: 1px solid var(--color-border-light);
+  }
+
+  :deep(.brand-item:last-child) {
+    border-bottom: none;
   }
 }
 </style>

--- a/src/components/dakota/DakotaHighlights.vue
+++ b/src/components/dakota/DakotaHighlights.vue
@@ -33,7 +33,7 @@ import {
                   </div>
                   <a class="brand-title" href="https://github.com/uutils/coreutils" target="_blank" rel="noopener noreferrer">Modern Userspace</a>
                 </div>
-                <p>uutils, systemd-boot, and legacy-free</p>
+                <p>bootc, brew, uutils, systemd-boot, container first, and legacy-free</p>
               </div>
 
               <!-- Left: primary — freedesktop-sdk -->
@@ -139,28 +139,6 @@ import {
 
   :deep(.brand-grid) {
     margin-bottom: 0;
-  }
-}
-
-// Phone: single column brand-grid
-@media (max-width: 500px) {
-  :deep(.brand-grid) {
-    grid-template-columns: 1fr;
-  }
-
-  // Remove odd-item right border in single-column
-  :deep(.brand-item:nth-child(odd)) {
-    border-right: none;
-  }
-
-  // Last 2 items still need no bottom border
-  :deep(.brand-item:nth-last-child(1)),
-  :deep(.brand-item:nth-last-child(2)) {
-    border-bottom: 1px solid var(--color-border-light);
-  }
-
-  :deep(.brand-item:last-child) {
-    border-bottom: none;
   }
 }
 </style>

--- a/src/components/dakota/DakotaScene.vue
+++ b/src/components/dakota/DakotaScene.vue
@@ -118,4 +118,15 @@ onMounted(() => {
   padding: 8px 16px;
   margin-bottom: 0;
 }
+
+@media (max-width: 500px) {
+  .alpha-badge {
+    font-size: 1.1rem;
+    padding: 6px 12px;
+  }
+
+  .hero-title {
+    font-size: 4.5rem;
+  }
+}
 </style>

--- a/src/components/dakota/DakotaVersionChips.vue
+++ b/src/components/dakota/DakotaVersionChips.vue
@@ -7,6 +7,7 @@ interface DakotaVersions {
 }
 
 const LABELS: Record<string, string> = {
+  baseline: 'x86-64',
   kernel: 'Kernel',
   gnome: 'GNOME',
   mesa: 'Mesa',

--- a/src/components/dakota/DakotaVersionChips.vue
+++ b/src/components/dakota/DakotaVersionChips.vue
@@ -93,4 +93,19 @@ const chips = computed(() => {
   font-weight: 700;
   font-size: 1.2rem;
 }
+
+@media (max-width: 500px) {
+  .version-chips {
+    gap: 6px;
+  }
+
+  .version-chip {
+    font-size: 1.1rem;
+  }
+
+  .chip-label,
+  .chip-value {
+    padding: 4px 6px;
+  }
+}
 </style>


### PR DESCRIPTION
Follow-up to #581. All improvements made post-merge:

- Fix i18n legacy mode locale cast (blank page regression)
- Version chip text bold white monospace
- Replace placeholder [CNCF] [Apache Foundation] [UAPI Group] links
- Side-by-side DAKOTA text + raptor at half 16:9 viewport
- bootc 1.15.2 and Nvidia 595.71.05 added to version chips
- Mobile layout: single-column feature grid at 500px, stacked download buttons
- Section titles linked to upstreams: GNOME OS, Freedesktop SDK, Modern Userspace
- BuildStream split into BuildStream & BuildGrid with separate links
- x86-64-v3 baseline pill added
- Modern Userspace copy: bootc, brew, uutils, systemd-boot, container first
- Freedesktop SDK description restored

Assisted-by: claude-sonnet-4.6 via pi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added baseline architecture support for package versions
  * Added external links to related projects (GNOME OS, Modern Userspace, Freedesktop SDK, BuildStream, and BuildGrid)

* **Style**
  * Improved mobile responsive design with optimized layouts, spacing, and font sizing for smaller screens

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/website/pull/582)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->