### PR TITLE
fix: Dakota not Bluefin in hero copy, fix awkward phrasing

### DIFF
--- a/src/components/dakota/DakotaScene.vue
+++ b/src/components/dakota/DakotaScene.vue
@@ -24,7 +24,7 @@ onMounted(() => {
     </p>
 
     <p class="hero-desc">
-      Bluefin is a Freedesktop.org and GNOME OS image designed from the ground up to be the most modern raptor in the pack. The familiar Bluefin desktop and developer experience, in a whole new streamlined package. Built from best tech OS tech from the <a href="https://cncf.io" target="_blank" rel="noopener noreferrer">CNCF</a>, <a href="https://www.apache.org" target="_blank" rel="noopener noreferrer">Apache Foundation</a>, and the <a href="https://uapi-group.org" target="_blank" rel="noopener noreferrer">UAPI Group</a>. Do not run, you'll only die tired.
+      Dakota is a Freedesktop.org and GNOME OS image designed from the ground up to be the most modern raptor in the pack. The familiar Bluefin desktop and developer experience, in a whole new streamlined package. Built from the best OS tech from the <a href="https://cncf.io" target="_blank" rel="noopener noreferrer">CNCF</a>, <a href="https://www.apache.org" target="_blank" rel="noopener noreferrer">Apache Foundation</a>, and the <a href="https://uapi-group.org" target="_blank" rel="noopener noreferrer">UAPI Group</a>. Do not run, you'll only die tired.
     </p>
 
     <div class="alpha-badge">


### PR DESCRIPTION
- 'Bluefin is a...' → 'Dakota is a...'
- 'best tech OS tech' → 'best OS tech'

Assisted-by: claude-sonnet-4.6 via pi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated component tagline text for improved clarity and messaging.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/website/pull/583)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->