### PR TITLE
feat: Freedesktop SDK chip, x86-64-v3 last in green

### DIFF
--- a/public/dakota-versions.json
+++ b/public/dakota-versions.json
@@ -1,15 +1,16 @@
 {
   "generatedAt": "2026-05-10T00:00:00.000Z",
   "packages": {
-    "baseline": "x86-64-v3",
     "kernel": "6.19.11",
     "gnome": "50.0",
+    "freedesktop-sdk": "25.08.11",
     "mesa": "26.0.5",
     "bootc": "1.15.2",
     "nvidia": "595.71.05",
     "systemd": "260.1",
     "podman": "5.8.2",
     "pipewire": "1.6.1",
-    "flatpak": "1.16.6"
+    "flatpak": "1.16.6",
+    "baseline": "x86-64-v3"
   }
 }

--- a/src/components/dakota/DakotaVersionChips.vue
+++ b/src/components/dakota/DakotaVersionChips.vue
@@ -7,17 +7,20 @@ interface DakotaVersions {
 }
 
 const LABELS: Record<string, string> = {
-  baseline: 'x86-64',
-  kernel: 'Kernel',
-  gnome: 'GNOME',
-  mesa: 'Mesa',
-  bootc: 'bootc',
-  nvidia: 'Nvidia',
-  systemd: 'systemd',
-  podman: 'Podman',
-  pipewire: 'PipeWire',
-  flatpak: 'Flatpak',
+  'kernel': 'Kernel',
+  'gnome': 'GNOME',
+  'freedesktop-sdk': 'Freedesktop SDK',
+  'mesa': 'Mesa',
+  'bootc': 'bootc',
+  'nvidia': 'Nvidia',
+  'systemd': 'systemd',
+  'podman': 'Podman',
+  'pipewire': 'PipeWire',
+  'flatpak': 'Flatpak',
+  'baseline': 'x86-64',
 }
+
+const FEATURE_KEYS = new Set(['baseline'])
 
 const versions = ref<DakotaVersions | null>(null)
 
@@ -42,7 +45,7 @@ const chips = computed(() => {
   }
   return Object.entries(versions.value.packages)
     .filter(([, v]) => v)
-    .map(([key, value]) => ({ label: LABELS[key] ?? key, value }))
+    .map(([key, value]) => ({ label: LABELS[key] ?? key, value, isFeature: FEATURE_KEYS.has(key) }))
 })
 </script>
 
@@ -52,6 +55,7 @@ const chips = computed(() => {
       v-for="chip in chips"
       :key="chip.label"
       class="version-chip"
+      :class="{ 'chip-feature': chip.isFeature }"
     >
       <span class="chip-label">{{ chip.label }}</span>
       <span class="chip-value">{{ chip.value }}</span>
@@ -76,6 +80,19 @@ const chips = computed(() => {
   overflow: hidden;
   font-size: 1.2rem;
   line-height: 1;
+
+  &.chip-feature {
+    border-color: rgba(var(--color-green-rgb, 80, 200, 120), 0.5);
+
+    .chip-label {
+      color: var(--color-text);
+    }
+
+    .chip-value {
+      background: rgba(80, 200, 120, 0.15);
+      color: rgb(120, 220, 150);
+    }
+  }
 }
 
 .chip-label {


### PR DESCRIPTION
- Add Freedesktop SDK 25.08.11 version chip (2nd after GNOME)
- Move x86-64-v3 baseline chip last
- Feature chips render in green to distinguish from version chips

Assisted-by: claude-sonnet-4.6 via pi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced version chip display with distinctive visual styling for key packages.
  * Expanded available package version support.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/website/pull/584)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->