### PR TITLE
feat(banner): consistent 'Project Bluefin Presents…' header, remove b…

### DIFF
--- a/src/components/dakota/DakotaScene.vue
+++ b/src/components/dakota/DakotaScene.vue
@@ -11,11 +11,8 @@ onMounted(() => {
 
 <template>
   <div class="dakota-text" :class="{ 'is-loaded': isLoaded }">
-    <a href="https://projectbluefin.io" class="back-link">
-      ← projectbluefin.io
-    </a>
     <div class="hero-tag">
-      <strong>Project Bluefin</strong>
+      <strong>Project Bluefin Presents&hellip;</strong>
     </div>
 
     <h1 class="hero-title">

--- a/src/components/knuckle/KnuckleScene.vue
+++ b/src/components/knuckle/KnuckleScene.vue
@@ -11,9 +11,6 @@ onMounted(() => {
 
 <template>
   <div class="knuckle-text" :class="{ 'is-loaded': isLoaded }">
-    <a href="https://projectbluefin.io" class="back-link">
-      ← projectbluefin.io
-    </a>
     <div class="hero-tag">
       <strong>Project Bluefin Presents&hellip;</strong>
     </div>


### PR DESCRIPTION
…ack-links

Both Dakota and Bluespeed now use identical banner structure:
- Remove '← projectbluefin.io' back-link from both pages
- Dakota: 'Project Bluefin' → 'Project Bluefin Presents…'
- Bluespeed: back-link removed, Presents… already present

Assisted-by: Claude claude-opus-4-5 via pi