### PR TITLE
fix(ci): add vitest coverage thresholds to prevent silent regressions

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,12 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov'],
+      thresholds: {
+        statements: 50,
+        branches: 50,
+        functions: 50,
+        lines: 50,
+      },
     },
   },
   plugins: [


### PR DESCRIPTION
## Summary

Closes #651

`vite.config.ts` reports coverage via @vitest/coverage-v8 but has no `thresholds` block, so PRs that delete tests still pass CI.

Adds conservative 50% floors across statements, branches, functions, and lines. These can be raised progressively as coverage improves.

## Changes

- `vite.config.ts`: add `thresholds` block to the `coverage` config

## Test plan

- [ ] Run `npm run test -- --coverage` and confirm it fails if coverage drops below 50%
- [ ] Confirm CI passes on this branch at current coverage levels

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented minimum code coverage thresholds to maintain and enforce code quality standards.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/website/pull/655?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->