### PR TITLE
feat(bluespeed): WebUI screenshots with fast click cycling

### DIFF
--- a/src/components/knuckle/KnuckleDemos.vue
+++ b/src/components/knuckle/KnuckleDemos.vue
@@ -3,7 +3,7 @@ import { onMounted, onUnmounted, ref } from 'vue'
 
 const baseUrl = import.meta.env.BASE_URL
 
-type Phase = 'cluster' | 'cpu' | 'storage' | 'progress'
+type Phase = 'cluster' | 'cpu' | 'storage'
 
 const phase = ref<Phase>('cluster')
 let timer: ReturnType<typeof setTimeout>
@@ -12,86 +12,73 @@ const sequence: Array<{ phase: Phase, duration: number }> = [
   { phase: 'cluster', duration: 10000 },
   { phase: 'cpu', duration: 10000 },
   { phase: 'storage', duration: 10000 },
-  { phase: 'progress', duration: 8000 },
 ]
 let idx = 0
 
 function cycle() {
-  const current = sequence[idx]
   timer = setTimeout(() => {
-    idx = (idx + 1) % sequence.length
-    phase.value = sequence[idx].phase
-    cycle()
-  }, current.duration)
+    advance()
+  }, sequence[idx].duration)
+}
+
+function advance() {
+  clearTimeout(timer)
+  idx = (idx + 1) % sequence.length
+  phase.value = sequence[idx].phase
+  cycle()
 }
 
 onMounted(() => cycle())
 onUnmounted(() => clearTimeout(timer))
 
-const isWebUI = (p: Phase) => p !== 'progress'
-
-const subtitleMap: Record<Phase, string> = {
-  cluster: 'cluster overview',
-  cpu: 'node metrics',
-  storage: 'storage',
-  progress: 'installing',
+const urlMap: Record<Phase, string> = {
+  cluster: 'vanguard.local/cluster',
+  cpu: 'vanguard.local/nodes',
+  storage: 'vanguard.local/storage',
 }
 </script>
 
 <template>
   <section class="knuckle-demos">
     <div class="demo-window">
-      <!-- Browser chrome for WebUI, Ghostty chrome for TUI -->
-      <template v-if="isWebUI(phase)">
-        <div class="browser-bar">
-          <div class="browser-spacer" />
-          <div class="browser-url">
-            <span class="browser-url-text">bluespeed · {{ subtitleMap[phase] }}</span>
-          </div>
-          <button class="hb-min-btn" aria-label="Minimize" tabindex="-1">
-            <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true">
-              <path d="M2 5h6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
-            </svg>
-          </button>
-          <button class="hb-max-btn" aria-label="Maximize" tabindex="-1">
-            <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true">
-              <rect x="1.5" y="1.5" width="7" height="7" rx="1" stroke="currentColor" stroke-width="1.5" fill="none" />
-            </svg>
-          </button>
-          <button class="hb-close-btn" aria-label="Close" tabindex="-1">
-            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
-              <path d="M2 2l8 8M10 2l-8 8" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
-            </svg>
-          </button>
+      <div class="browser-bar">
+        <div class="browser-spacer" />
+        <div class="browser-url">
+          <span class="browser-url-text">{{ urlMap[phase] }}</span>
         </div>
-      </template>
+        <button class="hb-min-btn" aria-label="Minimize" tabindex="-1">
+          <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true">
+            <path d="M2 5h6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
+          </svg>
+        </button>
+        <button class="hb-max-btn" aria-label="Maximize" tabindex="-1">
+          <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true">
+            <rect x="1.5" y="1.5" width="7" height="7" rx="1" stroke="currentColor" stroke-width="1.5" fill="none" />
+          </svg>
+        </button>
+        <button class="hb-close-btn" aria-label="Close" tabindex="-1">
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+            <path d="M2 2l8 8M10 2l-8 8" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
+          </svg>
+        </button>
+      </div>
 
       <transition name="fade" mode="out-in">
-        <img
-          v-if="phase === 'cluster'"
-          key="cluster"
-          :src="`${baseUrl}bluespeed-cluster.png`"
-          alt="Bluespeed cluster overview dashboard"
-        >
-        <img
-          v-else-if="phase === 'cpu'"
-          key="cpu"
-          :src="`${baseUrl}bluespeed-cpu.png`"
-          alt="Bluespeed node CPU metrics"
-        >
-        <img
-          v-else-if="phase === 'storage'"
-          key="storage"
-          :src="`${baseUrl}bluespeed-storage.png`"
-          alt="Bluespeed storage view"
-        >
-        <div v-else key="progress" class="tui-frame">
-          <p class="tui-caption">
-            Just one quick TUI install to get the web dashboard up and running.
-          </p>
+        <div :key="phase" class="img-wrap" @click="advance">
           <img
-            :src="`${baseUrl}knuckle-progress.png`"
-            alt="Knuckle installer progress"
+            v-if="phase === 'cluster'"
+            :src="`${baseUrl}bluespeed-cluster.png`"
+            alt="Bluespeed cluster overview"
+          >
+          <img
+            v-else-if="phase === 'cpu'"
+            :src="`${baseUrl}bluespeed-cpu.png`"
+            alt="Bluespeed node metrics"
+          >
+          <img
+            v-else
+            :src="`${baseUrl}bluespeed-storage.png`"
+            alt="Bluespeed storage"
           >
         </div>
       </transition>
@@ -113,15 +100,9 @@ const subtitleMap: Record<Phase, string> = {
     0 2px 6px rgba(0, 0, 0, 0.4),
     0 8px 24px rgba(0, 0, 0, 0.5),
     0 20px 48px rgba(0, 0, 0, 0.3);
-
-  img {
-    display: block;
-    width: 100%;
-    height: auto;
-  }
 }
 
-/* ── Browser chrome (WebUI) — Adwaita CSD style ── */
+/* ── Browser chrome ── */
 .browser-bar {
   display: flex;
   align-items: center;
@@ -134,7 +115,7 @@ const subtitleMap: Record<Phase, string> = {
 }
 
 .browser-spacer {
-  width: 82px; /* mirrors 3 buttons on right for visual balance */
+  width: 82px;
   flex-shrink: 0;
 }
 
@@ -146,93 +127,20 @@ const subtitleMap: Record<Phase, string> = {
 
 .browser-url-text {
   font-family: Cantarell, 'Noto Sans', system-ui, sans-serif;
-  font-size: 0.82rem;
-  color: rgba(255, 255, 255, 0.55);
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.85);
   background: rgba(255, 255, 255, 0.07);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.12);
   border-radius: 6px;
-  padding: 3px 14px;
-  min-width: 180px;
-  text-align: center;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-/* ── Adw.HeaderBar (TUI screenshot) ── */
-.adw-header-bar {
-  display: flex;
-  align-items: center;
-  height: 46px;
-  padding: 0 6px;
-  background: #303030;
-  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25);
-  user-select: none;
-  gap: 4px;
-}
-
-.hb-start,
-.hb-end {
-  display: flex;
-  align-items: center;
-  gap: 2px;
-  flex-shrink: 0;
-}
-
-.hb-title {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  min-width: 0;
-  line-height: 1.2;
-}
-
-.hb-title-text {
-  font-family: Cantarell, 'Noto Sans', system-ui, sans-serif;
-  font-size: 1rem;
-  font-weight: 700;
-  color: rgba(255, 255, 255, 0.9);
+  padding: 4px 20px;
   letter-spacing: 0.01em;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-.hb-subtitle-text {
-  font-family: Cantarell, 'Noto Sans', system-ui, sans-serif;
-  font-size: 0.78rem;
-  font-weight: 400;
-  color: rgba(255, 255, 255, 0.5);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.hb-icon-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 28px;
-  border-radius: 6px;
-  border: none;
-  background: transparent;
-  color: rgba(255, 255, 255, 0.75);
-  cursor: default;
-  padding: 0;
-  transition: background 0.1s;
-
-  &:hover {
-    background: rgba(255, 255, 255, 0.1);
-  }
-
-  svg {
-    display: block;
-  }
-}
-
+/* ── Window controls ── */
 .hb-min-btn,
 .hb-max-btn {
   display: inline-flex;
@@ -287,20 +195,27 @@ const subtitleMap: Record<Phase, string> = {
   }
 }
 
-.tui-caption {
-  font-family: Cantarell, 'Noto Sans', system-ui, sans-serif;
-  font-size: 1.1rem;
-  color: rgba(255, 255, 255, 0.55);
-  text-align: center;
-  padding: 10px 16px 8px;
-  margin: 0;
+/* ── Image container ── */
+.img-wrap {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 9;
   background: #1d1d20;
-  font-style: italic;
+  overflow: hidden;
+  cursor: pointer;
+
+  img {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+  }
 }
 
 .fade-enter-active,
 .fade-leave-active {
-  transition: opacity 1s ease;
+  transition: opacity 0.15s ease;
 }
 
 .fade-enter-from,


### PR DESCRIPTION
- 3 WebUI screenshots cycling (cluster, cpu, storage)
- Prominent URL bar: vanguard.local/cluster|nodes|storage
- Adwaita window controls (minimize, maximize, close)
- Click to advance, 0.15s fade
- Fixed 16:9 container — no page jump on transition

Assisted-by: claude-opus-4-5 via pi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined the demo progression sequence by simplifying state transitions, enabling more direct navigation through key demo states.

* **Style**
  * Enhanced visual presentation with improved image container styling, better aspect ratio handling, and refined transition animations for a smoother user experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/website/pull/605?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->