### PR TITLE
feat: 'Designed for Contributors' card on dakota page

### DIFF
--- a/src/components/dakota/DakotaHighlights.vue
+++ b/src/components/dakota/DakotaHighlights.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import {
+  IconAccountGroup,
   IconGnome,
   IconLayers,
   IconShieldCheck,
@@ -45,6 +46,17 @@ import {
                   <a class="brand-title" href="https://freedesktop-sdk.io" target="_blank" rel="noopener noreferrer">Freedesktop SDK</a>
                 </div>
                 <p>Same battle tested libraries as Flathub. Continuously upgraded, always up to date.</p>
+              </div>
+
+              <!-- Left: Designed for Contributors -->
+              <div class="brand-item">
+                <div>
+                  <div class="icon-wrap">
+                    <IconAccountGroup />
+                  </div>
+                  <span class="brand-title">Designed for Contributors</span>
+                </div>
+                <p>Your path to contributing to some of the coolest projects in desktop Linux. Start here, then level up and become part of the upstream teams.</p>
               </div>
 
               <!-- Right: BuildStream 2 -->


### PR DESCRIPTION
Adds a new feature card below Freedesktop SDK, paired with BuildStream & BuildGrid:

**Designed for Contributors**
Your path to contributing to some of the coolest projects in desktop Linux. Start here, then level up and become part of the upstream teams.

Icon: `IconAccountGroup` (MDI people/group icon)

Assisted-by: claude-sonnet-4.6 via pi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Designed for Contributors" highlight card showcasing contributor-focused capabilities in the brand highlights section.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/website/pull/593)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->