### PR TITLE
feat: automatically show pride.webp during June

### DIFF
--- a/src/components/scenes/SceneLanding.vue
+++ b/src/components/scenes/SceneLanding.vue
@@ -25,10 +25,14 @@ function getRandomBluefinImage() {
 
 const isLoaded = ref(false)
 
-const isHolidaySeason = new Date().getMonth() === 11
+const currentMonth = new Date().getMonth()
+const isHolidaySeason = currentMonth === 11
+const isPrideMonth = currentMonth === 5
 const imageToDisplay = isHolidaySeason
   ? Holidaysaurus
-  : getRandomBluefinImage()
+  : isPrideMonth
+    ? `${import.meta.env.BASE_URL}characters/header/pride.webp`
+    : getRandomBluefinImage()
 
 onMounted(() => {
   setTimeout(() => {


### PR DESCRIPTION
During Pride Month (June), the landing scene character is automatically set to `pride.webp` instead of a random character from the rotation.

## How it works

Follows the same pattern as the existing December → Holidaysaurus logic:

```ts
const currentMonth = new Date().getMonth()
const isHolidaySeason = currentMonth === 11  // December
const isPrideMonth = currentMonth === 5       // June
const imageToDisplay = isHolidaySeason
  ? Holidaysaurus
  : isPrideMonth
    ? `${import.meta.env.BASE_URL}characters/header/pride.webp`
    : getRandomBluefinImage()
```

No manual intervention needed — it just works every June automatically.