### PR TITLE
docs(contributing): document i18n locale field rendering types

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,48 @@ npm run typecheck   # Type-check with vue-tsc
 3. Translate all values — keep all keys identical to `enUS.json`
 4. Open a PR; CI will validate the JSON schema
 
+### Locale field rendering
+
+Not all locale fields are rendered the same way. Using the wrong markup in a field produces broken output.
+
+**Markdown fields** — support `**bold**`, `[links](url)`, `_italic_`, etc. (rendered via `marked.parse()`):
+
+| Key | Component |
+|-----|-----------|
+| `Users.Features` | SceneUsers.vue |
+| `Devs.TowerJoke` | SceneDevelopers.vue |
+| `Devs.RuntimeContainers` | SceneDevelopers.vue |
+| `Devs.CNJourney` | SceneDevelopers.vue |
+| `Mission.Text.Change` | SectionMission.vue |
+| `Mission.Text.CloudNative` | SectionMission.vue |
+| `Mission.Text.Sustainability` | SectionMission.vue |
+| `Mission.CleverGirl` | SectionMission.vue |
+| `TryBluefin.Description` | ImageChooser.vue |
+| `TryBluefin.Description.Choice` | ImageChooser.vue |
+| `TryBluefin.Description.Updates` | ImageChooser.vue |
+| `TryBluefin.Download.Documentation.Intro` | ImageChooser.vue |
+| `TryBluefin.Download.Documentation.Downloads` | ImageChooser.vue |
+| `TryBluefin.Download.Documentation.SecureBoot` | ImageChooser.vue |
+| `Video.Text.Passion` | SceneContent.vue |
+| `Video.Text.StateOfTheArt` | SceneContent.vue |
+| `Footer.Credits.Intro` | SectionFooter.vue |
+| `Footer.Credits.Wallpapers` | SectionFooter.vue |
+| `Footer.Credits.Website` | SectionFooter.vue |
+| `Footer.Credits.Logos` | SectionFooter.vue |
+| `Footer.Credits.Thanks` | SectionFooter.vue |
+| `Footer.Credits.Translations` | SectionFooter.vue |
+| `Footer.Credits.ImageEdit` | SectionFooter.vue |
+| `Footer.Project.Ublue` | SectionFooter.vue |
+
+**Raw HTML fields** — use `<a href="...">link</a>` directly; Markdown syntax will appear literally (rendered via `v-html`):
+
+| Key | Component |
+|-----|-----------|
+| `Bazaar.Description` | SectionBazaar.vue |
+| `Bazaar.Additional` | SectionBazaar.vue |
+
+**Plain text fields** — all other keys. Markdown and HTML tags will appear as literal characters. Do not use markup.
+
 ## Testing
 
 Run tests locally before opening a PR.


### PR DESCRIPTION
## Summary

Translators have no way to know which locale keys support Markdown, which accept raw HTML, and which are plain text only. Using the wrong markup produces literal asterisks or tags in the rendered page.

Adds a **Locale field rendering** subsection under the i18n instructions in `CONTRIBUTING.md` with three tables:
- 24 Markdown fields (rendered via `marked.parse()`)
- 2 raw HTML fields (`Bazaar.Description`, `Bazaar.Additional` — rendered via `v-html`)
- Plain text note for all remaining keys

Closes #648

## Test plan
- [ ] `CONTRIBUTING.md` renders correctly in GitHub preview
- [ ] Verify tables match current component source (spot-check `SceneUsers.vue`, `SectionBazaar.vue`, `SectionFooter.vue`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)