### PR TITLE
fix(test): floor coverage thresholds against the lowest supported Node

### DIFF
--- a/docs/skills/validation/SKILL.md
+++ b/docs/skills/validation/SKILL.md
@@ -124,10 +124,18 @@ against (learned 2026-08-09, issues #673–#676):
   `ERROR: Coverage for statements (X%) does not meet ...`, then set the real
   value.
 - **Ratchet below measured, never at aspirational targets.** Global thresholds
-  sit ~1pt under the current run; the components glob gets a wider margin
-  because one added component moves an aggregate more than the global figure.
-  Thresholds above measured fail CI on day one; thresholds far below allow
-  silent regression.
+  sit ~3pt under the *lowest* measured figure, and the components glob gets a
+  wider margin because one added component moves an aggregate more than the
+  global figure. Thresholds above measured fail CI on day one; thresholds far
+  below allow silent regression.
+- **v8 coverage is Node-version sensitive — floor thresholds against the
+  lowest supported version, not against CI.** The same commit measures
+  77.8/67.3/79.5/77.6 on Node 24 (what CI pins) but 73.6/65.1/77.6/73.2 on
+  Node 22 — a ~4pt spread with an identical test set. Thresholds derived from
+  a CI run alone therefore pass CI while failing every contributor on an older
+  Node, which reads as "the suite is broken on main" (hit 2026-08-09, right
+  after #712 set them ~1pt under the Node 24 figures). Measure on your local
+  Node *and* read the CI log before choosing numbers.
 
 Run coverage the way CI does — `CI=true npm run test:run -- --coverage`.
 `src/tests/wolvesBackCatalogue.test.ts` carries a live-network audit gated on

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -43,19 +43,23 @@ export default defineConfig({
       include: ['src/**'],
       reporter: ['text', 'lcov'],
       thresholds: {
-        // Global ratchet ~1pt below measured (77.8/67.3/79.5/77.6) so normal
-        // churn does not trip the gate while regressions still fail CI.
-        'statements': 77,
-        'branches': 66,
-        'functions': 78,
-        'lines': 76,
-        // Backstop for Vue components (measured 72.3/62.7/76.3): wider margin
-        // because a single added component moves the aggregate more.
+        // Ratchet ~3pt below the LOWEST measured figure across supported Node
+        // versions. v8 coverage is Node-version sensitive: the same commit
+        // measures 77.8/67.3/79.5/77.6 on Node 24 (CI) but 73.6/65.1/77.6/73.2
+        // on Node 22, a ~4pt spread. Thresholds set against the CI figure alone
+        // fail for contributors on Node 22, so floor them against the lower
+        // number and keep margin for churn.
+        'statements': 70,
+        'branches': 62,
+        'functions': 74,
+        'lines': 70,
+        // Backstop for Vue components (measured 72.3/62.8/76.6/71.7 on Node 22)
+        // so component coverage cannot regress behind a healthy global average.
         'src/components/**': {
-          statements: 70,
-          branches: 60,
-          functions: 74,
-          lines: 70,
+          statements: 68,
+          branches: 58,
+          functions: 72,
+          lines: 68,
         },
       },
     },


### PR DESCRIPTION
## Problem

v8 coverage is **Node-version sensitive**. The same commit on `main` measures:

| | Node 24 (CI) | Node 22 (local) |
|---|---|---|
| statements | 77.8 | 73.64 |
| branches | 67.33 | 65.13 |
| functions | 79.46 | 77.57 |
| lines | 77.55 | 73.18 |

A ~4pt spread with an **identical test set** (553 passed, 1 skipped in both).

#712 set the global thresholds ~1pt under the Node 24 figures (77/66/78/76). That passes CI, which pins Node 24 — but it means `npm run test:run -- --coverage` exits 1 for anyone on Node 22:

```
ERROR: Coverage for statements (73.64%) does not meet global threshold (77%)
ERROR: Coverage for branches (65.13%) does not meet global threshold (66%)
ERROR: Coverage for functions (77.57%) does not meet global threshold (78%)
ERROR: Coverage for lines (73.18%) does not meet global threshold (76%)
```

That is a green-CI/red-local split — the exact failure mode this repo just spent a full cleanup escaping. It also left only a **0.8pt margin** on CI, so ordinary churn could turn `main` red again.

## Fix

Floor the thresholds ~3pt under the **lower** measurement rather than the CI one:

- global: 77/66/78/76 → **70/62/74/70**
- `src/components/**`: 70/60/74/70 → **68/58/72/68**

Still a large ratchet over the 50/50/50/50 these replaced, and now honest on both Node versions.

## Verification

`CI=1 npm run test:run -- --coverage` → **exit 0** on Node 22, with headroom remaining on Node 24. `check:docs` passes.

The trap is recorded in `docs/skills/validation/SKILL.md` so the thresholds don't get re-tightened against a CI-only measurement.

_(Branch is `test/...` not `fix/...`: a stray remote branch literally named `fix` blocks every `fix/*` ref with a directory/file conflict. Worth deleting separately.)_