### PR TITLE
fix: navbar matches docs dark mode pixel-for-pixel

### DIFF
--- a/src/components/TopNavbar.vue
+++ b/src/components/TopNavbar.vue
@@ -82,8 +82,8 @@ const rightNavLinks = [
 .docusaurus-navbar {
   // Infima CSS variables - matching Docusaurus defaults
   --ifm-navbar-background-color: #242526;
-  --ifm-navbar-link-color: rgba(255, 255, 255, 0.9);
-  --ifm-navbar-link-hover-color: #4a69bd;
+  --ifm-navbar-link-color: rgb(227, 227, 227);
+  --ifm-navbar-link-hover-color: rgb(138, 151, 247);
   --ifm-navbar-height: 60px;
   --ifm-navbar-padding-horizontal: 16px;
   --ifm-navbar-padding-vertical: 14px;
@@ -214,8 +214,8 @@ const rightNavLinks = [
   }
 
   &--active {
-    color: var(--ifm-navbar-link-hover-color);
-    font-weight: 600;
+    color: rgb(138, 151, 247);
+    font-weight: 500;
   }
 }
 

--- a/tests/navbar-visual.mjs
+++ b/tests/navbar-visual.mjs
@@ -199,8 +199,8 @@ else {
     }
   }, activeLinkHandle)
 
-  assert('.navbar__link--active  color', activeStyles.color, 'rgb(74, 105, 189)')
-  assert('.navbar__link--active  fontWeight', activeStyles.fontWeight, '600')
+  assert('.navbar__link--active  color', activeStyles.color, 'rgb(138, 151, 247)')
+  assert('.navbar__link--active  fontWeight', activeStyles.fontWeight, '500')
 }
 
 // ── Section 6: right-side links exist and are in correct order ────────────────


### PR DESCRIPTION
Measured against docs.projectbluefin.io in forced dark mode via Playwright. Fixes:
- Active/hover link color: `rgb(74,105,189)` → `rgb(138,151,247)` (matches Docusaurus `--ifm-color-primary` dark)
- Active link weight: 600 → 500
- Link color: `rgba(255,255,255,0.9)` → `rgb(227,227,227)`

Background, height, font-size, padding, logo all already matched.
18/18 Playwright assertions pass.

Assisted-by: claude-sonnet-4.6 via pi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated navbar link default and hover colors to new RGB values.
  * Adjusted active navbar link font weight to 500.

* **Tests**
  * Updated visual regression tests to reflect navbar styling changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/website/pull/591)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->