### PR TITLE
feat(data): SBOM-driven nightly cache refresh, no PR workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+      - name: Restore live data from cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: |
+            public/stream-versions.yml
+            public/dakota-versions.json
+            src/assets/svg/growth_bluefins.svg
+          key: website-live-data-
+          restore-keys: |
+            website-live-data-
+          fail-on-cache-miss: false
       - name: Setup Node.js
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6
         with:

--- a/.github/workflows/update-content.yml
+++ b/.github/workflows/update-content.yml
@@ -1,18 +1,16 @@
-name: Update Content
+name: Update Live Data
 
 on:
   schedule:
-    # Run daily at 08:00 UTC
-    - cron: '0 8 * * *'
+    # Run daily at 10:00 UTC — after projectbluefin/documentation SBOM
+    # pipeline completes at ~04:00–06:00 UTC so we always get fresh data.
+    - cron: '0 10 * * *'
   workflow_dispatch:
-    # Allow manual triggering
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
-  update-content:
+  update:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -32,86 +30,33 @@ jobs:
           curl https://raw.githubusercontent.com/ublue-os/countme/refs/heads/main/growth_bluefins.svg --output src/assets/svg/growth_bluefins.svg
           sed -i 's/#ffffff/#0c1016/g; s/#cccccc/#272727/g; s/#616161/#bdbdbd/g; s/#77aadd/#4285f4/g; s/id="text_16">/id="text_16" style="fill: #bdbdbd">/' src/assets/svg/growth_bluefins.svg
 
-      - name: Update stream versions
+      - name: Update stream versions from SBOM
         run: node scripts/update-stream-versions.js
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Update Dakota versions
+      - name: Update Dakota versions from SBOM
         run: node scripts/update-dakota-versions.js
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Check for changes
-        id: changes
-        run: |
-          if git diff --quiet; then
-            echo "changed=false" >> $GITHUB_OUTPUT
-            echo "No changes detected"
-          else
-            echo "changed=true" >> $GITHUB_OUTPUT
-            echo "Changes detected:"
-            git diff --stat
-          fi
-
-      - name: Create Pull Request
-        if: steps.changes.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@0edc001d28a2959cd7a6b505629f1d82f0a6e67d
+      - name: Save live data to cache
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: |
-            chore: update content from upstream sources
-
-            - Updated Bluefin growth chart from ublue-os/countme
-            - Updated stream versions from latest releases
-            - Automated update via GitHub Actions
-          title: "chore: update content from upstream sources"
-          body: |
-            ## 🤖 Automated Content Update
-
-            This PR contains automated updates from upstream data sources:
-
-            ### Growth Chart
-            - Updated `src/assets/svg/growth_bluefins.svg` with latest data from [ublue-os/countme](https://github.com/ublue-os/countme)
-            - Chart shows Bluefin installation growth metrics
-            - Colors adjusted for dark theme compatibility
-
-            ### Stream Versions
-            - Updated `public/stream-versions.yml` with latest version information
-            - Data sourced from the most recent release changelogs:
-              - `ublue-os/bluefin` (for GTS and Stable streams)
-              - `ublue-os/bluefin-lts` (for LTS stream)
-
-            ### Dakota Versions
-            - Updated `public/dakota-versions.json` release metadata
-            - Data sourced from latest `projectbluefin/dakota` release tag
-
-            ### Review Notes
-            - This is an automated daily update
-            - Please verify the data looks correct before merging
-            - Both files are used by the website to display current information
-
-            ---
-            *This PR was automatically created by the `update-content` workflow.*
-          branch: automated/update-content
-          delete-branch: true
-          add-paths: |
-            src/assets/svg/growth_bluefins.svg
+          path: |
             public/stream-versions.yml
             public/dakota-versions.json
+            src/assets/svg/growth_bluefins.svg
+          key: website-live-data-${{ github.run_id }}
 
       - name: Create issue on failure
         if: failure()
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
         with:
           script: |
-            const runUrl = `${context.payload.repository.html_url}/actions/runs/` +
-                           `${context.runId}`;
+            const runUrl = `${context.payload.repository.html_url}/actions/runs/${context.runId}`;
             github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: 'Failed to update content from upstream sources',
-              body: `The automated content update failed. ` +
-                    `Please check the [workflow run](${runUrl}) for details.`,
+              title: 'Failed to update live data from SBOM sources',
+              body: `The automated data update failed. Please check the [workflow run](${runUrl}) for details.`,
               labels: ['bug', 'automation']
             })

--- a/public/dakota-versions.json
+++ b/public/dakota-versions.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-14T12:50:26.054Z",
+  "generatedAt": "2026-05-14T12:57:10.591Z",
   "packages": {
     "kernel": "6.19.14",
     "gnome": "50.1",

--- a/public/stream-versions.yml
+++ b/public/stream-versions.yml
@@ -1,18 +1,18 @@
 # Stream version information for Bluefin releases
-# This file contains the latest version information for each stream
-# Data is sourced from the most recent changelogs in ublue-os/bluefin and ublue-os/bluefin-lts repositories
-# Last updated: 2026-03-31
+# Source: docs.projectbluefin.io/data/sbom-attestations.json
+#         (cosign-verified OCI SBOM attestations from ghcr.io/ublue-os)
+# Last updated: 2026-05-14
 
+stable:
+  base: "Fedora 44"
+  kernel: "6.19.14-101.fc44"
+  gnome: "50.1"
+  mesa: "26.0.6"
+  nvidia: "595.71.05"
 lts:
   base: "CentOS Stream 10"
-  gnome: "48.4-1"
-  kernel: "6.12.0-172"
-  mesa: "25.2.5-3"
-  nvidia: "590.44.01-1"
-  hwe: "6.17.8-200.fc42"
-stable:
-  base: "Fedora 43"
-  gnome: "49.5-1"
-  kernel: "6.18.13-200"
-  mesa: "25.3.6-6"
-  nvidia: "595.58.03-1"
+  kernel: "6.12.0-226.el10"
+  gnome: "49.5"
+  mesa: "25.2.7"
+  hwe: "6.19.14-101.fc43"
+  nvidia: "595.71.05"

--- a/scripts/update-dakota-versions.js
+++ b/scripts/update-dakota-versions.js
@@ -63,6 +63,15 @@ async function main() {
         assign('bootc', all.bootc)
         current.generatedAt = new Date().toISOString()
         console.info('[dakota-versions] SBOM versions updated')
+
+        // nvidia from dakota-nvidia-latest stream
+        const nvStream = sbom?.streams?.['dakota-nvidia-latest']
+        const nvReleases = nvStream?.releases ?? {}
+        const nvLatest = Object.values(nvReleases)[0]
+        if (nvLatest) {
+          assign('nvidia', nvLatest.packageVersions?.nvidia)
+          console.info(`[dakota-versions] nvidia → ${nvLatest.packageVersions?.nvidia}`)
+        }
       }
     }
     else {

--- a/scripts/update-stream-versions.js
+++ b/scripts/update-stream-versions.js
@@ -1,19 +1,26 @@
 #!/usr/bin/env node
 
 /**
- * Script to update stream-versions.yml with latest package information
- * from ublue-os/bluefin and ublue-os/bluefin-lts releases
+ * Update stream-versions.yml from the SBOM attestations cache at
+ * docs.projectbluefin.io/data/sbom-attestations.json
  *
- * Current approach: fetches GitHub Releases API and parses the release body
- * markdown to extract kernel/gnome/mesa/nvidia versions from "### Major packages"
- * tables. This is fragile — any release note format change breaks it.
+ * This replaces the previous approach of parsing GitHub release markdown,
+ * which was fragile and broke whenever the release note format changed.
  *
- * TODO (proper fix): Query the OCI SBOM attestation for exact installed package
- * versions:
- *   cosign download attestation ghcr.io/ublue-os/bluefin:<tag> \
- *     | jq -r '.payload' | base64 -d | jq '.predicate.components[] | select(.name == "kernel")'
- * This would use the syft JSON schema embedded in the image attestation and is
- * immune to changelog format changes.
+ * Stream mapping:
+ *   stable.kernel  → bluefin-stable
+ *   stable.gnome   → bluefin-stable
+ *   stable.mesa    → bluefin-stable
+ *   stable.nvidia  → bluefin-nvidia-open-stable
+ *
+ *   lts.kernel     → bluefin-lts
+ *   lts.gnome      → bluefin-lts
+ *   lts.mesa       → bluefin-lts
+ *   lts.hwe        → bluefin-lts-hwe (kernel field)
+ *   lts.nvidia     → bluefin-gdx-lts
+ *
+ * The sbom-attestations.json is generated nightly by projectbluefin/documentation
+ * via cosign-verified OCI SBOM attestations from ghcr.io/ublue-os/bluefin* images.
  */
 
 import fs from 'node:fs'
@@ -21,233 +28,84 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { dump as dumpYaml } from 'js-yaml'
 
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = path.dirname(__filename)
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const OUT = path.join(__dirname, '../public/stream-versions.yml')
+const SBOM_URL = 'https://docs.projectbluefin.io/data/sbom-attestations.json'
 
-// GitHub API configuration
-const GITHUB_API = 'https://api.github.com'
-const REPOS = {
-  lts: 'ublue-os/bluefin-lts',
-  main: 'ublue-os/bluefin'
+function latestPv(streams, name) {
+  const stream = streams[name]
+  if (!stream) {
+    console.warn(`[stream-versions] stream "${name}" not found in SBOM`)
+    return {}
+  }
+  const releases = stream.releases ?? {}
+  const keys = Object.keys(releases)
+  if (!keys.length) {
+    console.warn(`[stream-versions] no releases for stream "${name}"`)
+    return {}
+  }
+  console.info(`[stream-versions] ${name}: using release ${keys[0]}`)
+  return releases[keys[0]]?.packageVersions ?? {}
 }
 
-// Base OS mapping for each stream
-const BASE_OS_MAP = {
-  lts: 'CentOS Stream 10',
-  stable: 'Fedora 43'
+async function main() {
+  const res = await fetch(SBOM_URL)
+  if (!res.ok) {
+    throw new Error(`SBOM fetch failed: ${res.status} ${res.statusText}`)
+  }
+
+  const sbom = await res.json()
+  const streams = sbom.streams ?? {}
+
+  const stable = latestPv(streams, 'bluefin-stable')
+  const stableNvidia = latestPv(streams, 'bluefin-nvidia-open-stable')
+  const lts = latestPv(streams, 'bluefin-lts')
+  const ltsHwe = latestPv(streams, 'bluefin-lts-hwe')
+  const ltsNvidia = latestPv(streams, 'bluefin-gdx-lts')
+
+  // Derive base OS name from fedora field, fall back to hardcoded known values
+  const stableBase = stable.fedora ? `Fedora ${stable.fedora.replace(/^F/, '')}` : 'Fedora 44'
+  const ltsBase = 'CentOS Stream 10'
+
+  const data = {
+    stable: {
+      base: stableBase,
+      kernel: stable.kernel ?? 'unknown',
+      gnome: stable.gnome ?? 'unknown',
+      mesa: stable.mesa ?? 'unknown',
+      nvidia: stableNvidia.nvidia ?? 'unknown',
+    },
+    lts: {
+      base: ltsBase,
+      kernel: lts.kernel ?? 'unknown',
+      gnome: lts.gnome ?? 'unknown',
+      mesa: lts.mesa ?? 'unknown',
+      hwe: ltsHwe.kernel ?? 'unknown',
+      nvidia: ltsNvidia.nvidia ?? 'unknown',
+    },
+  }
+
+  const today = new Date().toISOString().split('T')[0]
+  const header = [
+    '# Stream version information for Bluefin releases',
+    '# Source: docs.projectbluefin.io/data/sbom-attestations.json',
+    '#         (cosign-verified OCI SBOM attestations from ghcr.io/ublue-os)',
+    `# Last updated: ${today}`,
+    '',
+    '',
+  ].join('\n')
+
+  fs.writeFileSync(
+    OUT,
+    header + dumpYaml(data, { lineWidth: -1, quotingType: '"', forceQuotes: true }),
+  )
+
+  console.info('[stream-versions] wrote', OUT)
+  console.info('stable:', data.stable)
+  console.info('lts:', data.lts)
 }
 
-/**
- * Fetch the latest release for a repository
- */
-async function fetchLatestReleasesByStream(repo, stream) {
-  const url = `${GITHUB_API}/repos/${repo}/releases`
-  const response = await fetch(url, {
-    headers: {
-      'Authorization': process.env.GITHUB_TOKEN
-        ? `token ${process.env.GITHUB_TOKEN}`
-        : undefined,
-      'User-Agent': 'bluefin-website-updater',
-      'Accept': 'application/vnd.github.v3+json'
-    }
-  })
-
-  if (!response.ok) {
-    console.error(`GitHub API response status: ${response.status}`)
-    console.error(
-      `Response headers:`,
-      Object.fromEntries(response.headers.entries())
-    )
-    const text = await response.text()
-    console.error(`Response body:`, text.substring(0, 500))
-    throw new Error(
-      `Failed to fetch releases for ${repo}: ${response.status} ${response.statusText}`
-    )
-  }
-
-  const releases = await response.json()
-
-  // Find the latest release for the specified stream
-  const streamRelease = releases.find((release) => {
-    return (
-      release.tag_name.startsWith(`${stream}-`)
-      || release.tag_name.startsWith(`${stream}.`)
-    )
-  })
-
-  return streamRelease
-}
-
-/**
- * Parse the changelog body to extract package versions.
- *
- * This parses release note markdown tables of the form:
- *   ### Major packages
- *   | **Kernel** | 6.14.11-300 |
- *
- * If parsing fails for any field, 'unknown' is returned rather than crashing.
- *
- * NOTE: This approach is fragile. See TODO at the top of this file for the
- * proper fix using OCI SBOM attestation.
- */
-function parseChangelogVersions(body) {
-  if (!body) {
-    console.warn('Release body is empty — all versions will be unknown')
-    return { kernel: 'unknown', gnome: 'unknown', mesa: 'unknown', nvidia: 'unknown', hwe: 'unknown' }
-  }
-
-  const versions = {
-    kernel: 'unknown',
-    gnome: 'unknown',
-    mesa: 'unknown',
-    nvidia: 'unknown',
-    hwe: 'unknown'
-  }
-
-  try {
-    // Split by lines and find the Major packages and Major GDX packages sections
-    const lines = body.split('\n')
-    let inMajorPackages = false
-    let inMajorGdxPackages = false
-
-    for (const line of lines) {
-      const trimmed = line.trim()
-
-      // Start of major packages section
-      if (trimmed === '### Major packages') {
-        inMajorPackages = true
-        inMajorGdxPackages = false
-        continue
-      }
-
-      // Start of major GDX packages section (for LTS nvidia drivers)
-      if (trimmed === '### Major GDX packages') {
-        inMajorGdxPackages = true
-        inMajorPackages = false
-        continue
-      }
-
-      // End of current packages section
-      if (
-        (inMajorPackages || inMajorGdxPackages)
-        && trimmed.startsWith('###')
-        && !trimmed.includes('Major packages')
-        && !trimmed.includes('Major GDX packages')
-      ) {
-        inMajorPackages = false
-        inMajorGdxPackages = false
-        continue
-      }
-
-      if ((inMajorPackages || inMajorGdxPackages) && trimmed.startsWith('| **')) {
-        // Parse package version lines like: | **Kernel** | 6.14.11-300 |
-        // or with transitions like: | **Mesa** | 25.1.4-1 ➡️ 25.1.7-1 |
-        const match = trimmed.match(/\| \*\*([^*]+)\*\* \| (.+) \|/)
-        if (match) {
-          const packageName = match[1].toLowerCase()
-          let version = match[2].trim()
-
-          // Handle version transitions (take the newer version after ➡️)
-          if (version.includes('➡️')) {
-            version = version.split('➡️')[1].trim()
-          }
-
-          // Map package names to our keys
-          if (packageName === 'kernel') {
-            versions.kernel = version
-          }
-          else if (packageName === 'gnome') {
-            versions.gnome = version
-          }
-          else if (packageName === 'mesa') {
-            versions.mesa = version
-          }
-          else if (packageName === 'nvidia') {
-            versions.nvidia = version
-          }
-          else if (packageName === 'hwe kernel') {
-            versions.hwe = version
-          }
-        }
-      }
-    }
-  }
-  catch (parseError) {
-    console.warn('Error parsing changelog body:', parseError)
-    // Return whatever was parsed so far — unknown fields stay as 'unknown'
-  }
-
-  return versions
-}
-
-/**
- * Update the stream-versions.yml file
- */
-async function updateStreamVersions() {
-  console.info('Fetching latest releases...')
-
-  const updates = {}
-
-  try {
-    // Fetch LTS versions from bluefin-lts repo
-    const ltsRelease = await fetchLatestReleasesByStream(REPOS.lts, 'lts')
-    if (ltsRelease) {
-      console.info(`Found LTS release: ${ltsRelease.tag_name}`)
-      const ltsVersions = parseChangelogVersions(ltsRelease.body)
-      updates.lts = {
-        base: BASE_OS_MAP.lts,
-        gnome: ltsVersions.gnome,
-        kernel: ltsVersions.kernel,
-        mesa: ltsVersions.mesa,
-        nvidia: ltsVersions.nvidia,
-        hwe: ltsVersions.hwe
-      }
-    }
-
-    const stableRelease = await fetchLatestReleasesByStream(
-      REPOS.main,
-      'stable'
-    )
-    if (stableRelease) {
-      console.info(`Found Stable release: ${stableRelease.tag_name}`)
-      const stableVersions = parseChangelogVersions(stableRelease.body)
-      updates.stable = {
-        base: BASE_OS_MAP.stable,
-        gnome: stableVersions.gnome,
-        kernel: stableVersions.kernel,
-        mesa: stableVersions.mesa,
-        nvidia: stableVersions.nvidia
-      }
-    }
-
-    // Ensure we have at least some data
-    if (Object.keys(updates).length === 0) {
-      throw new Error('No release data found for any stream')
-    }
-
-    // Generate the updated YAML content using js-yaml
-    const today = new Date().toISOString().split('T')[0]
-    const header = `# Stream version information for Bluefin releases\n# This file contains the latest version information for each stream\n# Data is sourced from the most recent changelogs in ublue-os/bluefin and ublue-os/bluefin-lts repositories\n# Last updated: ${today}\n\n`
-    const yamlContent = header + dumpYaml(updates, { lineWidth: -1, quotingType: '"', forceQuotes: true })
-
-    // Write the updated file
-    const yamlPath = path.join(__dirname, '..', 'public', 'stream-versions.yml')
-    fs.writeFileSync(yamlPath, yamlContent)
-
-    console.info('Stream versions updated successfully!')
-    console.info('Updated streams:', Object.keys(updates))
-
-    // Log the parsed versions for verification
-    console.info('\nParsed versions:')
-    for (const [stream, versions] of Object.entries(updates)) {
-      console.info(`${stream}:`, versions)
-    }
-  }
-  catch (error) {
-    console.error('Error updating stream versions:', error)
-    process.exit(1)
-  }
-}
-
-// Run the update
-updateStreamVersions()
+main().catch((e) => {
+  console.error('[stream-versions] fatal:', e.message)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary

Replaces the old PR-based content update workflow with a GitHub Actions cache approach. Data files are never committed — they live in the cache and are restored at build time.

### What changed

**`update-stream-versions.js`** — complete rewrite
- Replaces fragile GitHub release changelog parsing (LTS was producing `unknown` for all fields)
- Now reads from `docs.projectbluefin.io/data/sbom-attestations.json` (cosign-verified OCI attestations)
- Stream mapping: `bluefin-stable`, `bluefin-lts`, `bluefin-lts-hwe`, `bluefin-nvidia-open-stable`, `bluefin-gdx-lts`

**`update-dakota-versions.js`**
- Adds `nvidia` from `dakota-nvidia-latest` SBOM stream (was previously not updating)

**`update-content.yml`**
- Saves output files to GitHub Actions cache (`website-live-data-{run_id}`)
- Removes `peter-evans/create-pull-request`, `contents: write`, `pull-requests: write`
- Runs at 10:00 UTC (after docs SBOM pipeline completes at ~06:00 UTC)
- `permissions: {}` — no repo write access needed at all

**`deploy.yml`**
- Restores from cache before build (`restore-keys: website-live-data-`)
- `fail-on-cache-miss: false` — falls back to repo-seeded files if no cache yet

### Data flow

```
04:00 UTC  projectbluefin/documentation updates sbom-attestations.json
10:00 UTC  update-content.yml fetches SBOM → saves to Actions cache
on push    deploy.yml restores cache → builds → deploys
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment efficiency through improved caching of build artifacts
  * Updated stable stream base OS to Fedora 44 with latest component versions
  * Refreshed LTS stream with updated kernel, graphics, and system packages
  * Optimized version tracking and data sourcing system

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/website/pull/599)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->