### PR TITLE
docs(contributing): document i18n locale field rendering types

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,48 @@ npm run typecheck   # Type-check with vue-tsc
 3. Translate all values — keep all keys identical to `enUS.json`
 4. Open a PR; CI will validate the JSON schema
 
+### Locale field rendering
+
+Not all locale fields are rendered the same way. Using the wrong markup in a field produces broken output.
+
+**Markdown fields** — support `**bold**`, `[links](url)`, `_italic_`, etc. (rendered via `marked.parse()`):
+
+| Key | Component |
+|-----|-----------|
+| `Users.Features` | SceneUsers.vue |
+| `Devs.TowerJoke` | SceneDevelopers.vue |
+| `Devs.RuntimeContainers` | SceneDevelopers.vue |
+| `Devs.CNJourney` | SceneDevelopers.vue |
+| `Mission.Text.Change` | SectionMission.vue |
+| `Mission.Text.CloudNative` | SectionMission.vue |
+| `Mission.Text.Sustainability` | SectionMission.vue |
+| `Mission.CleverGirl` | SectionMission.vue |
+| `TryBluefin.Description` | ImageChooser.vue |
+| `TryBluefin.Description.Choice` | ImageChooser.vue |
+| `TryBluefin.Description.Updates` | ImageChooser.vue |
+| `TryBluefin.Download.Documentation.Intro` | ImageChooser.vue |
+| `TryBluefin.Download.Documentation.Downloads` | ImageChooser.vue |
+| `TryBluefin.Download.Documentation.SecureBoot` | ImageChooser.vue |
+| `Video.Text.Passion` | SceneContent.vue |
+| `Video.Text.StateOfTheArt` | SceneContent.vue |
+| `Footer.Credits.Intro` | SectionFooter.vue |
+| `Footer.Credits.Wallpapers` | SectionFooter.vue |
+| `Footer.Credits.Website` | SectionFooter.vue |
+| `Footer.Credits.Logos` | SectionFooter.vue |
+| `Footer.Credits.Thanks` | SectionFooter.vue |
+| `Footer.Credits.Translations` | SectionFooter.vue |
+| `Footer.Credits.ImageEdit` | SectionFooter.vue |
+| `Footer.Project.Ublue` | SectionFooter.vue |
+
+**Raw HTML fields** — use `<a href="...">link</a>` directly; Markdown syntax will appear literally (rendered via `v-html`):
+
+| Key | Component |
+|-----|-----------|
+| `Bazaar.Description` | SectionBazaar.vue |
+| `Bazaar.Additional` | SectionBazaar.vue |
+
+**Plain text fields** — all other keys. Markdown and HTML tags will appear as literal characters. Do not use markup.
+
 ## Testing
 
 Run tests locally before opening a PR.


### PR DESCRIPTION
Applies the documentation from #656 directly to main.

Translators have no way to know which locale keys support Markdown, which accept raw HTML, and which are plain text only. This adds a 'Locale field rendering' subsection under the i18n instructions with three tables.

Closes #648
Closes #656

Co-authored-by: James Reilly <jreilly1821@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded contribution guidelines with comprehensive documentation on how locale JSON fields are rendered within the application, detailing the specific behavior of Markdown-formatted fields, raw HTML fields, and plain-text field types. Added a component/key mapping reference table and essential guidance on proper markup usage to prevent breaking output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->