### PR TITLE
feat: rename bluespeed page to /server, add Coming Soon widget

### DIFF
--- a/server/index.html
+++ b/server/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Bluefin Server — Cloud-native home infrastructure from Project Bluefin</title>
+  <meta name="description" content="The Bluefin experience for your homelab. Image-based, auto-updating, zero maintenance. One management suite for every node, every service, and every container you run at home." />
+  <!-- Hidden page: not linked from main site, intentionally excluded from search index -->
+  <meta name="robots" content="noindex, nofollow" />
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://projectbluefin.io/server/" />
+  <meta property="og:title" content="Bluefin Server — Cloud-native home infrastructure from Project Bluefin" />
+  <meta property="og:description" content="The Bluefin experience for your homelab. Image-based, auto-updating, zero maintenance. One management suite for every node, every service, and every container you run at home." />
+  <meta property="og:image" content="https://projectbluefin.io/characters/karl.webp" />
+
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Bluefin Server — Cloud-native home infrastructure from Project Bluefin" />
+  <meta name="twitter:description" content="The Bluefin experience for your homelab. Image-based, auto-updating, zero maintenance. One management suite for every node, every service, and every container you run at home." />
+  <meta name="twitter:image" content="https://projectbluefin.io/characters/karl.webp" />
+
+  <link rel="preload" as="image" href="/evening/august-night.webp">
+  <link rel="icon" href="/favicons/favicon.ico" />
+  <link rel="manifest" href="/favicons/site.webmanifest" />
+  <style>@view-transition { navigation: auto; }</style>
+</head>
+
+<body>
+  <div id="app"></div>
+  <script type="module" src="/src/knuckle-main.ts"></script>
+</body>
+
+</html>

--- a/src/KnuckleApp.vue
+++ b/src/KnuckleApp.vue
@@ -61,7 +61,15 @@ if (i18n.global.availableLocales.includes(currentLocale)) {
         </div>
         <div class="alpha-badge-row">
           <div class="alpha-badge">
-            <strong>⚠️ Beta.</strong> Take appropriate precautions.
+            <strong>⚠️ Coming Soon.</strong> Take appropriate precautions.
+          </div>
+        </div>
+
+        <div class="coming-soon-widget">
+          <span class="coming-soon-icon">🚧</span>
+          <div class="coming-soon-text">
+            <strong>Coming Soon!</strong>
+            <span>We're working hard to bring you the full Bluefin Server experience. Stay tuned!</span>
           </div>
         </div>
         <div>
@@ -77,7 +85,7 @@ if (i18n.global.availableLocales.includes(currentLocale)) {
             <li><strong>Built by Experts for themselves.</strong> This is how we would design our ultimate homelab ourselves, your favorite dinosaur people.</li>
             <li><strong>Common.</strong> Everything you learn here is a real world skill. One that is in high demand.</li>
             <li><strong>Foundational.</strong> Keep it simple or build an automation setup totally run by your own self host models. Sky is the limit.</li>
-            <li><strong>On Brand.</strong> Working hard to give you Star Trek, it's about useful bling here, we're trying to show off to our friends.</li>
+            <li><strong>On Brand.</strong> Working hard to give you Star Trek, it's about useful bling.</li>
           </ul>
         </div>
 
@@ -217,6 +225,40 @@ if (i18n.global.availableLocales.includes(currentLocale)) {
   border-radius: 12px;
   padding: 12px 16px;
   box-sizing: border-box;
+}
+
+.coming-soon-widget {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  background: rgba(var(--color-blue-rgb), 0.15);
+  border: 1px solid rgba(var(--color-blue-rgb), 0.4);
+  border-radius: 10px;
+  padding: 14px 20px;
+  backdrop-filter: blur(8px);
+
+  .coming-soon-icon {
+    font-size: 2.4rem;
+    flex-shrink: 0;
+  }
+
+  .coming-soon-text {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+
+    strong {
+      font-size: 1.6rem;
+      font-weight: 700;
+      color: var(--color-blue-light);
+    }
+
+    span {
+      font-size: 1.4rem;
+      color: var(--color-text-light);
+      opacity: 0.85;
+    }
+  }
 }
 
 .alpha-badge-row {

--- a/src/components/knuckle/KnuckleDesc.vue
+++ b/src/components/knuckle/KnuckleDesc.vue
@@ -12,13 +12,13 @@ const { isLoaded } = useFadeInUp()
 <template>
   <div class="knuckle-desc" :class="{ 'is-loaded': isLoaded }">
     <p class="hero-desc">
-      <strong>One management suite</strong> for every service and container you run at home.
+      Bluefin's <a href="https://www.flatcar.org/" target="_blank" rel="noopener noreferrer">Flatcar Linux</a> config. <strong>One management suite</strong> for every service and container in your home.
     </p>
     <p class="hero-desc">
       Image-based, auto-update, zero maintenance, for servers in your closet. <strong>Justfile-driven</strong>, just like Bluefin.
     </p>
     <p class="hero-desc">
-      Easy observability, supporting your steps into <strong>digital sovereignty</strong>!
+      Fully API and MCP driven, the ultimate <i>invisible</i> appliance for the home.
     </p>
   </div>
 </template>

--- a/src/components/knuckle/KnuckleTitle.vue
+++ b/src/components/knuckle/KnuckleTitle.vue
@@ -19,7 +19,7 @@ const { isLoaded } = useFadeInUp()
 
       <div class="title-col-right">
         <p class="title-subtitle">
-          Seamless homelab with CNCF tech stack
+          Digital sovereignty is not just for nations
         </p>
       </div>
     </div>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,7 +28,7 @@ export default defineConfig({
         main: resolve(__dirname, 'index.html'),
         testing: resolve(__dirname, 'public/testing.html'),
         dakota: resolve(__dirname, 'dakota/index.html'),
-        bluespeed: resolve(__dirname, 'bluespeed/index.html'),
+        server: resolve(__dirname, 'server/index.html'),
       },
       output: {
         manualChunks: {


### PR DESCRIPTION
## Changes

- **Rename page**: `/bluespeed/` → `/server/` (new `server/index.html` entry point, vite.config.ts updated)
- **Coming Soon! widget**: added between beta badge and version chips in `KnuckleApp.vue`
- **Flatcar Linux link**: in `KnuckleDesc.vue`, text now links to flatcar.org

Page remains `noindex/nofollow` — unlisted from main nav and search engines.