### PR TITLE
refactor: Revamp Dakota page layout & styling

### DIFF
--- a/src/DakotaApp.vue
+++ b/src/DakotaApp.vue
@@ -132,6 +132,37 @@ if (i18n.global.availableLocales.includes(currentLocale)) {
   }
 }
 
+.release-links {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  flex-wrap: wrap;
+  gap: 12px 20px;
+  font-size: 1.3rem;
+
+  span {
+    color: var(--color-text-light);
+  }
+
+  a {
+    font-weight: 600;
+    text-decoration: none;
+    background: var(--color-blue-light);
+    color: var(--color-text-light);
+    height: 36px;
+    line-height: 36px;
+    padding: 0 20px 0 20px;
+    border-radius: 18px;
+    transition: opacity 0.2s;
+
+    &:hover {
+      opacity: 1;
+      text-decoration: underline;
+    }
+  }
+}
+
 .alpha-badge-row {
   display: flex;
   justify-content: center;

--- a/src/DakotaApp.vue
+++ b/src/DakotaApp.vue
@@ -1,9 +1,8 @@
 <script setup lang="ts">
 import { onBeforeMount, provide, ref } from 'vue'
-import DakotaDownloadCard from './components/dakota/DakotaDownloadCard.vue'
 import DakotaHighlights from './components/dakota/DakotaHighlights.vue'
 import DakotaScene from './components/dakota/DakotaScene.vue'
-import DakotaVersionChips from './components/dakota/DakotaVersionChips.vue'
+import DakotaVersionCard from './components/dakota/DakotaVersionCard.vue'
 import PageLoading from './components/PageLoading.vue'
 import TopNavbar from './components/TopNavbar.vue'
 import { setLocale } from './composables/useLocale'
@@ -37,23 +36,31 @@ if (i18n.global.availableLocales.includes(currentLocale)) {
     <TopNavbar v-show="!isLoading" />
 
     <div v-show="!isLoading" class="dakota-layout">
-      <!-- Left: text on top, raptor below -->
+      <!-- Left: text, highlights -->
       <div class="col-left">
-        <DakotaScene>
-          <DakotaVersionChips />
-        </DakotaScene>
-        <img
-          class="raptor"
-          src="/characters/dakota.webp"
-          alt="Dakotaraptor"
-          fetchpriority="high"
-        >
+        <DakotaScene />
+        <DakotaHighlights />
       </div>
 
-      <!-- Right: features + download -->
-      <div class="col-features">
-        <DakotaHighlights />
-        <DakotaDownloadCard />
+      <!-- Right: version card + secondary chips -->
+      <div class="col-right">
+        <div class="col-right-sticky">
+          <div class="alpha-badge-row">
+            <div class="alpha-badge">
+              ⚠️ <strong>Alpha software.</strong> Take appropriate precautions.
+            </div>
+          </div>
+          <DakotaVersionCard />
+          <a
+            class="github-btn"
+            href="https://github.com/projectbluefin/dakota"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <svg viewBox="0 0 24 24" fill="currentColor" width="24" height="24"><path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.167 6.839 9.49.5.09.682-.217.682-.482 0-.237-.009-.866-.013-1.7-2.782.604-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0 1 12 6.836a9.59 9.59 0 0 1 2.504.337c1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.577.688.48C19.138 20.161 22 16.418 22 12c0-5.523-4.477-10-10-10z" /></svg>
+            View on GitHub
+          </a>
+        </div>
       </div>
     </div>
   </main>
@@ -61,8 +68,6 @@ if (i18n.global.availableLocales.includes(currentLocale)) {
 
 <style scoped lang="scss">
 .dakota-page {
-  min-height: 100vh;
-  overflow-y: auto;
   background-image: url('/evening/night-sky.webp');
   background-size: cover;
   background-position: center top;
@@ -71,28 +76,91 @@ if (i18n.global.availableLocales.includes(currentLocale)) {
 
 .dakota-layout {
   display: flex;
-  flex-direction: row;
-  align-items: flex-start;
+  flex-direction: column;
+  align-items: stretch;
   box-sizing: border-box;
-  padding: 48px 60px 40px;
-  gap: 40px;
+  padding: 32px 32px 48px;
+  gap: 32px;
 
-  // Keep the fullscreen feel on wide landscape without clipping tall content
-  @media (min-aspect-ratio: 16/10) and (min-width: 1024px) {
-    min-height: calc(100vh - 60px);
+  @media (min-width: 840px) {
+    flex-direction: row;
+    padding: 60px 60px 40px;
+    gap: 40px;
   }
 
-  // Tablet portrait / narrow desktop: stack columns
-  @media (max-aspect-ratio: 16/10), (max-width: 1023px) {
-    flex-direction: column;
-    padding: 32px 32px 48px;
-    gap: 32px;
-  }
-
-  // Phone
   @media (max-width: 600px) {
     padding: 24px 16px 48px;
     gap: 24px;
+  }
+}
+
+.col-right {
+  min-width: 0;
+
+  @media (min-width: 840px) {
+    width: 38%;
+    flex: none;
+  }
+}
+
+.col-right-sticky {
+  @media (min-width: 840px) {
+    position: sticky;
+    top: calc(50vh - 250px);
+  }
+}
+
+.alpha-badge-row {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 16px;
+}
+
+.alpha-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  font-size: 1.2rem;
+  color: var(--color-text-light);
+  background: rgba(var(--color-bg-rgb), 0.5);
+  border: 1px solid var(--color-border-light);
+  border-radius: 6px;
+  padding: 7px 10px;
+
+  strong {
+    font-weight: 600;
+  }
+}
+
+.github-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  height: 36px;
+  line-height: 36px;
+  padding: 0 20px;
+  margin: 16px 64px 0;
+  border-radius: 18px;
+  font-size: 1.4rem;
+  font-weight: 700;
+  background: var(--color-bg);
+  color: var(--color-text-light);
+  border: 2px solid var(--color-bg);
+  text-decoration: none;
+  cursor: pointer;
+  transition: all 0.15s ease;
+
+  svg {
+    width: 1.5rem;
+    height: 1.5rem;
+    flex-shrink: 0;
+  }
+
+  &:hover {
+    background: var(--color-blue);
+    border-color: var(--color-blue);
   }
 }
 
@@ -102,62 +170,5 @@ if (i18n.global.availableLocales.includes(currentLocale)) {
   align-items: flex-start;
   flex: 1;
   min-width: 0;
-
-  // Medium: text box and raptor side by side
-  @media (min-width: 640px) and ((max-aspect-ratio: 16/10) or (max-width: 1023px)) {
-    flex-direction: row;
-    align-items: flex-end;
-    gap: 32px;
-  }
-
-  .raptor {
-    height: 30vh;
-    width: auto;
-    transform: scaleX(-1);
-    filter: drop-shadow(0 20px 60px rgba(var(--color-blue-rgb), 0.2));
-    margin-top: 24px;
-
-    // Medium: no top margin, sits beside text
-    @media (min-width: 640px) and ((max-aspect-ratio: 16/10) or (max-width: 1023px)) {
-      margin-top: 0;
-      flex-shrink: 0;
-    }
-
-    @media (max-aspect-ratio: 16/10), (max-width: 1023px) {
-      height: 20vh;
-      align-self: center;
-    }
-
-    @media (max-width: 600px) {
-      height: 15vh;
-    }
-  }
-}
-
-.col-features {
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-start;
-  flex: 1;
-  min-width: 0;
-  min-height: 0;
-  overflow: visible;
-  background: rgba(var(--color-bg-rgb), 0.55);
-  backdrop-filter: blur(8px);
-  border-radius: 12px;
-  padding: 28px 32px;
-
-  @media (max-aspect-ratio: 16/10), (max-width: 1023px) {
-    width: 100%;
-    box-sizing: border-box;
-  }
-
-  @media (max-width: 600px) {
-    padding: 20px 20px;
-  }
-
-  @media (max-width: 500px) {
-    padding: 20px 16px;
-  }
 }
 </style>

--- a/src/DakotaApp.vue
+++ b/src/DakotaApp.vue
@@ -36,9 +36,31 @@ if (i18n.global.availableLocales.includes(currentLocale)) {
     <TopNavbar v-show="!isLoading" />
 
     <div v-show="!isLoading" class="dakota-layout">
-      <!-- Left: text, highlights -->
+      <!-- Left: text, video, highlights -->
       <div class="col-left">
         <DakotaScene />
+        <div class="video-wrap">
+          <iframe
+            src="https://www.youtube.com/embed/v18c8ipK02A"
+            title="Dakota"
+            frameborder="0"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowfullscreen
+          />
+        </div>
+        <div class="release-links">
+          <span>Read the announcements:</span>
+          <a
+            href="https://docs.projectbluefin.io/blog/making-our-own-fate/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >Alpha 2 Release →</a>
+          <a
+            href="https://docs.projectbluefin.io/blog/dakota-alpha-1/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >Alpha 1 Release →</a>
+        </div>
         <DakotaHighlights />
       </div>
 

--- a/src/DakotaApp.vue
+++ b/src/DakotaApp.vue
@@ -120,7 +120,7 @@ if (i18n.global.availableLocales.includes(currentLocale)) {
   min-width: 0;
 
   @media (min-width: 840px) {
-    width: 38%;
+    width: 35%;
     flex: none;
   }
 }
@@ -128,7 +128,7 @@ if (i18n.global.availableLocales.includes(currentLocale)) {
 .col-right-sticky {
   @media (min-width: 840px) {
     position: sticky;
-    top: calc(50vh - 250px);
+    top: calc(18vh);
   }
 }
 

--- a/src/DakotaApp.vue
+++ b/src/DakotaApp.vue
@@ -47,7 +47,7 @@ if (i18n.global.availableLocales.includes(currentLocale)) {
         <div class="col-right-sticky">
           <div class="alpha-badge-row">
             <div class="alpha-badge">
-              ⚠️ <strong>Alpha software.</strong> Take appropriate precautions.
+              ⚠️ <strong>Alpha.</strong>Take appropriate precautions.
             </div>
           </div>
           <DakotaVersionCard />
@@ -168,6 +168,7 @@ if (i18n.global.availableLocales.includes(currentLocale)) {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
+  gap: 24px;
   flex: 1;
   min-width: 0;
 }

--- a/src/DakotaApp.vue
+++ b/src/DakotaApp.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { onBeforeMount, provide, ref } from 'vue'
+import { IconGithubCircle } from '@iconify-prerendered/vue-mdi'
 import DakotaHighlights from './components/dakota/DakotaHighlights.vue'
 import DakotaScene from './components/dakota/DakotaScene.vue'
 import DakotaVersionCard from './components/dakota/DakotaVersionCard.vue'
@@ -69,11 +70,6 @@ if (i18n.global.availableLocales.includes(currentLocale)) {
       <!-- Right: version card + secondary chips -->
       <div class="col-right">
         <div class="col-right-sticky">
-          <div class="alpha-badge-row">
-            <div class="alpha-badge">
-              ⚠️ <strong>Alpha.</strong>Take appropriate precautions.
-            </div>
-          </div>
           <DakotaVersionCard />
           <a
             class="github-btn"
@@ -81,7 +77,7 @@ if (i18n.global.availableLocales.includes(currentLocale)) {
             target="_blank"
             rel="noopener noreferrer"
           >
-            <svg viewBox="0 0 24 24" fill="currentColor" width="24" height="24"><path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.167 6.839 9.49.5.09.682-.217.682-.482 0-.237-.009-.866-.013-1.7-2.782.604-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0 1 12 6.836a9.59 9.59 0 0 1 2.504.337c1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.577.688.48C19.138 20.161 22 16.418 22 12c0-5.523-4.477-10-10-10z" /></svg>
+            <IconGithubCircle />
             View on GitHub
           </a>
         </div>
@@ -145,7 +141,7 @@ if (i18n.global.availableLocales.includes(currentLocale)) {
 .col-right-sticky {
   @media (min-width: 840px) {
     position: sticky;
-    top: calc(18vh);
+    top: calc(22vh);
   }
 }
 
@@ -180,29 +176,6 @@ if (i18n.global.availableLocales.includes(currentLocale)) {
 	&:hover {
 	  background: var(--color-blue);
 	}
-  }
-}
-
-.alpha-badge-row {
-  display: flex;
-  justify-content: center;
-  margin-bottom: 16px;
-}
-
-.alpha-badge {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  font-size: 1.2rem;
-  color: var(--color-text-light);
-  background: rgba(var(--color-bg-rgb), 0.5);
-  border: 1px solid var(--color-border-light);
-  border-radius: 6px;
-  padding: 7px 10px;
-
-  strong {
-    font-weight: 600;
   }
 }
 

--- a/src/DakotaApp.vue
+++ b/src/DakotaApp.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { onBeforeMount, provide, ref } from 'vue'
 import { IconGithubCircle } from '@iconify-prerendered/vue-mdi'
+import { onBeforeMount, provide, ref } from 'vue'
 import DakotaHighlights from './components/dakota/DakotaHighlights.vue'
 import DakotaScene from './components/dakota/DakotaScene.vue'
 import DakotaVersionCard from './components/dakota/DakotaVersionCard.vue'
@@ -52,17 +52,17 @@ if (i18n.global.availableLocales.includes(currentLocale)) {
         <div class="release-links">
           <span>Read the announcements:</span>
           <div class="release-link-item">
-	        <a
-	          href="https://docs.projectbluefin.io/blog/making-our-own-fate/"
-	          target="_blank"
-	          rel="noopener noreferrer"
-	        >Alpha 2 Release →</a>
-	        <a
-	          href="https://docs.projectbluefin.io/blog/dakota-alpha-1/"
-	          target="_blank"
-	          rel="noopener noreferrer"
-	        >Alpha 1 Release →</a>
-	      </div>
+            <a
+              href="https://docs.projectbluefin.io/blog/making-our-own-fate/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >Alpha 2 Release →</a>
+            <a
+              href="https://docs.projectbluefin.io/blog/dakota-alpha-1/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >Alpha 1 Release →</a>
+          </div>
         </div>
         <DakotaHighlights />
       </div>
@@ -141,7 +141,7 @@ if (i18n.global.availableLocales.includes(currentLocale)) {
 .col-right-sticky {
   @media (min-width: 840px) {
     position: sticky;
-    top: calc(22vh);
+    top: 22vh;
   }
 }
 
@@ -173,9 +173,9 @@ if (i18n.global.availableLocales.includes(currentLocale)) {
     margin: 0 4px 0 4px;
     transition: background 0.2s;
 
-	&:hover {
-	  background: var(--color-blue);
-	}
+    &:hover {
+      background: var(--color-blue);
+    }
   }
 }
 

--- a/src/DakotaApp.vue
+++ b/src/DakotaApp.vue
@@ -50,16 +50,18 @@ if (i18n.global.availableLocales.includes(currentLocale)) {
         </div>
         <div class="release-links">
           <span>Read the announcements:</span>
-          <a
-            href="https://docs.projectbluefin.io/blog/making-our-own-fate/"
-            target="_blank"
-            rel="noopener noreferrer"
-          >Alpha 2 Release →</a>
-          <a
-            href="https://docs.projectbluefin.io/blog/dakota-alpha-1/"
-            target="_blank"
-            rel="noopener noreferrer"
-          >Alpha 1 Release →</a>
+          <div class="release-link-item">
+	        <a
+	          href="https://docs.projectbluefin.io/blog/making-our-own-fate/"
+	          target="_blank"
+	          rel="noopener noreferrer"
+	        >Alpha 2 Release →</a>
+	        <a
+	          href="https://docs.projectbluefin.io/blog/dakota-alpha-1/"
+	          target="_blank"
+	          rel="noopener noreferrer"
+	        >Alpha 1 Release →</a>
+	      </div>
         </div>
         <DakotaHighlights />
       </div>
@@ -145,21 +147,22 @@ if (i18n.global.availableLocales.includes(currentLocale)) {
     color: var(--color-text-light);
   }
 
+.release-link-item {
   a {
     font-weight: 600;
     text-decoration: none;
-    background: var(--color-blue-light);
+    background: rgb(var(--color-bg-rgb), 0.5);
     color: var(--color-text-light);
     height: 36px;
     line-height: 36px;
-    padding: 0 20px 0 20px;
+    padding: 8px 18px;
     border-radius: 18px;
-    transition: opacity 0.2s;
+    margin: 0 4px 0 4px;
+    transition: background 0.2s;
 
-    &:hover {
-      opacity: 1;
-      text-decoration: underline;
-    }
+	&:hover {
+	  background: var(--color-blue);
+	}
   }
 }
 

--- a/src/DakotaApp.vue
+++ b/src/DakotaApp.vue
@@ -140,12 +140,14 @@ if (i18n.global.availableLocales.includes(currentLocale)) {
   justify-content: center;
   width: 100%;
   flex-wrap: wrap;
-  gap: 12px 20px;
-  font-size: 1.3rem;
+  gap: 12px;
+  font-size: 1.4rem;
+  font-weight: 600;
 
   span {
     color: var(--color-text-light);
   }
+}
 
 .release-link-item {
   a {

--- a/src/DakotaApp.vue
+++ b/src/DakotaApp.vue
@@ -194,4 +194,16 @@ if (i18n.global.availableLocales.includes(currentLocale)) {
   flex: 1;
   min-width: 0;
 }
+
+.video-wrap {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  border-radius: 12px;
+  overflow: hidden;
+
+  iframe {
+    width: 100%;
+    height: 100%;
+  }
+}
 </style>

--- a/src/DakotaApp.vue
+++ b/src/DakotaApp.vue
@@ -197,15 +197,16 @@ if (i18n.global.availableLocales.includes(currentLocale)) {
   justify-content: center;
   gap: 8px;
   height: 36px;
+  min-width: 180px;
   line-height: 36px;
   padding: 0 20px;
-  margin: 16px 64px 0;
+  margin: 16px;
   border-radius: 18px;
   font-size: 1.4rem;
   font-weight: 700;
   background: var(--color-bg);
   color: var(--color-text-light);
-  border: 2px solid var(--color-bg);
+  border: 1px solid rgb(var(--color-blue-rgb), 0.3);
   text-decoration: none;
   cursor: pointer;
   transition: all 0.15s ease;

--- a/src/DakotaApp.vue
+++ b/src/DakotaApp.vue
@@ -92,13 +92,28 @@ if (i18n.global.availableLocales.includes(currentLocale)) {
 
 <style scoped lang="scss">
 .dakota-page {
+  position: relative;
   background-image: url('/evening/night-sky.webp');
   background-size: cover;
   background-position: center top;
   background-repeat: no-repeat;
+
+  &::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 600px;
+    background: linear-gradient(to bottom, rgba(var(--color-bg-rgb), 0.7), transparent);
+    z-index: 0;
+    pointer-events: none;
+  }
 }
 
 .dakota-layout {
+  position: relative;
+  z-index: 1;
   display: flex;
   flex-direction: column;
   align-items: stretch;
@@ -143,9 +158,9 @@ if (i18n.global.availableLocales.includes(currentLocale)) {
   gap: 12px;
   font-size: 1.4rem;
   font-weight: 600;
-
   span {
     color: var(--color-text-light);
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
   }
 }
 

--- a/src/components/dakota/DakotaHighlights.vue
+++ b/src/components/dakota/DakotaHighlights.vue
@@ -26,17 +26,6 @@ import {
                 <p>The latest stable release of GNOME, no delays</p>
               </div>
 
-              <!-- Right: uutils-coreutils + sudo-rs -->
-              <div class="brand-item">
-                <div>
-                  <div class="icon-wrap">
-                    <IconShieldCheck />
-                  </div>
-                  <a class="brand-title" href="https://github.com/uutils/coreutils" target="_blank" rel="noopener noreferrer">Modern Userspace</a>
-                </div>
-                <p>bootc, brew, uutils, systemd-boot, container first, and legacy-free</p>
-              </div>
-
               <!-- Left: primary — freedesktop-sdk -->
               <div class="brand-item brand-primary">
                 <div>
@@ -46,6 +35,17 @@ import {
                   <a class="brand-title" href="https://freedesktop-sdk.io" target="_blank" rel="noopener noreferrer">Freedesktop SDK</a>
                 </div>
                 <p>Same battle tested libraries as Flathub. Continuously upgraded, always up to date.</p>
+              </div>
+
+              <!-- Right: uutils-coreutils + sudo-rs -->
+              <div class="brand-item">
+                <div>
+                  <div class="icon-wrap">
+                    <IconShieldCheck />
+                  </div>
+                  <a class="brand-title" href="https://github.com/uutils/coreutils" target="_blank" rel="noopener noreferrer">Modern Userspace</a>
+                </div>
+                <p>bootc, brew, uutils, systemd-boot, container first, and legacy-free</p>
               </div>
 
               <!-- Left: Designed for Contributors -->
@@ -96,8 +96,8 @@ import {
   .icon-wrap {
     svg {
       display: block;
-      height: 24px;
-      width: 24px;
+      height: 32px;
+      width: 32px;
       color: var(--color-text-light);
     }
   }
@@ -121,22 +121,11 @@ import {
     }
 
     p {
-      font-size: 2rem !important;
       font-weight: 400;
     }
   }
 
   :deep(.brand-primary) {
-    .icon-wrap svg {
-      height: 36px;
-      width: 36px;
-    }
-
-    .brand-title,
-    p {
-      font-size: 1.6rem !important;
-    }
-
     p {
       font-weight: 400;
     }
@@ -170,10 +159,44 @@ import {
   }
 }
 
-@media (max-width: 840px) {
+@media (min-width: 957px) {
+  .dakota-highlights {
+    :deep(.brand-gnome) {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+
+      & > div {
+        margin-bottom: 0;
+        flex-shrink: 0;
+      }
+
+      p {
+        margin-left: auto;
+        text-align: right;
+        padding-left: 40px;
+        font-size: 1.6rem !important;
+      }
+    }
+  }
+}
+
+@media (max-width: 956px) {
   .dakota-highlights {
     :deep(.brand-grid) {
       grid-template-columns: 1fr !important;
+    }
+
+    :deep(.brand-gnome) {
+      p {
+        font-size: 1.6rem !important;
+      }
+    }
+
+    :deep(.brand-item) {
+      &:nth-last-child(2) {
+        border-bottom: 1px solid var(--color-border-light);
+      }
     }
   }
 }

--- a/src/components/dakota/DakotaHighlights.vue
+++ b/src/components/dakota/DakotaHighlights.vue
@@ -84,7 +84,14 @@ import {
 <style scoped lang="scss">
 .dakota-highlights {
   min-height: auto;
-  padding: 0;
+  padding: 24px;
+  background: rgba(var(--color-bg-rgb), 0.55);
+  backdrop-filter: blur(8px);
+  border-radius: 12px;
+
+  :deep(.container) {
+    padding: 0;
+  }
 
   .icon-wrap {
     svg {
@@ -97,6 +104,11 @@ import {
 
   :deep(.brand-item) {
     padding: 14px 20px;
+    border-right: none;
+
+    &:nth-child(odd) {
+      border-right: none;
+    }
   }
 
   :deep(.brand-gnome) {
@@ -162,9 +174,6 @@ import {
   .dakota-highlights {
     :deep(.brand-grid) {
       grid-template-columns: 1fr !important;
-    }
-    :deep(.brand-item:nth-child(odd)) {
-      border-right: none !important;
     }
   }
 }

--- a/src/components/dakota/DakotaHighlights.vue
+++ b/src/components/dakota/DakotaHighlights.vue
@@ -159,7 +159,7 @@ import {
   }
 }
 
-@media (min-width: 957px) {
+@media (min-width: 840px) {
   .dakota-highlights {
     :deep(.brand-gnome) {
       display: flex;
@@ -181,7 +181,11 @@ import {
   }
 }
 
-@media (max-width: 956px) {
+@media (max-width: 839px) {
+  .brand-grid {
+    margin-top: 0;
+  }
+
   .dakota-highlights {
     :deep(.brand-grid) {
       grid-template-columns: 1fr !important;

--- a/src/components/dakota/DakotaHighlights.vue
+++ b/src/components/dakota/DakotaHighlights.vue
@@ -170,11 +170,17 @@ import {
   }
 }
 
-@media (max-width: 500px) {
+@media (max-width: 840px) {
   .dakota-highlights {
     :deep(.brand-grid) {
       grid-template-columns: 1fr !important;
     }
+  }
+}
+
+@media only screen and (max-width: 956px) {
+  .brand-grid {
+     margin-top: 0px;
   }
 }
 </style>

--- a/src/components/dakota/DakotaHighlights.vue
+++ b/src/components/dakota/DakotaHighlights.vue
@@ -200,10 +200,4 @@ import {
     }
   }
 }
-
-@media only screen and (max-width: 956px) {
-  .brand-grid {
-     margin-top: 0px;
-  }
-}
 </style>

--- a/src/components/dakota/DakotaScene.vue
+++ b/src/components/dakota/DakotaScene.vue
@@ -23,10 +23,6 @@ onMounted(() => {
       Dakota is a <a href="https://freedesktop-sdk.io" target="_blank" rel="noopener noreferrer">Freedesktop.org</a> and <a href="https://os.gnome.org" target="_blank" rel="noopener noreferrer">GNOME OS</a> image designed from the ground up to be the most modern raptor in the pack. The familiar Bluefin desktop and developer experience, in a whole new streamlined package. Built from the best OS tech from the <a href="https://cncf.io" target="_blank" rel="noopener noreferrer">CNCF</a>, <a href="https://www.apache.org" target="_blank" rel="noopener noreferrer">Apache Foundation</a>, and the <a href="https://uapi-group.org" target="_blank" rel="noopener noreferrer">UAPI Group</a>. Do not run, you'll only die tired.
     </p>
 
-    <div class="alpha-badge">
-      ⚠️ Alpha software — take appropriate precautions
-    </div>
-
     <div class="release-links">
       <a
         href="https://docs.projectbluefin.io/blog/making-our-own-fate/"

--- a/src/components/dakota/DakotaScene.vue
+++ b/src/components/dakota/DakotaScene.vue
@@ -22,21 +22,6 @@ onMounted(() => {
     <p class="hero-desc">
       Dakota is a <a href="https://freedesktop-sdk.io" target="_blank" rel="noopener noreferrer">Freedesktop.org</a> and <a href="https://os.gnome.org" target="_blank" rel="noopener noreferrer">GNOME OS</a> image designed from the ground up to be the most modern raptor in the pack. The familiar Bluefin desktop and developer experience, in a whole new streamlined package. Built from the best OS tech from the <a href="https://cncf.io" target="_blank" rel="noopener noreferrer">CNCF</a>, <a href="https://www.apache.org" target="_blank" rel="noopener noreferrer">Apache Foundation</a>, and the <a href="https://uapi-group.org" target="_blank" rel="noopener noreferrer">UAPI Group</a>. Do not run, you'll only die tired.
     </p>
-
-    <div class="release-links">
-      <a
-        href="https://docs.projectbluefin.io/blog/making-our-own-fate/"
-        target="_blank"
-        rel="noopener noreferrer"
-      >Alpha 2 Announcement →</a>
-      <a
-        href="https://docs.projectbluefin.io/blog/dakota-alpha-1/"
-        target="_blank"
-        rel="noopener noreferrer"
-      >Alpha 1 Announcement →</a>
-    </div>
-
-    <slot />
   </div>
 </template>
 
@@ -99,52 +84,6 @@ onMounted(() => {
     &:hover {
       text-decoration: underline;
     }
-  }
-}
-
-.alpha-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 1.3rem;
-  font-weight: 600;
-  color: var(--color-text-light);
-  background: rgba(var(--color-bg-rgb), 0.5);
-  border: 1px solid var(--color-border-light);
-  border-radius: 6px;
-  padding: 8px 16px;
-  margin-bottom: 0;
-}
-
-.release-links {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px 20px;
-  margin-top: 10px;
-
-  a {
-    color: var(--color-blue-light);
-    font-size: 1.3rem;
-    font-weight: 600;
-    text-decoration: none;
-    opacity: 0.85;
-    transition: opacity 0.2s;
-
-    &:hover {
-      opacity: 1;
-      text-decoration: underline;
-    }
-  }
-}
-
-@media (max-width: 500px) {
-  .alpha-badge {
-    font-size: 1.1rem;
-    padding: 6px 12px;
-  }
-
-  .hero-title {
-    font-size: 4.5rem;
   }
 }
 </style>

--- a/src/components/dakota/DakotaScene.vue
+++ b/src/components/dakota/DakotaScene.vue
@@ -19,10 +19,6 @@ onMounted(() => {
       Dakota
     </h1>
 
-    <p class="hero-tagline">
-      The Final Form. Bluefin Perfected.
-    </p>
-
     <p class="hero-desc">
       Dakota is a <a href="https://freedesktop-sdk.io" target="_blank" rel="noopener noreferrer">Freedesktop.org</a> and <a href="https://os.gnome.org" target="_blank" rel="noopener noreferrer">GNOME OS</a> image designed from the ground up to be the most modern raptor in the pack. The familiar Bluefin desktop and developer experience, in a whole new streamlined package. Built from the best OS tech from the <a href="https://cncf.io" target="_blank" rel="noopener noreferrer">CNCF</a>, <a href="https://www.apache.org" target="_blank" rel="noopener noreferrer">Apache Foundation</a>, and the <a href="https://uapi-group.org" target="_blank" rel="noopener noreferrer">UAPI Group</a>. Do not run, you'll only die tired.
     </p>
@@ -91,14 +87,6 @@ onMounted(() => {
   line-height: 1;
   padding-top: 0;
   padding-left: 0;
-}
-
-.hero-tagline {
-  font-size: 1.6rem;
-  font-weight: 400;
-  color: var(--color-text-light);
-  margin: 0 0 12px 0;
-  line-height: 1.6;
 }
 
 .hero-desc {

--- a/src/components/dakota/DakotaScene.vue
+++ b/src/components/dakota/DakotaScene.vue
@@ -20,7 +20,7 @@ onMounted(() => {
     </h1>
 
     <p class="hero-desc">
-      Dakota is a <a href="https://freedesktop-sdk.io" target="_blank" rel="noopener noreferrer">Freedesktop.org</a> and <a href="https://os.gnome.org" target="_blank" rel="noopener noreferrer">GNOME OS</a> image designed from the ground up to be the most modern raptor in the pack. The familiar Bluefin desktop and developer experience, in a whole new streamlined package. Built from the best OS tech from the <a href="https://cncf.io" target="_blank" rel="noopener noreferrer">CNCF</a>, <a href="https://www.apache.org" target="_blank" rel="noopener noreferrer">Apache Foundation</a>, and the <a href="https://uapi-group.org" target="_blank" rel="noopener noreferrer">UAPI Group</a>. Do not run, you'll only die tired.
+      A <a href="https://freedesktop-sdk.io" target="_blank" rel="noopener noreferrer">Freedesktop.org</a> and <a href="https://os.gnome.org" target="_blank" rel="noopener noreferrer">GNOME OS</a> image, designed from the ground up to be the most modern raptor in the pack. The familiar Bluefin desktop and developer experience, in a whole new streamlined package. Built from the best OS tech from the <a href="https://cncf.io" target="_blank" rel="noopener noreferrer">CNCF</a>, <a href="https://www.apache.org" target="_blank" rel="noopener noreferrer">Apache Foundation</a>, and the <a href="https://uapi-group.org" target="_blank" rel="noopener noreferrer">UAPI Group</a>. Do not run, you'll only die tired.
     </p>
   </div>
 </template>
@@ -32,10 +32,6 @@ onMounted(() => {
   transition:
     opacity 0.6s ease,
     transform 0.6s ease;
-  background: rgba(var(--color-bg-rgb), 0.55);
-  backdrop-filter: blur(8px);
-  border-radius: 12px;
-  padding: 28px 32px;
   width: 100%;
   box-sizing: border-box;
 
@@ -63,18 +59,19 @@ onMounted(() => {
   font-weight: 700;
   font-size: 6rem;
   text-transform: uppercase;
-  color: var(--color-text-light);
+  color: var(--color-blue-light);
   margin: 0 0 24px 0;
   line-height: 1;
   padding-top: 0;
   padding-left: 0;
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
 }
 
 .hero-desc {
   font-size: 1.6rem;
   line-height: 1.6;
   color: var(--color-text-light);
-  margin: 0 0 20px 0;
+  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.4);
 
   a {
     color: var(--color-blue-light);

--- a/src/components/dakota/DakotaVersionCard.vue
+++ b/src/components/dakota/DakotaVersionCard.vue
@@ -423,6 +423,10 @@ function backToCard() {
   gap: 6px;
   font-size: 1.3rem;
   flex: 1;
+
+  &:hover {
+    text-decoration: underline;
+  }
 }
 
 .entry-checksum {
@@ -456,13 +460,15 @@ function backToCard() {
 /* ── Responsive ── */
 
 @media (max-width: 700px) {
-  .card-box {
+  .card-box,
+  .download-view {
     height: 350px;
   }
 }
 
 @media (max-width: 500px) {
-  .card-box {
+  .card-box,
+  .download-view {
     height: 300px;
   }
 

--- a/src/components/dakota/DakotaVersionCard.vue
+++ b/src/components/dakota/DakotaVersionCard.vue
@@ -1,0 +1,457 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import {
+  IconCheckCircleOutline,
+  IconDownload,
+  IconGithubCircle,
+} from '@iconify-prerendered/vue-mdi'
+import { getDakotaVersions } from '../../composables'
+import DakotaVersionChips from './DakotaVersionChips.vue'
+
+interface DakotaVersions {
+  generatedAt: string
+  packages: Record<string, string>
+}
+
+interface DownloadEntry {
+  label: string
+  isoUrl: string
+  isoFilename: string
+  checksumUrl: string
+}
+
+const BASE = 'https://projectbluefin.dev'
+
+const versions = ref<DakotaVersions | null>(null)
+const showDownloads = ref(false)
+
+const cardImageStyle = computed(() => ({
+  backgroundImage: `url(${import.meta.env.BASE_URL}characters/dakota.webp)`,
+}))
+
+const entries: DownloadEntry[] = [
+  {
+    label: 'AMD / Intel',
+    isoUrl: `${BASE}/dakota-live-alpha2.iso`,
+    isoFilename: 'dakota-live-alpha2.iso',
+    checksumUrl: `${BASE}/dakota-live-alpha2.iso-CHECKSUM`,
+  },
+  {
+    label: 'NVIDIA',
+    isoUrl: `${BASE}/dakota-nvidia-live-alpha2.iso`,
+    isoFilename: 'dakota-nvidia-live-alpha2.iso',
+    checksumUrl: `${BASE}/dakota-nvidia-live-alpha2.iso-CHECKSUM`,
+  },
+]
+
+const VERSION_LABELS: Record<string, string> = {
+  'kernel': 'Kernel',
+  'gnome': 'GNOME',
+  'mesa': 'Mesa',
+  'nvidia': 'NVIDIA',
+  'freedesktop-sdk': 'Freedesktop SDK',
+  'bootc': 'bootc',
+}
+
+const versionRows = computed(() => {
+  if (!versions.value) {
+    return []
+  }
+  return Object.entries(versions.value.packages)
+    .filter(([key]) => key in VERSION_LABELS)
+    .map(([key, value]) => ({
+      label: VERSION_LABELS[key],
+      value,
+    }))
+})
+
+onMounted(async () => {
+  try {
+    versions.value = await getDakotaVersions()
+  }
+  catch (e) {
+    if (import.meta.env.DEV) {
+      console.warn('[DakotaVersionCard] failed to load versions', e)
+    }
+  }
+})
+
+function openDownloads() {
+  showDownloads.value = true
+}
+
+function backToCard() {
+  showDownloads.value = false
+}
+</script>
+
+<template>
+  <div class="dakota-version-card">
+    <!-- Card view (character art + version info) -->
+    <div
+      v-if="!showDownloads"
+      class="card-box"
+      @click="openDownloads"
+    >
+      <div
+        class="card-image"
+        :style="cardImageStyle"
+      >
+        <div class="card-overlay">
+          <div class="card-header">
+            <h3 class="card-title">Dakota</h3>
+            <span class="card-subtitle">For the brave soul</span>
+          </div>
+
+          <p class="card-description">
+            The Final Form. Bluefin Perfected.
+          </p>
+
+          <!-- Version Information -->
+          <div v-if="versionRows.length" class="version-info">
+            <div
+              v-for="row in versionRows"
+              :key="row.label"
+              class="version-row"
+            >
+              <span class="version-label">{{ row.label }}</span>
+              <span class="version-value">{{ row.value }}</span>
+            </div>
+          </div>
+
+          <div class="click-hint">
+            Click to download ↓
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Download view -->
+    <div v-else class="download-view">
+      <div class="entries-wrapper">
+        <DakotaVersionChips
+          class="secondary-chips"
+          :keys="['systemd', 'podman', 'pipewire', 'flatpak', 'baseline']"
+        />
+        <div class="download-entries">
+          <div
+            v-for="entry in entries"
+            :key="entry.label"
+            class="download-entry"
+          >
+            <div class="entry-header">
+              <span class="entry-label">{{ entry.label }}</span>
+              <span class="entry-filename">{{ entry.isoFilename }}</span>
+            </div>
+            <div class="entry-buttons">
+              <a
+                class="btn filled entry-dl"
+                :href="entry.isoUrl"
+                :download="entry.isoFilename"
+              >
+                <IconDownload />
+                Download ISO
+              </a>
+              <a
+                class="btn entry-checksum"
+                :href="entry.checksumUrl"
+                title="Verify checksum"
+              >
+                <IconCheckCircleOutline />
+                Verify
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <button class="back-button" @click="backToCard">
+        ← Back
+      </button>
+    </div>
+  </div>
+</template>
+
+<style scoped lang="scss">
+.dakota-version-card {
+  width: 100%;
+}
+
+/* ── Card View ── */
+
+.card-box {
+  position: relative;
+  height: 400px;
+  border-radius: 12px;
+  overflow: hidden;
+  cursor: pointer;
+  transition:
+    transform 0.3s ease,
+    box-shadow 0.3s ease;
+  border: 2px solid rgba(79, 156, 249, 0.25);
+  background: #1f2937;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+    border-color: rgba(79, 156, 249, 0.5);
+  }
+}
+
+.card-image {
+  width: 100%;
+  height: 100%;
+  background-size: contain;
+  background-position: center;
+  background-repeat: no-repeat;
+  position: relative;
+}
+
+.card-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    to bottom,
+    rgba(0, 0, 0, 0.15) 0%,
+    rgba(0, 0, 0, 0.4) 30%,
+    rgba(0, 0, 0, 0.92) 100%
+  );
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  padding: 1.5rem;
+  color: white;
+  border-radius: 12px;
+}
+
+.card-header {
+  margin-bottom: 0.5rem;
+}
+
+.card-title {
+  font-size: 2rem;
+  font-weight: 700;
+  margin: 0 0 0.25rem 0;
+  text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.8);
+}
+
+.card-subtitle {
+  font-size: 1.5rem;
+  opacity: 0.9;
+  display: block;
+  margin-bottom: 0.5rem;
+  text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.8);
+}
+
+.card-description {
+  font-size: 1.5rem;
+  line-height: 1.4;
+  opacity: 0.85;
+  margin: 0 0 0.75rem 0;
+  text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.8);
+  text-align: center;
+}
+
+/* Version rows */
+.version-info {
+  margin-top: 0.75rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.version-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.4rem;
+  font-size: 1.55rem;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.version-label {
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.8);
+  text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.8);
+}
+
+.version-value {
+  font-family: 'Courier New', monospace;
+  color: #93c5fd;
+  font-weight: 500;
+  background: rgba(0, 0, 0, 0.3);
+  padding: 0.1rem 0.4rem;
+  border-radius: 4px;
+  font-size: 1.55rem;
+}
+
+.click-hint {
+  margin-top: 0.75rem;
+  font-size: 1.3rem;
+  font-weight: 600;
+  text-align: center;
+  color: rgba(147, 197, 253, 0.8);
+  animation: pulse-hint 2s ease-in-out infinite;
+}
+
+@keyframes pulse-hint {
+  0%, 100% { opacity: 0.7; }
+  50% { opacity: 1; }
+}
+
+/* ── Download View ── */
+
+.download-view {
+  height: 400px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  background: rgba(31, 41, 55, 0.6);
+  backdrop-filter: blur(8px);
+  border: 2px solid rgba(79, 156, 249, 0.25);
+  border-radius: 12px;
+  padding: 1.5rem;
+  transition:
+    transform 0.3s ease,
+    box-shadow 0.3s ease;
+}
+
+.entries-wrapper {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.secondary-chips {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  margin-bottom: 16px;
+}
+
+.download-entries {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  width: 100%;
+  padding: 0 16px;
+}
+
+.download-entry {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 12px 0;
+}
+
+.download-entry + .download-entry {
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  padding-top: 16px;
+}
+
+.entry-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.entry-label {
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: var(--color-text-light);
+}
+
+.entry-filename {
+  font-size: 1.1rem;
+  font-family: 'Courier New', monospace;
+  color: var(--color-text);
+}
+
+.entry-buttons {
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
+  width: 100%;
+}
+
+.entry-dl {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  font-size: 1.3rem;
+  flex: 1;
+}
+
+.entry-checksum {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  font-size: 1.3rem;
+}
+
+.back-button {
+  display: block;
+  margin-top: auto;
+  margin-bottom: 0;
+  margin-left: auto;
+  margin-right: auto;
+  font-size: 1.3rem;
+  font-weight: 600;
+  color: rgba(147, 197, 253, 0.8);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  transition: color 0.2s ease;
+
+  &:hover {
+    color: rgba(147, 197, 253, 1);
+  }
+}
+
+/* ── Responsive ── */
+
+@media (max-width: 700px) {
+  .card-box {
+    height: 350px;
+  }
+}
+
+@media (max-width: 500px) {
+  .card-box {
+    height: 300px;
+  }
+
+  .card-title {
+    font-size: 1.7rem;
+  }
+
+  .card-subtitle {
+    font-size: 1.3rem;
+  }
+
+  .card-description {
+    font-size: 1.3rem;
+  }
+
+  .version-row {
+    font-size: 1.35rem;
+  }
+
+  .version-value {
+    font-size: 1.35rem;
+  }
+
+  .download-view {
+    padding: 1rem;
+  }
+}
+</style>

--- a/src/components/dakota/DakotaVersionCard.vue
+++ b/src/components/dakota/DakotaVersionCard.vue
@@ -90,7 +90,11 @@ function backToCard() {
     <div
       v-if="!showDownloads"
       class="card-box"
-      @click="openDownloads"
+      role="button"
+      tabindex="0"
+      `@click`="openDownloads"
+      `@keydown.enter.prevent`="openDownloads"
+      `@keydown.space.prevent`="openDownloads"
     >
       <div class="alpha-badge">
         <span class="alpha-badge-title">⚠️ Alpha.</span>

--- a/src/components/dakota/DakotaVersionCard.vue
+++ b/src/components/dakota/DakotaVersionCard.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
 import {
   IconCheckCircleOutline,
   IconDownload,
 } from '@iconify-prerendered/vue-mdi'
+import { computed, onMounted, ref } from 'vue'
 import { getDakotaVersions } from '../../composables'
 import DakotaVersionChips from './DakotaVersionChips.vue'
 
@@ -102,7 +102,9 @@ function backToCard() {
       >
         <div class="card-overlay">
           <div class="card-header">
-            <h3 class="card-title">Dakota</h3>
+            <h3 class="card-title">
+              Dakota
+            </h3>
             <span class="card-subtitle">For the brave soul</span>
           </div>
 
@@ -150,7 +152,6 @@ function backToCard() {
               <a
                 class="btn filled entry-dl"
                 :href="entry.isoUrl"
-                :download="entry.isoFilename"
               >
                 <IconDownload />
                 Download ISO
@@ -214,12 +215,7 @@ function backToCard() {
 .card-overlay {
   position: absolute;
   inset: 0;
-  background: linear-gradient(
-    to bottom,
-    rgba(0, 0, 0, 0.15) 0%,
-    rgba(0, 0, 0, 0.4) 30%,
-    rgba(0, 0, 0, 0.92) 100%
-  );
+  background: linear-gradient(to bottom, rgba(0, 0, 0, 0.15) 0%, rgba(0, 0, 0, 0.4) 30%, rgba(0, 0, 0, 0.92) 100%);
   display: flex;
   flex-direction: column;
   justify-content: flex-end;
@@ -334,8 +330,13 @@ function backToCard() {
 }
 
 @keyframes pulse-hint {
-  0%, 100% { opacity: 0.7; }
-  50% { opacity: 1; }
+  0%,
+  100% {
+    opacity: 0.7;
+  }
+  50% {
+    opacity: 1;
+  }
 }
 
 /* ── Download View ── */

--- a/src/components/dakota/DakotaVersionCard.vue
+++ b/src/components/dakota/DakotaVersionCard.vue
@@ -3,7 +3,6 @@ import { computed, onMounted, ref } from 'vue'
 import {
   IconCheckCircleOutline,
   IconDownload,
-  IconGithubCircle,
 } from '@iconify-prerendered/vue-mdi'
 import { getDakotaVersions } from '../../composables'
 import DakotaVersionChips from './DakotaVersionChips.vue'
@@ -93,6 +92,10 @@ function backToCard() {
       class="card-box"
       @click="openDownloads"
     >
+      <div class="alpha-badge">
+        <span class="alpha-badge-title">⚠️ Alpha.</span>
+        <span class="alpha-badge-sub">Take appropriate precautions.</span>
+      </div>
       <div
         class="card-image"
         :style="cardImageStyle"
@@ -263,7 +266,7 @@ function backToCard() {
 .version-row {
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-end;
   margin-bottom: 0.4rem;
   font-size: 1.55rem;
 
@@ -286,6 +289,39 @@ function backToCard() {
   padding: 0.1rem 0.4rem;
   border-radius: 4px;
   font-size: 1.55rem;
+}
+
+.alpha-badge {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  z-index: 10;
+  width: max-content;
+  max-width: calc(100% - 24px);
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  align-items: baseline;
+  column-gap: 0.3em;
+  white-space: normal;
+  font-size: 1.2rem;
+  line-height: 1.3;
+  color: #fff;
+  background: rgba(0, 0, 0, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 6px;
+  padding: 5px 10px;
+  pointer-events: none;
+  text-align: right;
+
+  .alpha-badge-title {
+    font-weight: 600;
+  }
+
+  .alpha-badge-sub {
+    opacity: 0.9;
+  }
 }
 
 .click-hint {

--- a/src/components/dakota/DakotaVersionCard.vue
+++ b/src/components/dakota/DakotaVersionCard.vue
@@ -92,9 +92,9 @@ function backToCard() {
       class="card-box"
       role="button"
       tabindex="0"
-      `@click`="openDownloads"
-      `@keydown.enter.prevent`="openDownloads"
-      `@keydown.space.prevent`="openDownloads"
+      @click="openDownloads"
+      @keydown.enter.prevent="openDownloads"
+      @keydown.space.prevent="openDownloads"
     >
       <div class="alpha-badge">
         <span class="alpha-badge-title">⚠️ Alpha.</span>

--- a/src/components/dakota/DakotaVersionCard.vue
+++ b/src/components/dakota/DakotaVersionCard.vue
@@ -162,7 +162,7 @@ function backToCard() {
                 title="Verify checksum"
               >
                 <IconCheckCircleOutline />
-                Verify
+                <span class="btn-label">Verify</span>
               </a>
             </div>
           </div>
@@ -342,6 +342,7 @@ function backToCard() {
 /* ── Download View ── */
 
 .download-view {
+  container-type: inline-size;
   min-height: 400px;
   box-sizing: border-box;
   display: flex;
@@ -354,6 +355,18 @@ function backToCard() {
   transition:
     transform 0.3s ease,
     box-shadow 0.3s ease;
+}
+
+@container (max-width: 380px) {
+  .btn-label {
+    display: none;
+  }
+
+  .entry-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 2px;
+  }
 }
 
 .entries-wrapper {

--- a/src/components/dakota/DakotaVersionCard.vue
+++ b/src/components/dakota/DakotaVersionCard.vue
@@ -191,14 +191,14 @@ function backToCard() {
   transition:
     transform 0.3s ease,
     box-shadow 0.3s ease;
-  border: 2px solid rgba(79, 156, 249, 0.25);
+  border: 2px solid rgba(var(--color-blue-rgb), 0.25);
   background: #1f2937;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
 
   &:hover {
     transform: translateY(-2px);
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
-    border-color: rgba(79, 156, 249, 0.5);
+    border-color: rgba(var(--color-blue-rgb), 0.5);
   }
 }
 
@@ -224,7 +224,7 @@ function backToCard() {
   flex-direction: column;
   justify-content: flex-end;
   padding: 1.5rem;
-  color: white;
+  color: var(--color-text-light);
   border-radius: 12px;
 }
 
@@ -307,7 +307,7 @@ function backToCard() {
   white-space: normal;
   font-size: 1.2rem;
   line-height: 1.3;
-  color: #fff;
+  color: var(--color-text-light);
   background: rgba(0, 0, 0, 0.55);
   border: 1px solid rgba(255, 255, 255, 0.2);
   border-radius: 6px;
@@ -347,7 +347,7 @@ function backToCard() {
   flex-direction: column;
   background: rgba(31, 41, 55, 0.6);
   backdrop-filter: blur(8px);
-  border: 2px solid rgba(79, 156, 249, 0.25);
+  border: 2px solid rgba(var(--color-blue-rgb), 0.25);
   border-radius: 12px;
   padding: 1.25rem;
   transition:

--- a/src/components/dakota/DakotaVersionCard.vue
+++ b/src/components/dakota/DakotaVersionCard.vue
@@ -341,7 +341,7 @@ function backToCard() {
 /* ── Download View ── */
 
 .download-view {
-  height: 400px;
+  min-height: 400px;
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
@@ -349,7 +349,7 @@ function backToCard() {
   backdrop-filter: blur(8px);
   border: 2px solid rgba(79, 156, 249, 0.25);
   border-radius: 12px;
-  padding: 1.5rem;
+  padding: 1.25rem;
   transition:
     transform 0.3s ease,
     box-shadow 0.3s ease;
@@ -375,7 +375,7 @@ function backToCard() {
   flex-direction: column;
   gap: 0;
   width: 100%;
-  padding: 0 16px;
+  padding: 0 8px;
 }
 
 .download-entry {
@@ -422,7 +422,8 @@ function backToCard() {
   justify-content: center;
   gap: 6px;
   font-size: 1.3rem;
-  flex: 1;
+  flex: 1 1 0%;
+  white-space: nowrap;
 
   &:hover {
     text-decoration: underline;
@@ -435,6 +436,8 @@ function backToCard() {
   justify-content: center;
   gap: 6px;
   font-size: 1.3rem;
+  flex: 0 1 auto;
+  max-width: 160px;
 }
 
 .back-button {
@@ -459,19 +462,7 @@ function backToCard() {
 
 /* ── Responsive ── */
 
-@media (max-width: 700px) {
-  .card-box,
-  .download-view {
-    height: 350px;
-  }
-}
-
 @media (max-width: 500px) {
-  .card-box,
-  .download-view {
-    height: 300px;
-  }
-
   .card-title {
     font-size: 1.7rem;
   }

--- a/src/components/dakota/DakotaVersionChips.vue
+++ b/src/components/dakota/DakotaVersionChips.vue
@@ -82,6 +82,8 @@ const chips = computed(() => {
   overflow: hidden;
   font-size: 1.2rem;
   line-height: 1;
+  background: rgba(var(--color-bg-rgb), 0.45);
+  backdrop-filter: blur(8px);
 
   &.chip-feature {
     border-color: rgba(var(--color-green-rgb, 80, 200, 120), 0.5);

--- a/src/components/dakota/DakotaVersionChips.vue
+++ b/src/components/dakota/DakotaVersionChips.vue
@@ -17,7 +17,7 @@ const LABELS: Record<string, string> = {
   'freedesktop-sdk': 'Freedesktop SDK',
   'mesa': 'Mesa',
   'bootc': 'bootc',
-  'nvidia': 'Nvidia',
+  'nvidia': 'NVIDIA',
   'systemd': 'systemd',
   'podman': 'Podman',
   'pipewire': 'PipeWire',

--- a/src/components/dakota/DakotaVersionChips.vue
+++ b/src/components/dakota/DakotaVersionChips.vue
@@ -1,5 +1,10 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
+import { getDakotaVersions } from '../../composables'
+
+const props = defineProps<{
+  keys?: string[]
+}>()
 
 interface DakotaVersions {
   generatedAt: string
@@ -26,11 +31,7 @@ const versions = ref<DakotaVersions | null>(null)
 
 onMounted(async () => {
   try {
-    const res = await fetch('/dakota-versions.json')
-    if (!res.ok) {
-      throw new Error(`HTTP ${res.status}`)
-    }
-    versions.value = await res.json()
+    versions.value = await getDakotaVersions()
   }
   catch (e) {
     if (import.meta.env.DEV) {
@@ -44,6 +45,7 @@ const chips = computed(() => {
     return []
   }
   return Object.entries(versions.value.packages)
+    .filter(([key]) => !props.keys || props.keys.includes(key))
     .filter(([, v]) => v)
     .map(([key, value]) => ({ label: LABELS[key] ?? key, value, isFeature: FEATURE_KEYS.has(key) }))
 })

--- a/src/components/dakota/DakotaVersionChips.vue
+++ b/src/components/dakota/DakotaVersionChips.vue
@@ -1,15 +1,11 @@
 <script setup lang="ts">
+import type { DakotaVersions } from '../../composables'
 import { computed, onMounted, ref } from 'vue'
 import { getDakotaVersions } from '../../composables'
 
 const props = defineProps<{
   keys?: string[]
 }>()
-
-interface DakotaVersions {
-  generatedAt: string
-  packages: Record<string, string>
-}
 
 const LABELS: Record<string, string> = {
   'kernel': 'Kernel',

--- a/src/composables.ts
+++ b/src/composables.ts
@@ -10,6 +10,33 @@ export const IS_TABLET = computed(() => {
   return width.value <= 956
 })
 
+interface DakotaVersions {
+  generatedAt: string
+  packages: Record<string, string>
+}
+
+let versionsPromise: Promise<DakotaVersions> | null = null
+
+function fetchVersionsOnce(): Promise<DakotaVersions> {
+  if (!versionsPromise) {
+    versionsPromise = (async () => {
+      const res = await fetch(`${import.meta.env.BASE_URL}dakota-versions.json`)
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`)
+      }
+      return res.json()
+    })()
+  }
+  return versionsPromise
+}
+
+/**
+ * Fetches dakota-versions.json once and caches the result.
+ */
+export async function getDakotaVersions(): Promise<DakotaVersions> {
+  return fetchVersionsOnce()
+}
+
 /**
  * Fades in + slides up 150ms after mount. Used by KnuckleTitle and KnuckleDesc.
  */

--- a/src/composables.ts
+++ b/src/composables.ts
@@ -10,7 +10,7 @@ export const IS_TABLET = computed(() => {
   return width.value <= 956
 })
 
-interface DakotaVersions {
+export interface DakotaVersions {
   generatedAt: string
   packages: Record<string, string>
 }


### PR DESCRIPTION
### Comparison in desktop view

[Screencast From 2026-06-01 11-19-20.webm](https://github.com/user-attachments/assets/d82c453c-6140-46bb-b65e-d4c049aebfae)

### Comparison in mobile view

[Screencast From 2026-06-01 11-37-50.webm](https://github.com/user-attachments/assets/0b22d41b-8946-477a-940d-731b49da333b)

### Highlights

- Change hero section styling approach from blurred card into transparent gradient as page background, to give it more spotlight.
- Brought version card (with download links) from homepage, this time with Dakotaraptor inside.
- Change grid system to put most objects in first column, except for version card & GitHub repo link. Mobile/grid breakpoint is now unified at 840px.
- Embed the ["Bluefin Perfected"](https://youtu.be/v18c8ipK02A) YouTube video from Jorge, and put the announcement post links below it.
- Fix overall visual look between cards/components, on desktop and mobile viewports.

Assisted-by: Deepseek V4 Flash & MiMo V2.5 in OpenCode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned Dakota page layout featuring integrated video/scene content and announcement links
  * Added dedicated version card for easy access to package information and downloads
  * Integrated GitHub repository link

* **Style**
  * Enhanced visual styling with improved card effects, blur effects, and responsive design improvements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->