### PR TITLE
chore(dakota): update version chips from SBOM

### DIFF
--- a/public/dakota-versions.json
+++ b/public/dakota-versions.json
@@ -1,9 +1,9 @@
 {
-  "generatedAt": "2026-05-11T05:04:41.312Z",
+  "generatedAt": "2026-05-14T12:50:26.054Z",
   "packages": {
-    "kernel": "6.19.11",
-    "gnome": "50.0",
-    "freedesktop-sdk": "25.08.10",
+    "kernel": "6.19.14",
+    "gnome": "50.1",
+    "freedesktop-sdk": "25.08.11",
     "mesa": "26.0.5",
     "bootc": "1.15.2",
     "nvidia": "595.71.05",


### PR DESCRIPTION
## Summary

Pull latest versions from SBOM pipeline into `public/dakota-versions.json`:

| Package | Was | Now |
|---|---|---|
| kernel | 6.19.11 | **6.19.14** |
| gnome | 50.0 | **50.1** |
| freedesktop-sdk | 25.08.10 | **25.08.11** |

All other packages unchanged. Data sourced from `docs.projectbluefin.io/data/sbom-attestations.json` (`dakota-latest` stream).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency packages including kernel, GNOME, and freedesktop-sdk to latest versions.
  * Refreshed generated timestamp data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/website/pull/598)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->