### PR TITLE
fix(test): stop wolves-movie-flow strict-mode violation on comic-hero-shot

### DIFF
--- a/tests/wolves-movie-flow.mjs
+++ b/tests/wolves-movie-flow.mjs
@@ -260,7 +260,10 @@ try {
     window.__mockWolvesPlayers[index].seekTo(24.01, true)
   }, introPlayerIndex)
   await page.waitForTimeout(250)
-  const comicHeroShotStart = page.locator('[data-comic-hero-shot]')
+  // Exclude the outgoing image mid cross-fade: during a `comic-hero-shot-fade`
+  // transition both the leaving and entering <img> carry data-comic-hero-shot,
+  // which trips Playwright strict mode. Matches the guardian-plate pattern above.
+  const comicHeroShotStart = page.locator('[data-comic-hero-shot]:not(.comic-hero-shot-fade-leave-active)')
   assertTruthy('Comic Hero Shots title card starts on the Jorge hero shot', (await comicHeroShotStart.getAttribute('data-comic-hero-shot'))?.includes('youre-holding-it-wrong-post1'))
   await page.evaluate((index) => {
     window.__mockWolvesPlayers[index].seekTo(30.3, true)


### PR DESCRIPTION
## What

Fixes the **Playwright strict-mode violation** in the `wolves-movie-flow` test that fails on `main` (and therefore every open PR — e.g. #696, #699, which touch only package files):

```
locator.getAttribute: Error: strict mode violation:
locator('[data-comic-hero-shot]') resolved to 2 elements
```

## Why

`WolvesIntroOverlay.vue` cross-fades the hero-shot `<img>` via `<Transition name="comic-hero-shot-fade">` (no `mode="out-in"`), so mid-fade both the outgoing (`…-leave-active`) and incoming (`…-enter-active`) images are in the DOM and both carry `data-comic-hero-shot`. The bare attribute locator matched two elements and `getAttribute` threw.

## Fix

Scope the locator to exclude `.comic-hero-shot-fade-leave-active`, mirroring the existing `:not(.wolves-guardian-plate-swap-leave-active)` guard used a few lines above. One-line change, no component/UX change.

## Verified

CI run on this branch advances from **13 → 19** passing assertions and the strict-mode violation is gone.

## ⚠️ Not fully green yet — a separate, previously-masked failure remains

With the strict violation cleared, the test now reaches a **second, pre-existing bug** it never used to get to:

```
page.waitForSelector: Timeout 10000ms exceeded
  - waiting for locator('.wolves-intro-overlay--transparent-handoff') to be visible
  at tests/wolves-movie-flow.mjs:327
```

The transparent-handoff class is only set by `WolvesApp.handleIntroComplete()` **after** `await startCinematicStage()`, which runs when the overlay emits `complete` (i.e. `sequenceState.done` becomes true). After the single `getByLabel('Next').click()` at line 325 the handoff never appears — so either that one click isn't enough to complete the intro sequence, or the cinematic Track-0 stage doesn't start under the mock fixtures. That needs the Wolves feature owners; it's out of scope for this locator fix but is the next blocker for a green `wolves-movie-flow`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)