### PR TITLE
fix(knuckle): remove erroneous backticks from @media query in KnuckleTitle.vue

### DIFF
--- a/src/components/knuckle/KnuckleTitle.vue
+++ b/src/components/knuckle/KnuckleTitle.vue
@@ -87,7 +87,7 @@ const { isLoaded } = useFadeInUp()
   text-shadow: 0 2px 8px rgba(var(--color-bg-rgb), 0.6);
 }
 
-`@media` (max-width: 640px) {
+@media (max-width: 640px) {
   .hero-title {
     font-size: 3.2rem;
   }


### PR DESCRIPTION
## Problem

The deploy workflow has been failing since the knuckle page was introduced:

```
[vite:css] [sass] expected selector.
   ╷
60 │ }
   │  ^
   ╵
  src/components/knuckle/KnuckleTitle.vue 60:2  root stylesheet
```

## Root Cause

Line 90 of `KnuckleTitle.vue` had backtick-wrapped ````@media```` instead of a plain `@media` at-rule:

```scss
// before (broken)
`@media` (max-width: 640px) { ... }

// after (fixed)
@media (max-width: 640px) { ... }
```

SCSS treats the backtick-wrapped token as a selector string, then hits the closing `}` without a matching open rule, producing the 'expected selector' error.

## Fix

One-character change: remove the backticks.

## Test

`npm run build` now completes successfully.