### PR TITLE
feat(dakota): update ISOs to alpha2, add alpha1/alpha2 blog post links

### DIFF
--- a/src/components/dakota/DakotaDownloadCard.vue
+++ b/src/components/dakota/DakotaDownloadCard.vue
@@ -17,15 +17,15 @@ const BASE = 'https://projectbluefin.dev'
 const entries: DownloadEntry[] = [
   {
     label: 'AMD / Intel',
-    isoUrl: `${BASE}/dakota-live-latest.iso`,
-    isoFilename: 'dakota-live-latest.iso',
-    checksumUrl: `${BASE}/dakota-live-latest.iso-CHECKSUM`,
+    isoUrl: `${BASE}/dakota-live-alpha2.iso`,
+    isoFilename: 'dakota-live-alpha2.iso',
+    checksumUrl: `${BASE}/dakota-live-alpha2.iso-CHECKSUM`,
   },
   {
     label: 'Nvidia',
-    isoUrl: `${BASE}/dakota-nvidia-live-latest.iso`,
-    isoFilename: 'dakota-nvidia-live-latest.iso',
-    checksumUrl: `${BASE}/dakota-nvidia-live-latest.iso-CHECKSUM`,
+    isoUrl: `${BASE}/dakota-nvidia-live-alpha2.iso`,
+    isoFilename: 'dakota-nvidia-live-alpha2.iso',
+    checksumUrl: `${BASE}/dakota-nvidia-live-alpha2.iso-CHECKSUM`,
   },
 ]
 </script>

--- a/src/components/dakota/DakotaScene.vue
+++ b/src/components/dakota/DakotaScene.vue
@@ -34,6 +34,19 @@ onMounted(() => {
       ⚠️ Alpha software — take appropriate precautions
     </div>
 
+    <div class="release-links">
+      <a
+        href="https://docs.projectbluefin.io/blog/making-our-own-fate/"
+        target="_blank"
+        rel="noopener noreferrer"
+      >Alpha 2 Announcement →</a>
+      <a
+        href="https://docs.projectbluefin.io/blog/dakota-alpha-1/"
+        target="_blank"
+        rel="noopener noreferrer"
+      >Alpha 1 Announcement →</a>
+    </div>
+
     <slot />
   </div>
 </template>
@@ -120,6 +133,27 @@ onMounted(() => {
   border-radius: 6px;
   padding: 8px 16px;
   margin-bottom: 0;
+}
+
+.release-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 20px;
+  margin-top: 10px;
+
+  a {
+    color: var(--color-blue-light);
+    font-size: 1.3rem;
+    font-weight: 600;
+    text-decoration: none;
+    opacity: 0.85;
+    transition: opacity 0.2s;
+
+    &:hover {
+      opacity: 1;
+      text-decoration: underline;
+    }
+  }
 }
 
 .back-link {


### PR DESCRIPTION
## Summary

- Update Dakota download ISO filenames and URLs from `latest` to `alpha2`:
  - `dakota-live-alpha2.iso` / `dakota-nvidia-live-alpha2.iso`
- Add Alpha 1 and Alpha 2 blog post announcement links in the Dakota hero scene, below the alpha warning badge
  - Alpha 2: https://docs.projectbluefin.io/blog/making-our-own-fate/
  - Alpha 1: https://docs.projectbluefin.io/blog/dakota-alpha-1/

## Test plan
- Build passes: `npm run build` ✓
- Lint clean: `npm run lint:fix` ✓

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added release announcement links providing access to Alpha 2 and Alpha 1 release information
  * Updated ISO download links and checksums to provide Alpha 2 builds for all platforms

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/website/pull/597)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->