### PR TITLE
fix: multiple lint & type issues

### DIFF
--- a/scripts/tests/update-dakota-versions.test.ts
+++ b/scripts/tests/update-dakota-versions.test.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'node:buffer'
 import { describe, expect, it } from 'vitest'
 import {
   applySbomVersions,

--- a/src/components/ImageChooser.vue
+++ b/src/components/ImageChooser.vue
@@ -143,7 +143,8 @@ function selectArchitecture(arch: string) {
     imageName.value.gpu = undefined
     showGpuStep.value = false
     showDownload.value = true
-  } else {
+  }
+  else {
     showGpuStep.value = true
   }
 }
@@ -418,11 +419,13 @@ onMounted(() => {
                 imageName.arch = undefined
                 imageName.gpu = undefined
                 showDownload = false
-              } else if (imageName.stream === 'lts' && imageName.gpu === 'amd') {
+              }
+              else if (imageName.stream === 'lts' && imageName.gpu === 'amd') {
                 showKernelStep = true
                 imageName.kernel = undefined
                 showDownload = false
-              } else {
+              }
+              else {
                 showGpuStep = true
                 imageName.gpu = undefined
                 imageName.kernel = undefined

--- a/src/components/RssFeed.vue
+++ b/src/components/RssFeed.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import type { MessageSchema } from './../locales/schema'
 import type { BlogPost } from '../utils/feedParser'
-import { parseAtomFeed } from '../utils/feedParser'
+import type { MessageSchema } from './../locales/schema'
 import { onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { parseAtomFeed } from '../utils/feedParser'
 
 const props = defineProps<{
   feedUrl: string

--- a/src/components/TopNavbar.vue
+++ b/src/components/TopNavbar.vue
@@ -48,7 +48,7 @@ const rightNavLinks: NavLink[] = [
 
 const mobileNavLinks = [...leftNavLinks, ...rightNavLinks]
 
-const closeMenu = () => {
+function closeMenu() {
   menuOpen.value = false
 }
 </script>

--- a/src/components/dakota/DakotaScene.vue
+++ b/src/components/dakota/DakotaScene.vue
@@ -153,7 +153,6 @@ onMounted(() => {
   }
 }
 
-
 @media (max-width: 500px) {
   .alpha-badge {
     font-size: 1.1rem;

--- a/src/components/sections/SectionCommunity.vue
+++ b/src/components/sections/SectionCommunity.vue
@@ -52,7 +52,6 @@ const { t } = useI18n<MessageSchema>({
             </div>
           </div>
         </div>
-
       </div>
     </div>
     <SceneVisibilityChecker name="#scene-community" />

--- a/src/tests/composables.test.ts
+++ b/src/tests/composables.test.ts
@@ -1,5 +1,5 @@
-import { ref } from 'vue'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
 
 const width = ref(0)
 

--- a/src/tests/feedParser.test.ts
+++ b/src/tests/feedParser.test.ts
@@ -1,6 +1,6 @@
+import type { XmlParser } from '../utils/feedParser'
 import { DOMParser } from '@xmldom/xmldom'
 import { describe, expect, it } from 'vitest'
-import type { XmlParser } from '../utils/feedParser'
 import { formatFeedDate, parseAtomFeed } from '../utils/feedParser'
 
 describe('feedParser', () => {

--- a/src/utils/feedParser.ts
+++ b/src/utils/feedParser.ts
@@ -13,10 +13,7 @@ interface XmlNodeLike {
 }
 
 export interface XmlParser {
-  parseFromString: (xml: string, mimeType: string) => {
-    documentElement?: { nodeName?: string }
-    getElementsByTagName: (tagName: string) => ArrayLike<XmlNodeLike>
-  }
+  parseFromString: (xml: string, mimeType: DOMParserSupportedType) => Document
 }
 
 function getFirstElement(parent: { getElementsByTagName: (tagName: string) => ArrayLike<XmlNodeLike> }, tagName: string) {

--- a/src/utils/feedParser.ts
+++ b/src/utils/feedParser.ts
@@ -8,26 +8,26 @@ export interface BlogPost {
 
 interface XmlNodeLike {
   textContent?: string | null
-  getAttribute?(name: string): string | null
-  getElementsByTagName(tagName: string): ArrayLike<XmlNodeLike>
+  getAttribute?: (name: string) => string | null
+  getElementsByTagName: (tagName: string) => ArrayLike<XmlNodeLike>
 }
 
 export interface XmlParser {
-  parseFromString(xml: string, mimeType: string): {
+  parseFromString: (xml: string, mimeType: string) => {
     documentElement?: { nodeName?: string }
-    getElementsByTagName(tagName: string): ArrayLike<XmlNodeLike>
+    getElementsByTagName: (tagName: string) => ArrayLike<XmlNodeLike>
   }
 }
 
-function getFirstElement(parent: { getElementsByTagName(tagName: string): ArrayLike<XmlNodeLike> }, tagName: string) {
+function getFirstElement(parent: { getElementsByTagName: (tagName: string) => ArrayLike<XmlNodeLike> }, tagName: string) {
   return parent.getElementsByTagName(tagName)[0] ?? null
 }
 
-function getTextContent(parent: { getElementsByTagName(tagName: string): ArrayLike<XmlNodeLike> }, tagName: string) {
+function getTextContent(parent: { getElementsByTagName: (tagName: string) => ArrayLike<XmlNodeLike> }, tagName: string) {
   return getFirstElement(parent, tagName)?.textContent?.trim() ?? ''
 }
 
-function getAttribute(parent: { getElementsByTagName(tagName: string): ArrayLike<XmlNodeLike> }, tagName: string, name: string) {
+function getAttribute(parent: { getElementsByTagName: (tagName: string) => ArrayLike<XmlNodeLike> }, tagName: string, name: string) {
   return getFirstElement(parent, tagName)?.getAttribute?.(name) ?? ''
 }
 


### PR DESCRIPTION
### Lint changes via `eslint --fix`

- `scripts/tests/update-dakota-versions.test.ts`: Declare `Buffer` import from `node:buffer` directly instead of relying in global Buffer function
- `src/components/TopNavbar.vue`: Convert `closeMenu` into a function
- Prettify code in `src/components/ImageChooser.vue` & `src/utils/feedParser.ts`
- Remove excess blank lines in `src/components/dakota/DakotaScene.vue` & `src/components/sections/SectionCommunity.vue`
- Reorganize import orders in `src/tests/composables.test.ts`, `src/tests/feedParser.test.ts` & `src/components/RssFeed.vue`

---

### Type issue fixed for `src/utils/feedParser.ts`

`XmlParser` interface had a manually-defined `return type ({ documentElement?: ...;  getElementsByTagName: ... })` and `mimeType: string` param, which was incompatible with `DOMParser`'s native signature (`parseFromString(xml: string, type: DOMParserSupportedType): Document`). The interface now matches `DOMParser` exactly, so the default parameter new `DOMParser()` satisfies the type constraint.

Assisted-by: MiMo V2.5 Pro in Pi
https://pi.dev/session/#62b956c4b00c1ae8e95c4f39d437d1a7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Fixed formatting and line breaks in component templates and stylesheets for improved readability.

* **Tests**
  * Updated test utilities and imports for better compatibility.

* **Refactor**
  * Reorganized import statements across files and refined type definitions for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->