### PR TITLE
Back catalogue audit: one unweighted pool, event diversity, and honest captions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,10 +37,15 @@ jobs:
       - name: Restore live data from cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
+          # Must match the save step's path list in update-content.yml exactly,
+          # order included: actions/cache derives the cache version from the
+          # path list, so a mismatch silently restores nothing and every deploy
+          # quietly ships the committed fallback data.
           path: |
             public/stream-versions.yml
             public/dakota-versions.json
             public/flickr-photos.json
+            public/experiences
             src/assets/svg/growth_bluefins.svg
           key: website-live-data-
           restore-keys: |

--- a/.github/workflows/update-content.yml
+++ b/.github/workflows/update-content.yml
@@ -56,10 +56,13 @@ jobs:
         run: node scripts/update-flickr-photos.js
 
       # Album prose and cover art only. Track ingestion scrapes YouTube via
-      # yt-dlp, which is unreliable from CI, so it stays manual; this step fails
-      # loudly (and opens an issue) when an upstream album is missing entirely.
+      # yt-dlp, which is unreliable from CI, so it stays manual. A missing album
+      # is recorded rather than thrown, so a routine upstream publish cannot
+      # discard this run's cache save and deployment; it is escalated at the end.
       - name: Refresh back catalogue metadata
         run: node scripts/update-back-catalogue.js --metadata-only
+        env:
+          MISSING_ALBUMS_FILE: ${{ runner.temp }}/missing-albums.txt
 
       - name: Save live data to cache
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
@@ -76,6 +79,17 @@ jobs:
         run: gh workflow run deploy.yml
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Escalates only after the cache and deployment are safely done, so the
+      # resulting issue never costs a week of live data.
+      - name: Report albums needing a manual ingest
+        run: |
+          if [ -s "${{ runner.temp }}/missing-albums.txt" ]; then
+            echo "Albums published upstream but absent from public/experiences/catalogue.json:"
+            cat "${{ runner.temp }}/missing-albums.txt"
+            echo "Run 'npm run update:back-catalogue' locally with yt-dlp installed."
+            exit 1
+          fi
 
       - name: Create issue on failure
         if: failure()

--- a/.github/workflows/update-content.yml
+++ b/.github/workflows/update-content.yml
@@ -55,6 +55,12 @@ jobs:
       - name: Update Flickr photos
         run: node scripts/update-flickr-photos.js
 
+      # Album prose and cover art only. Track ingestion scrapes YouTube via
+      # yt-dlp, which is unreliable from CI, so it stays manual; this step fails
+      # loudly (and opens an issue) when an upstream album is missing entirely.
+      - name: Refresh back catalogue metadata
+        run: node scripts/update-back-catalogue.js --metadata-only
+
       - name: Save live data to cache
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
@@ -62,6 +68,7 @@ jobs:
             public/stream-versions.yml
             public/dakota-versions.json
             public/flickr-photos.json
+            public/experiences
             src/assets/svg/growth_bluefins.svg
           key: website-live-data-${{ github.run_id }}
 

--- a/docs/skills/wolves-content/SKILL.md
+++ b/docs/skills/wolves-content/SKILL.md
@@ -206,3 +206,113 @@ the attribute intact.
   static quote or source records; preserve explicitly approved cadence locks.
 - Derive Track 0's rotating HUD queue directly from the authored plan and keep
   duplicate status lines; deduping breaks the approved finale cadence.
+
+
+## The back catalogue draws one unweighted pool, not a curated-versus-CNCF mix
+
+The eleven album experiences in `public/experiences/catalogue.json` share a
+single slide pool, ordered by `src/data/back-catalogue-order.ts`:
+
+| Pool | Source | Approx. |
+|---|---|---|
+| CNCF stream | `public/flickr-photos.json` plus locally mirrored CNCF files | 667 |
+| Curated | `wolves/people/` portraits and lore | 77 |
+| Showcase | `wolves/showcase/` | 33 |
+| Mascot art | `wolves/wolves/` | 8 |
+| Hero shots | `public/characters/` via `wolves-comic-hero-shots.ts` | 23 |
+
+Three rules, applied as independent passes:
+
+1. **No category weighting.** Curated slides are placed into gaps between CNCF
+   slides, each gap equally likely. CNCF leads because it outnumbers everything
+   else, never because the ordering prefers it.
+2. **No two non-CNCF slides adjacent**, across the combined curated set. A
+   screenshot followed by a dinosaur reads from the back row as "the photos
+   stopped", so a per-category rule is not enough.
+3. **No two consecutive CNCF slides from the same event.**
+
+Two traps live here.
+
+**Never satisfy an ordering rule by re-drawing.** Re-shuffling until a predicate
+holds is rejection sampling: it biases the distribution and silently breaks rule
+1 while appearing to enforce rule 2. Place correctly by construction, then
+repair what remains in a single deterministic pass.
+
+**Concatenation order is a preference.** Gaps are filled in ascending order, so
+passing the pool as portraits-then-showcase-then-mascot-then-heroes put the
+first dinosaur at slide 745 of 808 — a category bias created by array order
+alone, invisible in every unit test that only checked membership. Shuffle the
+curated slides before placing them, and verify by asking where the first slide
+of the rarest category actually lands.
+
+
+## `wolves/people/` is hand-picked, and two thirds of it is CNCF photography
+
+`wolves/people/` is the owner's selection for the Wolves catalogue. It is **not**
+a CNCF mirror, and it is not all Bluefin work either: 136 of its 213 files came
+from CNCF albums and kept source-prefixed filenames (`flickr-`, `cncf-`,
+`kubecon-`) or `KC+CNC_...` export titles.
+
+So provenance cannot be inferred from the directory, and it cannot be inferred
+from whether the file is served locally. Both shortcuts credit someone else's
+conference photography to Bluefin. Use `classifyCuratedSlide()`, which checks
+the filename stem and the title, and key the on-screen credit on the resulting
+`kind`.
+
+
+## Gallery captions are derived, never invented, and may be withheld
+
+Both feeds ship filenames rather than captions: photographer exports
+(`KC+CNC_EU_240319_KCS_GroupPhoto_MN_001`), camera names (`0R0A9083`,
+`PXL_20240720_181225593`), and Flickr ids (`Cncf 54927603143`). All of it was
+rendered verbatim, at projection size.
+
+`src/data/gallery-captions.ts` reads back only what the filename literally
+encodes — event, region, session, date. Everything else is passed through
+untouched, because authored titles are already correct.
+
+When a title encodes nothing, **render no caption**. Do not guess, and do not
+fall back to a bare timestamp: "July 2024" alone describes no subject and is
+noise wearing a caption's clothes. Roughly 79 of 786 titles legitimately produce
+no caption.
+
+Verify against the real feeds, not fixtures. `public/flickr-photos.json` and
+`wallpapers-list.ts` between them contain grammars no fixture will suggest —
+a second photographer convention (`2024-06-06_OHSNAP_...`), wordplay that a
+naive camel-case split mangles (`KuberTENes` becoming `Kuber TENes`), and room
+codes (`BreakoutsB206`).
+
+
+## `shuffleWolvesGalleryPhotos` is a primitive, not a diversity mechanism
+
+It is a bare Fisher-Yates. The event-diversity logic lives in
+`src/data/wolves-gallery-cycle.ts`.
+
+This matters because it has already gone wrong once: `33a63532` shipped the
+event cycle, and `255f61fb` ("retime intro and shuffle galleries") deleted the
+module and pointed the call site at the shuffle. The commit subject reads like a
+refactor, nothing flagged the lost guarantee, and the catalogue quietly served
+long same-event runs from then on. `src/tests/wolvesGalleryCycle.test.ts` now
+pins the behaviour.
+
+The cycle spreads each event across its own stratum of the run rather than
+dealing round-robin. Round-robin only behaves when events are similar sizes; the
+live feed has hundreds of single-photo events, and dealing every bucket once per
+round put all of them in round one.
+
+
+## Wire every generated feed into the weekly refresh
+
+`update-content.yml` refreshed Flickr photos weekly while
+`update:back-catalogue` was wired into nothing, so album metadata sat at
+whatever a human last ran locally. A single regeneration then pulled six track
+changes and replaced a `[ Redacted ]` subtitle that had been resolved upstream
+long before.
+
+The catalogue generator shells out to `yt-dlp`, which is unreliable from CI, so
+the weekly job runs `--metadata-only`: album prose and cover art over plain
+`fetch`, no scraping. It exits non-zero when an upstream album is missing from
+the catalogue entirely, because that genuinely needs a human with `yt-dlp`.
+
+When adding a generated feed, check it is actually scheduled. "There is a script
+for it" is not the same as "it runs".

--- a/public/experiences/catalogue.json
+++ b/public/experiences/catalogue.json
@@ -123,13 +123,23 @@
           "artist": "Metallica",
           "artwork": "https://i.ytimg.com/vi/dtHuqY679io/hqdefault.jpg",
           "durationSeconds": 270
+        },
+        {
+          "id": "NQtUl7PfD28",
+          "kind": "youtube",
+          "youtubeId": "NQtUl7PfD28",
+          "chapter": "Harbringer: Requiem",
+          "title": "Alone",
+          "artist": "Exit Eden",
+          "artwork": "https://i.ytimg.com/vi/NQtUl7PfD28/hqdefault.jpg",
+          "durationSeconds": 218
         }
       ]
     },
     {
       "id": "PLbORkyQL0Pe8",
       "title": "The Forbidden Factory",
-      "subtitle": "[ Redacted ]",
+      "subtitle": "A factory lost to the ancients. An exiled madman. Can the Maintainer-Guardians get to it before Blue Universal?",
       "artwork": "experiences/PLbORkyQL0Pe8.jpg",
       "segments": [
         {
@@ -143,14 +153,44 @@
           "durationSeconds": 216
         },
         {
-          "id": "Sef7g0yESbA",
+          "id": "PE43-wJ6F84",
           "kind": "youtube",
-          "youtubeId": "Sef7g0yESbA",
+          "youtubeId": "PE43-wJ6F84",
           "chapter": "The Forbidden Factory",
-          "title": "Blur The Technicolor",
-          "artist": "White Zombie",
-          "artwork": "https://i.ytimg.com/vi/Sef7g0yESbA/hqdefault.jpg",
-          "durationSeconds": 250
+          "title": "Here We Go, Let's Rock & Roll",
+          "artist": "C&C Music Factory",
+          "artwork": "https://i.ytimg.com/vi/PE43-wJ6F84/hqdefault.jpg",
+          "durationSeconds": 341
+        },
+        {
+          "id": "WqaiHivKlsE",
+          "kind": "youtube",
+          "youtubeId": "WqaiHivKlsE",
+          "chapter": "The Forbidden Factory",
+          "title": "Deutschland (Instrumental)",
+          "artist": "RAMMSTEIN",
+          "artwork": "https://i.ytimg.com/vi/WqaiHivKlsE/hqdefault.jpg",
+          "durationSeconds": 315
+        },
+        {
+          "id": "BRM3MYxz-38",
+          "kind": "youtube",
+          "youtubeId": "BRM3MYxz-38",
+          "chapter": "The Forbidden Factory",
+          "title": "Hell March Trilogy",
+          "artist": "Smiechu",
+          "artwork": "https://i.ytimg.com/vi/BRM3MYxz-38/hqdefault.jpg",
+          "durationSeconds": 406
+        },
+        {
+          "id": "hLmjP6wDn3M",
+          "kind": "youtube",
+          "youtubeId": "hLmjP6wDn3M",
+          "chapter": "The Forbidden Factory",
+          "title": "Can't Play Dead",
+          "artist": "The Heavy",
+          "artwork": "https://i.ytimg.com/vi/hLmjP6wDn3M/hqdefault.jpg",
+          "durationSeconds": 261
         },
         {
           "id": "mlgdJjqFfjg",
@@ -163,14 +203,24 @@
           "durationSeconds": 258
         },
         {
-          "id": "rmenTtGe_6I",
+          "id": "TeJDIzPxd0M",
           "kind": "youtube",
-          "youtubeId": "rmenTtGe_6I",
+          "youtubeId": "TeJDIzPxd0M",
           "chapter": "The Forbidden Factory",
-          "title": "Jesus Built My Hotrod",
+          "title": "Just One Fix",
           "artist": "Ministry",
-          "artwork": "https://i.ytimg.com/vi/rmenTtGe_6I/hqdefault.jpg",
-          "durationSeconds": 292
+          "artwork": "https://i.ytimg.com/vi/TeJDIzPxd0M/hqdefault.jpg",
+          "durationSeconds": 311
+        },
+        {
+          "id": "Sef7g0yESbA",
+          "kind": "youtube",
+          "youtubeId": "Sef7g0yESbA",
+          "chapter": "The Forbidden Factory",
+          "title": "Blur The Technicolor",
+          "artist": "Release",
+          "artwork": "https://i.ytimg.com/vi/Sef7g0yESbA/hqdefault.jpg",
+          "durationSeconds": 250
         },
         {
           "id": "zVq7Ps9SaI4",
@@ -193,14 +243,14 @@
           "durationSeconds": 273
         },
         {
-          "id": "hLmjP6wDn3M",
+          "id": "EfGBeAGwokg",
           "kind": "youtube",
-          "youtubeId": "hLmjP6wDn3M",
+          "youtubeId": "EfGBeAGwokg",
           "chapter": "The Forbidden Factory",
-          "title": "Can't Play Dead",
-          "artist": "The Heavy",
-          "artwork": "https://i.ytimg.com/vi/hLmjP6wDn3M/hqdefault.jpg",
-          "durationSeconds": 261
+          "title": "Ich Will Instrumental",
+          "artist": "Rammstein",
+          "artwork": "https://i.ytimg.com/vi/EfGBeAGwokg/hqdefault.jpg",
+          "durationSeconds": 217
         }
       ]
     },
@@ -384,7 +434,7 @@
           "youtubeId": "yUCTlqExGyo",
           "chapter": "Bluefin finds Her Way",
           "title": "The Mark Has Been Made",
-          "artist": "Nine Inch Nails",
+          "artist": "Release",
           "artwork": "https://i.ytimg.com/vi/yUCTlqExGyo/hqdefault.jpg",
           "durationSeconds": 316
         },
@@ -404,7 +454,7 @@
           "youtubeId": "UZ0M09LQTI4",
           "chapter": "Bluefin finds Her Way",
           "title": "Song And Emotion",
-          "artist": "TESLA",
+          "artist": "Release",
           "artwork": "https://i.ytimg.com/vi/UZ0M09LQTI4/hqdefault.jpg",
           "durationSeconds": 509
         },
@@ -472,7 +522,7 @@
           "youtubeId": "b612uztK8io",
           "chapter": "Bluefin and Achillobator",
           "title": "The Mercenary",
-          "artist": "Iron Maiden",
+          "artist": "Release",
           "artwork": "https://i.ytimg.com/vi/b612uztK8io/hqdefault.jpg",
           "durationSeconds": 283
         },
@@ -776,7 +826,7 @@
           "youtubeId": "ZP657058PbQ",
           "chapter": "Bluefin and the Children of Jensen",
           "title": "Unsung",
-          "artist": "Helmet",
+          "artist": "Helmut",
           "artwork": "https://i.ytimg.com/vi/ZP657058PbQ/hqdefault.jpg",
           "durationSeconds": 237
         },
@@ -1032,7 +1082,7 @@
           "youtubeId": "4aZX-C8HKJc",
           "chapter": "Bluefin and the Syrens of Metal",
           "title": "School Revolution",
-          "artist": "VoB (Voice of Baceprot)",
+          "artist": "Voice of Baceprot",
           "artwork": "https://i.ytimg.com/vi/4aZX-C8HKJc/hqdefault.jpg",
           "durationSeconds": 350
         },

--- a/scripts/tests/update-back-catalogue.test.ts
+++ b/scripts/tests/update-back-catalogue.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { auditExperience, buildExperience } from '../update-back-catalogue.js'
+
+const album = { id: 'PLtest', title: 'Test Album', description: 'A test album' }
+
+function entry(overrides = {}) {
+  return { id: 'vid00000001', title: 'Artist - Song', duration: 200, ...overrides }
+}
+
+describe('buildExperience', () => {
+  it('applies the artist override for the Voice of Baceprot channel name', () => {
+    const experience = buildExperience(album, [
+      entry({ id: '4aZX-C8HKJc', title: 'VoB (Voice of Baceprot) - School Revolution' }),
+    ])
+
+    expect(experience.segments[0].artist).toBe('Voice of Baceprot')
+  })
+})
+
+describe('auditExperience', () => {
+  it('accepts a well-formed experience', () => {
+    const entries = [entry()]
+    expect(() => auditExperience(album, entries, buildExperience(album, entries))).not.toThrow()
+  })
+
+  it('rejects an empty artist', () => {
+    const entries = [entry()]
+    const experience = buildExperience(album, entries)
+    experience.segments[0].artist = '   '
+
+    expect(() => auditExperience(album, entries, experience)).toThrow(/empty artist/)
+  })
+
+  it('rejects an empty title', () => {
+    const entries = [entry()]
+    const experience = buildExperience(album, entries)
+    experience.segments[0].title = ''
+
+    expect(() => auditExperience(album, entries, experience)).toThrow(/empty title/)
+  })
+
+  it('rejects an implausible duration', () => {
+    const entries = [entry()]
+    const experience = buildExperience(album, entries)
+    experience.segments[0].durationSeconds = 60 * 60 * 5
+
+    expect(() => auditExperience(album, entries, experience)).toThrow(/implausible duration/)
+  })
+
+  it('rejects a non-finite duration', () => {
+    const entries = [entry()]
+    const experience = buildExperience(album, entries)
+    experience.segments[0].durationSeconds = Number.POSITIVE_INFINITY
+
+    expect(() => auditExperience(album, entries, experience)).toThrow(/implausible duration/)
+  })
+
+  it('still rejects a zero duration', () => {
+    const entries = [entry()]
+    const experience = buildExperience(album, entries)
+    experience.segments[0].durationSeconds = 0
+
+    expect(() => auditExperience(album, entries, experience)).toThrow(/bad duration/)
+  })
+})

--- a/scripts/update-back-catalogue.js
+++ b/scripts/update-back-catalogue.js
@@ -27,12 +27,14 @@
 
 import { Buffer } from 'node:buffer'
 import { execFileSync } from 'node:child_process'
-import { mkdir, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const METADATA_URL = 'https://docs.projectbluefin.io/data/playlist-metadata.json'
 const COVER_URL = id => `https://docs.projectbluefin.io/img/playlists/${id}.jpg`
+/** Longest plausible track. Guards against a malformed duration reaching the timeline. */
+const MAX_SEGMENT_SECONDS = 60 * 60
 const FEATURED_ALBUM_IDS = new Set(['PLA78oiE-RGAE'])
 const FEATURED_ALBUM_TITLES = new Set(['Seven Days to the Wolves'])
 const MODULE_PATH = import.meta.url.startsWith('file:')
@@ -104,6 +106,9 @@ const TRACK_METADATA_OVERRIDES = {
   '_HGZBLdn9_c': { artist: 'Ice Cube' },
   'Ma440BTErHw': { title: 'I Don\'t Like Mondays', artist: 'Tori Amos' },
   'Z6VpX-feA2M': { title: 'Quad Machine', artist: 'Sonic Mayhem' },
+  // The band's own channel name carries the expansion in parentheses; the
+  // nameplate has room for the performing name only.
+  '4aZX-C8HKJc': { artist: 'Voice of Baceprot' },
 }
 
 export function stripArtistPrefix(title, artist) {
@@ -221,8 +226,17 @@ export function auditExperience(album, entries, experience) {
     if (typeof segment.durationSeconds !== 'number' || segment.durationSeconds <= 0) {
       throw new Error(`Back catalogue audit failed for ${album.title}: bad duration for ${segment.id}`)
     }
+    if (!Number.isFinite(segment.durationSeconds) || segment.durationSeconds > MAX_SEGMENT_SECONDS) {
+      throw new Error(`Back catalogue audit failed for ${album.title}: implausible duration ${segment.durationSeconds}s for ${segment.id}`)
+    }
     if (typeof segment.youtubeId !== 'string' || segment.youtubeId.trim().length === 0) {
       throw new Error(`Back catalogue audit failed for ${album.title}: bad youtubeId for ${segment.id}`)
+    }
+    if (typeof segment.title !== 'string' || segment.title.trim().length === 0) {
+      throw new Error(`Back catalogue audit failed for ${album.title}: empty title for ${segment.id}`)
+    }
+    if (typeof segment.artist !== 'string' || segment.artist.trim().length === 0) {
+      throw new Error(`Back catalogue audit failed for ${album.title}: empty artist for ${segment.id}`)
     }
   }
 }
@@ -263,8 +277,66 @@ export async function main() {
   console.info(`Wrote ${experiences.length} experiences to public/experiences/catalogue.json`)
 }
 
+/**
+ * Weekly refresh that needs no `yt-dlp`.
+ *
+ * Album prose (title, subtitle) and cover art change upstream far more often
+ * than tracklists do, and refreshing them is a plain `fetch`. Track ingestion
+ * scrapes YouTube, which is rate-limited and unreliable from CI, so it stays a
+ * deliberate manual step.
+ *
+ * An album published upstream but absent from the catalogue cannot be filled in
+ * without that scrape, so this exits non-zero and names the command to run. The
+ * caller's failure handler turns that into an issue rather than letting the
+ * grid quietly go stale — which is exactly what happened before this existed.
+ */
+export async function refreshMetadata() {
+  const albums = await (await fetch(METADATA_URL)).json()
+  if (!Array.isArray(albums)) {
+    throw new TypeError('Malformed playlist metadata: expected an array')
+  }
+
+  const cataloguePath = join(EXPERIENCES_DIR, 'catalogue.json')
+  const existing = JSON.parse(await readFile(cataloguePath, 'utf8'))
+  if (!Array.isArray(existing?.experiences)) {
+    throw new TypeError('Malformed catalogue.json: expected an experiences array')
+  }
+  const byId = new Map(existing.experiences.map(experience => [experience.id, experience]))
+  const missing = []
+  let updated = 0
+
+  for (const album of albums) {
+    if (!shouldIncludeAlbum(album)) {
+      continue
+    }
+    const experience = byId.get(album.id)
+    if (!experience) {
+      missing.push(album)
+      continue
+    }
+    if (experience.title !== album.title || experience.subtitle !== album.description) {
+      console.info(`Updating prose for ${album.title} (${album.id})`)
+      experience.title = album.title
+      experience.subtitle = album.description
+      updated++
+    }
+    await writeFile(join(EXPERIENCES_DIR, `${album.id}.jpg`), await download(COVER_URL(album.id)))
+  }
+
+  await writeFile(cataloguePath, `${JSON.stringify(existing, null, 2)}\n`)
+  console.info(`Refreshed ${byId.size} album covers; ${updated} prose updates.`)
+
+  if (missing.length > 0) {
+    for (const album of missing) {
+      console.error(`Album not in the catalogue: ${album.title} (${album.id})`)
+    }
+    throw new Error(`${missing.length} album(s) need a full ingest: run "npm run update:back-catalogue" locally with yt-dlp installed.`)
+  }
+}
+
 if (MODULE_PATH && process.argv[1] && MODULE_PATH === resolve(process.argv[1])) {
-  main().catch((error) => {
+  const run = process.argv.includes('--metadata-only') ? refreshMetadata : main
+  run().catch((error) => {
     console.error(error instanceof Error ? error.message : String(error))
     process.exitCode = 1
   })

--- a/scripts/update-back-catalogue.js
+++ b/scripts/update-back-catalogue.js
@@ -280,6 +280,12 @@ export async function main() {
 /**
  * Weekly refresh that needs no `yt-dlp`.
  *
+ * Reports missing albums rather than failing. A new album published upstream is
+ * routine, and this step runs before the cache save and the deploy trigger — so
+ * throwing here would discard that week's stream versions, Dakota versions,
+ * growth chart and Flickr refresh over a cosmetic gap in one grid. The caller
+ * escalates afterwards, via MISSING_ALBUMS_FILE, once the pipeline has run.
+ *
  * Album prose (title, subtitle) and cover art change upstream far more often
  * than tracklists do, and refreshing them is a plain `fetch`. Track ingestion
  * scrapes YouTube, which is rate-limited and unreliable from CI, so it stays a
@@ -328,10 +334,18 @@ export async function refreshMetadata() {
 
   if (missing.length > 0) {
     for (const album of missing) {
-      console.error(`Album not in the catalogue: ${album.title} (${album.id})`)
+      console.warn(`Album not in the catalogue: ${album.title} (${album.id})`)
     }
-    throw new Error(`${missing.length} album(s) need a full ingest: run "npm run update:back-catalogue" locally with yt-dlp installed.`)
+    console.warn(`${missing.length} album(s) need a full ingest: run "npm run update:back-catalogue" locally with yt-dlp installed.`)
+    if (process.env.MISSING_ALBUMS_FILE) {
+      await writeFile(
+        process.env.MISSING_ALBUMS_FILE,
+        `${missing.map(album => `${album.title} (${album.id})`).join('\n')}\n`,
+      )
+    }
   }
+
+  return { missing }
 }
 
 if (MODULE_PATH && process.argv[1] && MODULE_PATH === resolve(process.argv[1])) {

--- a/src/components/wolves/WolvesComicReader.vue
+++ b/src/components/wolves/WolvesComicReader.vue
@@ -1089,7 +1089,18 @@ function photoObjectPosition(photo: any) {
   return isWolvesExperience.value && photo?.id === ghostsInTheMistOpeningSlide.photoId ? 'center top' : 'center'
 }
 
+/**
+ * Caption text. The frozen Wolves show keeps its historical raw titles: the
+ * derivation withholds a caption for titles that encode nothing, and 25 photos
+ * in the Wolves later-track rotation carry camera-roll names (`A7V06139`,
+ * `CRJ07242`). Suppressing those would take the `CNCF STREAM //` credit off the
+ * screen with them, which is a change to the authored show, not to the
+ * catalogue.
+ */
 function photoCaptionText(photo: any) {
+  if (isWolvesExperience.value) {
+    return photo?.title || 'Untitled slide'
+  }
   return formatGalleryCaption(photo?.title)
 }
 

--- a/src/components/wolves/WolvesComicReader.vue
+++ b/src/components/wolves/WolvesComicReader.vue
@@ -16,6 +16,9 @@ is a no-op kept only for the download link.
 import type { SoundtrackTrack, WolvesSoundtrackManifest } from '@/data/wolves-soundtrack'
 
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { classifyCuratedSlide, isCncfSlide, orderBackCatalogueSlides } from '@/data/back-catalogue-order'
+import { formatGalleryCaption, getGalleryCaptionLabel } from '@/data/gallery-captions'
+import { wolvesComicHeroShots } from '@/data/wolves-comic-hero-shots'
 import { ghostsInTheMistOpeningSlide } from '@/data/wolves-gallery-featured'
 import { shuffleWolvesGalleryPhotos } from '@/data/wolves-gallery-shuffle'
 import { loadWolvesSoundtrack } from '@/data/wolves-soundtrack'
@@ -177,133 +180,6 @@ const currentBeat = computed(() => {
 
 // Evaluated to keep the computed active for vitest assertions without TS6133 unused error
 void currentBeat.value
-
-const mixedPhotos = computed(() => {
-  // NOT DEAD CODE. This is the slideshow for the ten non-Wolves album
-  // experiences in public/experiences/catalogue.json. `mixedPhotosToUse` only
-  // swaps in `timelineSlides` when `wolvesExperience` is true, so this branch
-  // still runs for every other album at trackIndex 0. Deleting it because the
-  // Wolves path looks like a replacement breaks those albums silently — the
-  // Wolves route keeps working, so a /wolves/ smoke test will not catch it.
-
-  // Rebuild the per-experience shuffle when the lobby launches another album.
-  void props.experienceId
-
-  // 1. Local Showcase and Story wallpapers (isPeople = false)
-  const localShowcase = wallpapers.filter((wp) => {
-    const isPeople = wp.name?.includes('/people/') || wp.dayName?.includes('/people/') || wp.nightName?.includes('/people/')
-    return !isPeople && !wp.name?.endsWith('.gif')
-  }).map(wp => ({
-    id: wp.name,
-    isLocal: true,
-    path: wp.name,
-    title: wp.title,
-    type: wp.type,
-    dayName: wp.dayName,
-    nightName: wp.nightName,
-    fit: wp.fit,
-    description: wp.description
-  }))
-
-  // 2. Local People wallpapers (isPeople = true)
-  const localPeople = wallpapers.filter((wp) => {
-    const isPeople = wp.name?.includes('/people/') || wp.dayName?.includes('/people/') || wp.nightName?.includes('/people/')
-    const id = wp.name ?? wp.dayName ?? wp.nightName ?? ''
-    return isPeople && !trackZeroReservedForLaterIds.has(id)
-  }).map(wp => ({
-    id: wp.name,
-    isLocal: true,
-    path: wp.name,
-    title: wp.title,
-    type: wp.type,
-    dayName: wp.dayName,
-    nightName: wp.nightName,
-    fit: wp.fit,
-    description: wp.description
-  }))
-
-  // 3. Flickr Remote People photos
-  const remotePeople = flickrPhotos.value.map(p => ({
-    id: p.id,
-    isLocal: false,
-    path: `https://live.staticflickr.com/${p.server}/${p.id}_${p.secret}_b.jpg`,
-    title: p.title,
-    type: 'single' as const,
-    dayName: undefined,
-    nightName: undefined,
-    rawPhoto: p
-  }))
-
-  const trackIdx = props.trackIndex ?? 1
-
-  if (trackIdx > 0) {
-    return laterTrackPhotos.value
-  }
-
-  // Shuffle inputs to vary the lists per-song
-  const shuffledShowcase = shuffleArray([...localShowcase])
-  const shuffledPeople = shuffleArray([
-    ...localPeople,
-    ...remotePeople
-  ])
-
-  // Every track starts with 3 showcase screenshots
-  const pinnedStart = shuffledShowcase.slice(0, 3)
-  const remainingShowcase = shuffledShowcase.slice(3)
-
-  if (trackIdx === 1) {
-    // Track 1 (First Song of Slideshow): Bias showcase at start and fade smoothly into people/Flickr photos
-    const result: any[] = [...pinnedStart]
-    const remainingShowcaseCopy = [...remainingShowcase]
-    const shuffledPeopleCopy = [...shuffledPeople]
-
-    const totalRemaining = remainingShowcaseCopy.length + shuffledPeopleCopy.length
-    for (let i = 0; i < totalRemaining; i++) {
-      // Linear fade-out of showcase probability from 0.8 to 0.0 over 40 slides
-      const showcaseProb = Math.max(0, 0.8 * (1 - i / 40))
-      if (remainingShowcaseCopy.length > 0 && (shuffledPeopleCopy.length === 0 || Math.random() < showcaseProb)) {
-        result.push(remainingShowcaseCopy.shift())
-      }
-      else if (shuffledPeopleCopy.length > 0) {
-        result.push(shuffledPeopleCopy.shift())
-      }
-      else {
-        result.push(remainingShowcaseCopy.shift())
-      }
-    }
-    return result
-  }
-  else {
-    // Tracks 2-6: Ensure showcase photos never go back-to-back, and each song starts with a showcase photo
-    const result: any[] = []
-    const showcaseCopy = [...shuffledShowcase]
-    const peopleCopy = [...shuffledPeople]
-
-    // Start with 1 showcase photo
-    if (showcaseCopy.length > 0) {
-      result.push(showcaseCopy.shift())
-    }
-
-    while (showcaseCopy.length > 0 || peopleCopy.length > 0) {
-      // Add up to 2 people/Flickr photos
-      let addedPeople = 0
-      for (let k = 0; k < 2; k++) {
-        if (peopleCopy.length > 0) {
-          result.push(peopleCopy.shift())
-          addedPeople++
-        }
-      }
-
-      // Add 1 showcase photo (only if we added at least 1 people/Flickr photo to prevent back-to-back!)
-      if (showcaseCopy.length > 0) {
-        if (addedPeople > 0 || result.length === 0) {
-          result.push(showcaseCopy.shift())
-        }
-      }
-    }
-    return result
-  }
-})
 
 interface TimelineSlide {
   id: string
@@ -750,8 +626,53 @@ const trackZeroCarryForwardPhotos = computed(() => {
       nightName: wallpaper.nightName,
       fit: wallpaper.fit,
       description: wallpaper.description,
+      kind: classifyCuratedSlide(wallpaper.name ?? '', wallpaper.title),
     }))
     .filter(photo => !scheduledIds.has(photo.id))
+})
+
+/**
+ * The rest of the curated catalogue, for back-catalogue albums only: product
+ * showcase, commissioned mascot art, and the comic hero shots.
+ *
+ * None of these could previously reach an album. `trackZeroCarryForwardPhotos`
+ * filters to `/people/`, so showcase and mascot art were excluded, and the hero
+ * shots were only ever wired into the intro overlay.
+ *
+ * Hero shots keep the authored order from `wolves-comic-hero-shots.ts`, where
+ * no character or species repeats back-to-back — a property a shuffle cannot
+ * reconstruct, because it has no idea which dinosaur is which. They resolve
+ * from `public/characters/` rather than `img/wallpapers/`, so they are marked
+ * remote and carry a fully-resolved path.
+ */
+const backCatalogueCuratedPhotos = computed(() => {
+  const showcaseAndArt = wallpapers
+    .filter(wallpaper => !wallpaper.name?.includes('/people/') && !wallpaper.name?.endsWith('.gif'))
+    .map(wallpaper => ({
+      id: wallpaper.name || wallpaper.dayName || wallpaper.nightName || '',
+      isLocal: true,
+      path: wallpaper.name,
+      title: wallpaper.title,
+      type: wallpaper.type,
+      dayName: wallpaper.dayName,
+      nightName: wallpaper.nightName,
+      fit: wallpaper.fit,
+      description: wallpaper.description,
+      kind: classifyCuratedSlide(wallpaper.name || wallpaper.dayName || '', wallpaper.title),
+    }))
+
+  const heroShots = wolvesComicHeroShots.map(shot => ({
+    id: shot.id,
+    isLocal: false,
+    path: `${baseUrl}characters/${shot.src.replace(/^characters\//, '')}`,
+    title: shot.label,
+    type: 'single' as const,
+    dayName: undefined,
+    nightName: undefined,
+    kind: 'hero' as const,
+  }))
+
+  return [...showcaseAndArt, ...heroShots]
 })
 
 const activeTimelineSlide = computed(() => {
@@ -837,6 +758,48 @@ const activeTimelineSlideIndex = computed(() => {
     return 0
   }
   return timelineSlides.value.indexOf(slide)
+})
+
+const mixedPhotos = computed(() => {
+  // NOT DEAD CODE. This is the slideshow for the ten non-Wolves album
+  // experiences in public/experiences/catalogue.json. `mixedPhotosToUse` only
+  // swaps in `timelineSlides` when `wolvesExperience` is true, so this branch
+  // still runs for every other album at trackIndex 0. Deleting it because the
+  // Wolves path looks like a replacement breaks those albums silently — the
+  // Wolves route keeps working, so a /wolves/ smoke test will not catch it.
+
+  // Rebuild the per-experience shuffle when the lobby launches another album.
+  void props.experienceId
+
+  const remotePeople = flickrPhotos.value.map(p => ({
+    id: p.id,
+    isLocal: false,
+    path: `https://live.staticflickr.com/${p.server}/${p.id}_${p.secret}_b.jpg`,
+    title: p.title,
+    type: 'single' as const,
+    dayName: undefined,
+    nightName: undefined,
+    kind: 'cncf' as const,
+    rawPhoto: p
+  }))
+
+  const trackIdx = props.trackIndex ?? 1
+
+  if (trackIdx > 0) {
+    return laterTrackPhotos.value
+  }
+
+  // The album's opening segment. Previously this pinned three showcase
+  // screenshots to the front and interleaved the rest on a fixed 1:2 ratio,
+  // which is a coded preference for product art over community photography.
+  // The catalogue now draws one unweighted pool — CNCF leads because it
+  // outnumbers everything else, not because anything here favours it — and
+  // relies on `orderBackCatalogueSlides` for event diversity and spacing.
+  return orderGalleryPool([
+    ...trackZeroCarryForwardPhotos.value,
+    ...backCatalogueCuratedPhotos.value,
+    ...remotePeople,
+  ])
 })
 
 const activeFlickrIndex = computed(() => {
@@ -1126,13 +1089,27 @@ function photoObjectPosition(photo: any) {
   return isWolvesExperience.value && photo?.id === ghostsInTheMistOpeningSlide.photoId ? 'center top' : 'center'
 }
 
-function shuffleArray<T>(array: T[]): T[] {
-  const copy = [...array]
-  for (let i = copy.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [copy[i], copy[j]] = [copy[j], copy[i]]
+function photoCaptionText(photo: any) {
+  return formatGalleryCaption(photo?.title)
+}
+
+function photoCaptionLabel(photo: any) {
+  return getGalleryCaptionLabel(photo ?? {})
+}
+
+/**
+ * The frozen Wolves show keeps its historical plain shuffle. Back-catalogue
+ * albums get event-diverse CNCF ordering with the curated slides merged in at
+ * uniformly random positions and spaced apart. See `back-catalogue-order.ts`.
+ */
+function orderGalleryPool(pool: any[]): any[] {
+  if (isWolvesExperience.value) {
+    return shuffleWolvesGalleryPhotos(pool)
   }
-  return copy
+  return orderBackCatalogueSlides(
+    pool.filter(photo => isCncfSlide(photo)),
+    pool.filter(photo => !isCncfSlide(photo)),
+  )
 }
 
 function snapshotLaterTrackPhotos() {
@@ -1150,15 +1127,21 @@ function snapshotLaterTrackPhotos() {
         type: 'single' as const,
         dayName: undefined,
         nightName: undefined,
+        kind: 'cncf' as const,
         rawPhoto: photo
       }
     })
   // Authored Wolves tracks use only the contributor-summit feed after the
-  // one Jorge hero opening in Track 2. Generic catalogue albums retain the
-  // carry-forward gallery behavior.
+  // one Jorge hero opening in Track 2. Generic catalogue albums mix the CNCF
+  // stream with the whole curated catalogue: portraits and lore, product
+  // showcase, mascot art, and the comic hero shots.
   const galleryCandidates = isWolvesExperience.value
     ? remotePhotos
-    : [...trackZeroCarryForwardPhotos.value, ...remotePhotos]
+    : [
+        ...trackZeroCarryForwardPhotos.value,
+        ...backCatalogueCuratedPhotos.value,
+        ...remotePhotos,
+      ]
   if (galleryCandidates.length === 0) {
     shuffledLaterTrackPhotos.value = []
     shownLaterTrackPhotoIds.clear()
@@ -1173,13 +1156,13 @@ function snapshotLaterTrackPhotos() {
     ? galleryCandidates.filter(photo => photo.id !== ghostsInTheMistOpeningSlide.photoId)
     : galleryCandidates
   if (shuffledLaterTrackPhotos.value.length === 0) {
-    shuffledLaterTrackPhotos.value = shuffleWolvesGalleryPhotos(shufflePool)
+    shuffledLaterTrackPhotos.value = orderGalleryPool(shufflePool)
   }
   else {
     const knownIds = new Set(shuffledLaterTrackPhotos.value.map(photo => photo.id))
     const newPhotos = shufflePool.filter(photo => !knownIds.has(photo.id))
     if (newPhotos.length > 0) {
-      shuffledLaterTrackPhotos.value.push(...shuffleWolvesGalleryPhotos(newPhotos))
+      shuffledLaterTrackPhotos.value.push(...orderGalleryPool(newPhotos))
     }
   }
 
@@ -1430,11 +1413,11 @@ onBeforeUnmount(() => {
                 </p>
               </template>
             </div>
-            <div v-else-if="activePhoto" class="flickr-caption font-mono">
+            <div v-else-if="activePhoto && photoCaptionText(activePhoto)" class="flickr-caption font-mono">
               <span class="caption-label text-cyan">
-                {{ activePhoto.isLocal ? 'BLUEFIN SHOWCASE //' : 'CNCF STREAM //' }}
+                {{ photoCaptionLabel(activePhoto) }}
               </span>
-              {{ activePhoto.title || 'Untitled slide' }}
+              {{ photoCaptionText(activePhoto) }}
             </div>
           </div>
 

--- a/src/data/back-catalogue-order.ts
+++ b/src/data/back-catalogue-order.ts
@@ -1,0 +1,222 @@
+/**
+ * Slide ordering for the back-catalogue album experiences (every experience in
+ * public/experiences/catalogue.json except the authored Wolves show).
+ *
+ * The pool has two halves with very different characters:
+ *
+ * - **CNCF stream** — `public/flickr-photos.json`, bulk conference photography,
+ *   refreshed weekly, ~65% of the pool.
+ * - **Curated slides** — hand-selected by the project owner for the Wolves
+ *   catalogue: portraits and lore (`wolves/people/`), product showcase
+ *   (`wolves/showcase/`), commissioned mascot art (`wolves/wolves/`) and comic
+ *   hero shots (`public/characters/`). NOT a CNCF mirror; a handful carry
+ *   CNCF-style filenames but the selection is authored.
+ *
+ * Three rules, applied as independent passes so none distorts another:
+ *
+ * 1. **Event diversity** on the CNCF half, via `buildWolvesGalleryCycle`.
+ * 2. **No category weighting.** Curated slides are merged at uniformly random
+ *    positions, so each half keeps exactly its share of the pool. CNCF dominates
+ *    because it outnumbers, never because anything here prefers it.
+ * 3. **No two curated slides back-to-back.** Applied as a repair pass, never as
+ *    a re-roll: re-drawing until a predicate holds is rejection sampling, which
+ *    biases the distribution and would quietly violate rule 2.
+ */
+
+import type { WolvesGalleryPhoto } from './wolves-gallery-cycle'
+import { buildWolvesGalleryCycle } from './wolves-gallery-cycle'
+import { shuffleWolvesGalleryPhotos } from './wolves-gallery-shuffle'
+
+/** Provenance of a slide. Drives both ordering and the on-screen credit. */
+export type BackCatalogueSlideKind = 'cncf' | 'curated' | 'showcase' | 'mascot' | 'hero'
+
+export interface BackCatalogueSlide extends WolvesGalleryPhoto {
+  kind: BackCatalogueSlideKind
+}
+
+export function isCncfSlide(slide: { kind?: BackCatalogueSlideKind }): boolean {
+  return slide.kind === 'cncf'
+}
+
+/**
+ * Provenance of a local wallpaper, derived from its path and title.
+ *
+ * Locality cannot answer this. `wolves/people/` is the owner's hand-picked
+ * selection, but 136 of its 213 files were pulled from CNCF albums and kept
+ * their source-prefixed filenames (`flickr-`, `cncf-`, `kubecon-`) or their
+ * `KC+CNC_...` export titles. Crediting those to Bluefin because they happen to
+ * sit on our disk misattributes someone else's photography, so every signal is
+ * checked explicitly rather than inferred from the directory.
+ */
+export function classifyCuratedSlide(id: string, title = ''): BackCatalogueSlideKind {
+  if (id.includes('/showcase/')) {
+    return 'showcase'
+  }
+  if (id.startsWith('wolves/wolves/') || id.includes('/wolves/wolves/') || id.startsWith('bluefin-')) {
+    return 'mascot'
+  }
+  const basename = id.split('/').pop() ?? ''
+  if (/^(?:flickr|cncf|kubecon)-\d+/i.test(basename) || title.startsWith('KC+CNC')) {
+    return 'cncf'
+  }
+  return 'curated'
+}
+
+/**
+ * Choose `count` distinct slot indices from `[0, slots)`, uniformly at random.
+ * Partial Fisher-Yates over a lazily-materialised index map, so picking a few
+ * hundred slots out of a few hundred stays linear in `count`.
+ */
+export function pickDistinctSlots(slots: number, count: number, random: () => number = Math.random): number[] {
+  const taken = new Map<number, number>()
+  const chosen: number[] = []
+
+  for (let round = 0; round < Math.min(count, slots); round++) {
+    const limit = slots - round
+    const pick = Math.floor(random() * limit)
+    const value = taken.get(pick) ?? pick
+    const tail = limit - 1
+    taken.set(pick, taken.get(tail) ?? tail)
+    chosen.push(value)
+  }
+
+  return chosen.sort((left, right) => left - right)
+}
+
+/**
+ * Place `curated` into the gaps between `cncf` slides.
+ *
+ * There are `cncf.length + 1` gaps (before each slide, plus one after the
+ * last). Choosing distinct gaps uniformly at random gives both properties the
+ * owner asked for at once:
+ *
+ * - **no weighting** — every gap is equally likely, so curated slides are
+ *   spread uniformly across the run rather than pinned to the front;
+ * - **no two curated back-to-back** — distinct gaps means at least one CNCF
+ *   slide always sits between them.
+ *
+ * This is why the ordering is not "shuffle then fix up". A repair pass that
+ * swaps offenders forward cannot separate slides that clump at the very tail,
+ * and re-drawing until the predicate holds is rejection sampling, which biases
+ * the distribution and would break the first property to satisfy the second.
+ *
+ * When there are more curated slides than gaps, separation is impossible; the
+ * remainder is merged in and the sequence degrades gracefully.
+ */
+export function placeCuratedInGaps<T>(
+  cncf: readonly T[],
+  curated: readonly T[],
+  random: () => number = Math.random,
+): T[] {
+  const gapCount = cncf.length + 1
+  if (curated.length > gapCount) {
+    return mergeAtRandomPositions(cncf, curated, random)
+  }
+
+  const gaps = pickDistinctSlots(gapCount, curated.length, random)
+  const placed: T[] = []
+  let curatedIndex = 0
+
+  for (let index = 0; index <= cncf.length; index++) {
+    while (curatedIndex < gaps.length && gaps[curatedIndex] === index) {
+      placed.push(curated[curatedIndex++])
+    }
+    if (index < cncf.length) {
+      placed.push(cncf[index])
+    }
+  }
+
+  return placed
+}
+
+/**
+ * Interleave `extras` into `base` at uniformly random positions while
+ * preserving the internal order of both. Equivalent to choosing which
+ * `extras.length` of the `base.length + extras.length` output slots belong to
+ * extras, uniformly at random — so neither side is favoured at any position.
+ */
+export function mergeAtRandomPositions<T>(
+  base: readonly T[],
+  extras: readonly T[],
+  random: () => number = Math.random,
+): T[] {
+  const merged: T[] = []
+  let baseIndex = 0
+  let extraIndex = 0
+
+  while (baseIndex < base.length || extraIndex < extras.length) {
+    const baseRemaining = base.length - baseIndex
+    const extraRemaining = extras.length - extraIndex
+    const takeExtra = random() * (baseRemaining + extraRemaining) < extraRemaining
+
+    if (extraRemaining > 0 && (baseRemaining === 0 || takeExtra)) {
+      merged.push(extras[extraIndex++])
+    }
+    else {
+      merged.push(base[baseIndex++])
+    }
+  }
+
+  return merged
+}
+
+/**
+ * Safety net for the degenerate case where `placeCuratedInGaps` had to fall
+ * back to a plain merge: swap any curated slide that landed beside another with
+ * the nearest later CNCF slide. Order-preserving elsewhere, single walk.
+ */
+export function spaceOutCuratedSlides<T extends { kind?: BackCatalogueSlideKind }>(
+  slides: readonly T[],
+): T[] {
+  const spaced = [...slides]
+
+  for (let index = 1; index < spaced.length; index++) {
+    if (isCncfSlide(spaced[index]) || isCncfSlide(spaced[index - 1])) {
+      continue
+    }
+
+    const swapIndex = spaced.findIndex((slide, candidate) => candidate > index && isCncfSlide(slide))
+    if (swapIndex === -1) {
+      break
+    }
+
+    ;[spaced[index], spaced[swapIndex]] = [spaced[swapIndex], spaced[index]]
+  }
+
+  return spaced
+}
+
+/**
+ * Shuffle the curated slides before they are placed.
+ *
+ * `placeCuratedInGaps` fills gaps in ascending order, so the curated list's own
+ * order maps straight onto screen position. Passing the pool in its natural
+ * order — portraits, then showcase, then mascot art, then hero shots — put the
+ * first dinosaur at slide 745 of 808: a category preference created purely by
+ * concatenation order, which is exactly what "no preference" rules out.
+ *
+ * Hero shots are merged back in afterwards rather than shuffled with everything
+ * else, because their authored sequence in `wolves-comic-hero-shots.ts` spaces
+ * characters and species apart. That ordering is information a shuffle would
+ * destroy and cannot reconstruct.
+ */
+export function orderCuratedSlides<T extends BackCatalogueSlide>(
+  curated: readonly T[],
+  random: () => number = Math.random,
+): T[] {
+  const heroes = curated.filter(slide => slide.kind === 'hero')
+  const others = shuffleWolvesGalleryPhotos(curated.filter(slide => slide.kind !== 'hero'), random)
+  return mergeAtRandomPositions(others, heroes, random)
+}
+
+/**
+ * Full ordering for one album launch.
+ */
+export function orderBackCatalogueSlides<T extends BackCatalogueSlide>(
+  cncf: readonly T[],
+  curated: readonly T[],
+  random: () => number = Math.random,
+): T[] {
+  const diversified = buildWolvesGalleryCycle(cncf, random)
+  return spaceOutCuratedSlides(placeCuratedInGaps(diversified, orderCuratedSlides(curated, random), random))
+}

--- a/src/data/gallery-captions.ts
+++ b/src/data/gallery-captions.ts
@@ -1,0 +1,275 @@
+/**
+ * Caption text and provenance credit for gallery slides.
+ *
+ * Two sources feed the gallery and neither ships display-ready captions:
+ *
+ * - The CNCF stream carries photographer export filenames
+ *   (`KC+CNC_EU_240319_KCS_GroupPhoto_MN_001`).
+ * - 43 curated wallpapers are missing from the title dictionary in
+ *   scripts/generate-wallpapers.js, so `formatTitle` title-cases their basename
+ *   instead (`32433026808 C8529aca08 K`).
+ *
+ * Both were rendered verbatim, at size, to a projected audience.
+ *
+ * This is a *derivation*, never an invention. The event, region, session and
+ * date are literally encoded in the filename, so reading them back out is
+ * faithful. A bare Flickr id encodes nothing, so it yields no caption at all
+ * rather than a guess — a wrong caption on a cinema screen is worse than none.
+ * Anything unrecognised is passed through untouched, because authored titles
+ * ("Bluefin Advisor Chris Aniszczyk") are already correct.
+ */
+
+import type { BackCatalogueSlideKind } from './back-catalogue-order'
+
+const REGIONS: Record<string, string> = {
+  NA: 'KubeCon NA',
+  EU: 'KubeCon EU',
+  CN: 'KubeCon China',
+  JP: 'KubeCon Japan',
+  IN: 'KubeCon India',
+}
+
+const SESSIONS: Record<string, string> = {
+  KCS: 'Contributor Summit',
+  CS: 'Contributor Summit',
+}
+
+const MONTHS = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+]
+
+/** Filename stems that name a source or a device rather than a subject. */
+const SOURCE_PREFIXES = new Set([
+  'cncf',
+  'kubecon',
+  'flickr',
+  'img',
+  'dsc',
+  'photo',
+  'pxl',
+  'temp',
+  'image',
+  'screenshot',
+])
+
+/** A hex blob from a uuid or a Flickr secret. */
+function isHexBlob(token: string): boolean {
+  return /^[0-9a-f]{6,}$/i.test(token) && /\d/.test(token)
+}
+
+/**
+ * A token that could plausibly describe a subject: three or more consecutive
+ * letters that are not a device name or a hex blob.
+ */
+function isMeaningfulToken(token: string): boolean {
+  return /[A-Z]{3,}/i.test(token)
+    && !SOURCE_PREFIXES.has(token.toLowerCase())
+    && !isHexBlob(token)
+}
+
+/**
+ * A title that identifies a file rather than describing a photograph: a bare
+ * Flickr id (`53322730377 Ca5b65a035 K`), a source-prefixed id
+ * (`Cncf 54927603143`), a camera or phone filename (`0R0A9083`, `DSC04181`,
+ * `PXL 20240720 181225593`), or a scratch export
+ * (`Temp Image 20230915 011731 Aeb0b8f4 ...`).
+ *
+ * None of these encodes anything a caption could honestly say. A few carry a
+ * timestamp, but "July 2024" alone describes no subject — on a cinema screen
+ * that is noise wearing a caption's clothes. All of them render no caption.
+ *
+ * The meaningless-token test only fires on titles that also carry a long number
+ * or hex blob. Without that guard it swallows short authored titles whose only
+ * word happens to be a generic noun, such as "Photo A".
+ */
+function isOpaqueIdentifier(title: string): boolean {
+  const tokens = title.split(/[\s_]+/).filter(Boolean)
+  if (tokens.length === 0) {
+    return false
+  }
+  if (/^\d{9,}$/.test(tokens[0])) {
+    return true
+  }
+  const looksLikeAFilename = tokens.some(token => /^\d{6,}$/.test(token) || isHexBlob(token))
+  if (looksLikeAFilename && !tokens.some(isMeaningfulToken)) {
+    return true
+  }
+  return tokens.length === 1
+    && !/[a-z]/.test(tokens[0])
+    && (tokens[0].match(/\d/g)?.length ?? 0) >= 4
+}
+
+function formatSixDigitDate(token: string): string | undefined {
+  if (!/^\d{6}$/.test(token)) {
+    return undefined
+  }
+  const month = Number(token.slice(2, 4))
+  if (month < 1 || month > 12) {
+    return undefined
+  }
+  return `${MONTHS[month - 1]} 20${token.slice(0, 2)}`
+}
+
+function formatEightDigitDate(token: string): string | undefined {
+  if (!/^20\d{6}$/.test(token)) {
+    return undefined
+  }
+  const month = Number(token.slice(4, 6))
+  if (month < 1 || month > 12) {
+    return undefined
+  }
+  return `${MONTHS[month - 1]} ${token.slice(0, 4)}`
+}
+
+/**
+ * `MaintainerSummitBreakoutsB206` -> `Maintainer Summit Breakouts B206`.
+ *
+ * Splits only before an initial-capital word or a capital-plus-digit room code,
+ * never inside an all-caps run: the CNCF feed contains wordplay like
+ * `KuberTENes` that a naive boundary split would break into `Kuber TENes`.
+ */
+function humaniseSession(token: string): string {
+  const mapped = SESSIONS[token]
+  if (mapped) {
+    return mapped
+  }
+  return token
+    .split('-')
+    .map(part => SESSIONS[part] ?? part
+      .replace(/([a-z\d])([A-Z][a-z])/g, '$1 $2')
+      .replace(/([a-z])([A-Z]\d)/g, '$1 $2')
+      .replace(/\s+/g, ' ')
+      .trim())
+    .filter(Boolean)
+    .join(' · ')
+}
+
+/** Photographer initials (`MN`, `ML-MN`) and trailing frame counters. */
+function isPhotographerOrCounter(token: string): boolean {
+  return /^\d+$/.test(token) || /^[A-Z]{2,3}(?:-[A-Z]{2,3})*$/.test(token)
+}
+
+function formatIsoDate(token: string): string | undefined {
+  const match = /^(\d{4})-(\d{2})-\d{2}$/.exec(token)
+  if (!match) {
+    return undefined
+  }
+  const month = Number(match[2])
+  if (month < 1 || month > 12) {
+    return undefined
+  }
+  return `${MONTHS[month - 1]} ${match[1]}`
+}
+
+function formatUnderscoreExportTitle(title: string, leadingDate: string): string {
+  const parts: string[] = []
+
+  for (const token of title.split('_').slice(1)) {
+    if (isPhotographerOrCounter(token)) {
+      continue
+    }
+    parts.push(humaniseSession(token))
+  }
+
+  parts.push(leadingDate)
+  return parts.filter(Boolean).join(' · ')
+}
+
+function formatCncfExportTitle(title: string): string {
+  const tokens = title.split('_').filter(Boolean)
+  const parts: string[] = []
+  let date: string | undefined
+
+  for (const token of tokens.slice(1)) {
+    const sixDigit = formatSixDigitDate(token)
+    if (sixDigit) {
+      date = sixDigit
+      continue
+    }
+    if (REGIONS[token]) {
+      parts.push(REGIONS[token])
+      continue
+    }
+    // Session abbreviations are checked before the photographer/counter filter:
+    // `KCS` is indistinguishable from a photographer's initials by shape alone.
+    if (SESSIONS[token]) {
+      parts.push(SESSIONS[token])
+      continue
+    }
+    if (isPhotographerOrCounter(token)) {
+      continue
+    }
+    parts.push(humaniseSession(token))
+  }
+
+  if (parts.length === 0) {
+    parts.push('KubeCon + CloudNativeCon')
+  }
+  if (date) {
+    parts.push(date)
+  }
+  return parts.join(' · ')
+}
+
+/**
+ * Display caption for a slide title. Returns an empty string when the title
+ * carries no meaning, in which case the caption is not rendered at all.
+ */
+export function formatGalleryCaption(title: string | undefined): string {
+  const trimmed = (title ?? '').trim()
+  if (trimmed.length === 0 || isOpaqueIdentifier(trimmed)) {
+    return ''
+  }
+
+  if (trimmed.startsWith('KC+CNC')) {
+    return formatCncfExportTitle(trimmed)
+  }
+
+  // A second photographer grammar in the same feed: `2024-06-06_OHSNAP_...`.
+  const isoDate = formatIsoDate(trimmed.split('_')[0])
+  if (isoDate && trimmed.includes('_')) {
+    return formatUnderscoreExportTitle(trimmed, isoDate)
+  }
+
+  const tokens = trimmed.split(/\s+/)
+  const leadingDate = formatEightDigitDate(tokens[0])
+  if (leadingDate && tokens.length > 1) {
+    const rest = tokens.slice(1).filter(token => !/^\d+$/.test(token))
+    return [...rest.map(token => token.toUpperCase() === token ? token : token), leadingDate]
+      .filter(Boolean)
+      .join(' · ')
+  }
+
+  return trimmed
+}
+
+const KIND_LABELS: Record<BackCatalogueSlideKind, string> = {
+  cncf: 'CNCF STREAM //',
+  curated: 'BLUEFIN SHOWCASE //',
+  showcase: 'BLUEFIN SHOWCASE //',
+  mascot: 'BLUEFIN ORIGINAL //',
+  hero: 'BLUEFIN ORIGINAL //',
+}
+
+/**
+ * Provenance credit. Keyed on `kind`, never on whether the file happens to sit
+ * on our disk: 38 CNCF conference photos are mirrored under `wolves/people/`
+ * and crediting those to Bluefin misattributes someone else's photography.
+ */
+export function getGalleryCaptionLabel(slide: { kind?: BackCatalogueSlideKind, isLocal?: boolean }): string {
+  if (slide.kind) {
+    return KIND_LABELS[slide.kind]
+  }
+  return slide.isLocal ? 'BLUEFIN SHOWCASE //' : 'CNCF STREAM //'
+}

--- a/src/data/wolves-gallery-cycle.ts
+++ b/src/data/wolves-gallery-cycle.ts
@@ -1,0 +1,124 @@
+/**
+ * Event-diversity ordering for CNCF gallery photos.
+ *
+ * Photos arrive from `public/flickr-photos.json` grouped by shoot: a single
+ * breakout room can contribute dozens of frames whose titles differ only by a
+ * trailing counter. A plain shuffle happily deals eight of them in a row, which
+ * reads to an audience as "the slideshow is stuck".
+ *
+ * `buildWolvesGalleryCycle` groups by event, shuffles inside each group, then
+ * deals one photo per group per round. Consecutive slides therefore come from
+ * different events for as long as the pool allows.
+ *
+ * HISTORY — do not replace this with a shuffle again. This module originally
+ * shipped in 33a63532 ("diversify post-hero gallery events") and was deleted in
+ * 255f61fb ("retime intro and shuffle galleries"), which swapped the call site
+ * to `shuffleWolvesGalleryPhotos` — a bare Fisher-Yates whose name implies an
+ * event-awareness its body does not have. The guarantee above was silently lost
+ * and stayed lost. `src/tests/wolvesGalleryCycle.test.ts` now pins it.
+ */
+
+export interface WolvesGalleryPhoto {
+  id: string
+  title: string
+}
+
+/**
+ * CNCF export filenames follow `KC+CNC_<region>_<date>_<session>_<photographer>_<n>`,
+ * so the first three underscore-separated segments identify the shoot
+ * (`KC+CNC_EU_240319`). This is the runtime sibling of `computeTitleFamily` in
+ * scripts/update-flickr-photos.js, which caps the same grouping at ingest.
+ *
+ * Curated slides carry authored prose titles with no underscore structure
+ * ("Bluefin Advisor Chris Aniszczyk"), so they group by the whole title. A
+ * distinct portrait forms its own single-item group, while several art pieces
+ * sharing one credit line group together and get spread apart — both correct.
+ * The photo id is the last resort, for a slide with no title at all.
+ */
+export function getWolvesGalleryEventKey(photo: WolvesGalleryPhoto): string {
+  const eventKey = photo.title.split('_').slice(0, 3).filter(Boolean).join('_')
+  return eventKey || photo.id
+}
+
+function shuffle<T>(items: readonly T[], random: () => number): T[] {
+  const result = [...items]
+
+  for (let index = result.length - 1; index > 0; index--) {
+    const swapIndex = Math.floor(random() * (index + 1))
+    ;[result[index], result[swapIndex]] = [result[swapIndex], result[index]]
+  }
+
+  return result
+}
+
+/**
+ * Spread every event evenly across the whole run.
+ *
+ * Each event's photos are shuffled, then assigned a position inside their own
+ * stratum of the output: photo `i` of an `n`-photo event lands somewhere in
+ * `[i/n, (i+1)/n)`. Sorting by that position leaves consecutive photos of the
+ * same event roughly `total/n` slides apart, whatever `n` is.
+ *
+ * This replaced a strict round-robin deal, which is only well-behaved when the
+ * events are similar sizes. The live feed is not: hundreds of photos carry
+ * unstructured titles and so form single-photo events, and a round-robin deals
+ * every bucket once per round — which put all of them in round one and left the
+ * first ~200 slides looking like a dump of untitled frames.
+ */
+export function buildWolvesGalleryCycle<T extends WolvesGalleryPhoto>(
+  photos: readonly T[],
+  random: () => number = Math.random,
+): T[] {
+  const eventGroups = new Map<string, T[]>()
+
+  for (const photo of photos) {
+    const eventKey = getWolvesGalleryEventKey(photo)
+    eventGroups.set(eventKey, [...(eventGroups.get(eventKey) ?? []), photo])
+  }
+
+  const placed: { photo: T, position: number }[] = []
+
+  for (const group of eventGroups.values()) {
+    const shuffled = shuffle(group, random)
+    for (const [index, photo] of shuffled.entries()) {
+      placed.push({ photo, position: (index + random()) / shuffled.length })
+    }
+  }
+
+  return separateAdjacentEvents(
+    placed
+      .sort((left, right) => left.position - right.position)
+      .map(entry => entry.photo),
+  )
+}
+
+/**
+ * Restore the hard guarantee the old round-robin gave: no two consecutive
+ * photos from the same event.
+ *
+ * Stratified placement separates events well on average but not absolutely —
+ * two photos of one event can still meet across a stratum boundary. A single
+ * forward repair pass swaps the offender with the nearest later photo from a
+ * different event. Order-preserving elsewhere, and a no-op once the pool holds
+ * too few distinct events to separate.
+ */
+export function separateAdjacentEvents<T extends WolvesGalleryPhoto>(photos: readonly T[]): T[] {
+  const separated = [...photos]
+
+  for (let index = 1; index < separated.length; index++) {
+    const previousKey = getWolvesGalleryEventKey(separated[index - 1])
+    if (getWolvesGalleryEventKey(separated[index]) !== previousKey) {
+      continue
+    }
+
+    const swapIndex = separated.findIndex((photo, candidate) =>
+      candidate > index && getWolvesGalleryEventKey(photo) !== previousKey)
+    if (swapIndex === -1) {
+      break
+    }
+
+    ;[separated[index], separated[swapIndex]] = [separated[swapIndex], separated[index]]
+  }
+
+  return separated
+}

--- a/src/tests/backCatalogueOrder.test.ts
+++ b/src/tests/backCatalogueOrder.test.ts
@@ -1,0 +1,169 @@
+import type { BackCatalogueSlide, BackCatalogueSlideKind } from '@/data/back-catalogue-order'
+import { describe, expect, it } from 'vitest'
+import {
+  classifyCuratedSlide,
+  isCncfSlide,
+  mergeAtRandomPositions,
+  orderBackCatalogueSlides,
+  spaceOutCuratedSlides,
+} from '@/data/back-catalogue-order'
+
+/**
+ * Deterministic PRNG. These are distribution assertions, so seeding them is the
+ * difference between a regression guard and an intermittently red CI run.
+ */
+function seededRandom(seed = 1) {
+  let state = seed
+  return () => {
+    state = (state * 1664525 + 1013904223) % 4294967296
+    return state / 4294967296
+  }
+}
+
+function slide(kind: BackCatalogueSlideKind, index: number, event = 'KC+CNC_EU_240319'): BackCatalogueSlide {
+  return {
+    id: `${kind}-${index}`,
+    title: kind === 'cncf' ? `${event}_Breakouts_MN_${index}` : `Curated slide ${index}`,
+    kind,
+  }
+}
+
+function buildPool() {
+  const cncf = Array.from({ length: 120 }, (_, index) =>
+    slide('cncf', index, `KC+CNC_EU_24031${index % 5}`))
+  const curated = [
+    ...Array.from({ length: 30 }, (_, index) => slide('curated', index)),
+    ...Array.from({ length: 8 }, (_, index) => slide('showcase', index)),
+    ...Array.from({ length: 4 }, (_, index) => slide('mascot', index)),
+    ...Array.from({ length: 6 }, (_, index) => slide('hero', index)),
+  ]
+  return { cncf, curated }
+}
+
+describe('classifyCuratedSlide', () => {
+  it('credits locally mirrored CNCF exports to the CNCF stream', () => {
+    expect(classifyCuratedSlide('wolves/people/flickr-53608872377.webp', 'KC+CNC_EU_240319_KCS_Breakouts_MN_024'))
+      .toBe('cncf')
+  })
+
+  it('credits an authored portrait to the curated catalogue', () => {
+    expect(classifyCuratedSlide('wolves/people/Bluefin Advisor Chris Aniszczyk.webp', 'Bluefin Advisor Chris Aniszczyk'))
+      .toBe('curated')
+  })
+
+  it('separates product showcase from commissioned mascot art', () => {
+    expect(classifyCuratedSlide('wolves/showcase/desktop.webp', 'Desktop')).toBe('showcase')
+    expect(classifyCuratedSlide('wolves/wolves/bluefin-eyes.webp', 'Eyes')).toBe('mascot')
+  })
+
+  it('classifies a day/night mascot pair by its synthetic name', () => {
+    expect(classifyCuratedSlide('bluefin-duality', 'Duality (Day & Night)')).toBe('mascot')
+  })
+})
+
+describe('mergeAtRandomPositions', () => {
+  it('preserves the internal order of both inputs', () => {
+    const merged = mergeAtRandomPositions(['a', 'b', 'c'], ['x', 'y'], () => 0.5)
+
+    expect(merged.filter(item => 'abc'.includes(item))).toEqual(['a', 'b', 'c'])
+    expect(merged.filter(item => 'xy'.includes(item))).toEqual(['x', 'y'])
+    expect(merged).toHaveLength(5)
+  })
+
+  it('keeps every item when one side is empty', () => {
+    expect(mergeAtRandomPositions(['a', 'b'], [], () => 0.5)).toEqual(['a', 'b'])
+    expect(mergeAtRandomPositions([], ['x'], () => 0.5)).toEqual(['x'])
+  })
+})
+
+describe('spaceOutCuratedSlides', () => {
+  it('separates curated slides that land back-to-back', () => {
+    const spaced = spaceOutCuratedSlides([
+      slide('curated', 0),
+      slide('hero', 0),
+      slide('cncf', 0),
+      slide('cncf', 1),
+      slide('cncf', 2),
+    ])
+
+    for (let index = 1; index < spaced.length; index++) {
+      expect(isCncfSlide(spaced[index]) || isCncfSlide(spaced[index - 1])).toBe(true)
+    }
+  })
+
+  it('leaves the sequence intact when there are too few CNCF slides to separate', () => {
+    const input = [slide('curated', 0), slide('showcase', 0), slide('hero', 0)]
+    expect(spaceOutCuratedSlides(input).map(item => item.id)).toEqual(input.map(item => item.id))
+  })
+})
+
+describe('orderBackCatalogueSlides', () => {
+  it('never places two non-CNCF slides back-to-back', () => {
+    const { cncf, curated } = buildPool()
+
+    const random = seededRandom(5)
+    for (let run = 0; run < 50; run++) {
+      const ordered = orderBackCatalogueSlides(cncf, curated, random)
+      for (let index = 1; index < ordered.length; index++) {
+        expect(isCncfSlide(ordered[index]) || isCncfSlide(ordered[index - 1])).toBe(true)
+      }
+    }
+  })
+
+  it('carries every slide through exactly once', () => {
+    const { cncf, curated } = buildPool()
+    const ordered = orderBackCatalogueSlides(cncf, curated, seededRandom(19))
+
+    expect(ordered).toHaveLength(cncf.length + curated.length)
+    expect(new Set(ordered.map(item => item.id)).size).toBe(cncf.length + curated.length)
+  })
+
+  it('includes every provenance kind', () => {
+    const { cncf, curated } = buildPool()
+    const kinds = new Set(orderBackCatalogueSlides(cncf, curated, seededRandom(23)).map(item => item.kind))
+
+    expect(kinds).toEqual(new Set(['cncf', 'curated', 'showcase', 'mascot', 'hero']))
+  })
+
+  // The owner's instruction was "do not give a preference" — CNCF should lead
+  // because it outnumbers the curated set, not because the ordering favours it.
+  // A pinned opener (the old behaviour reserved three showcase slides for the
+  // front) would drive the curated share of first slides to 1.0.
+  it('does not reserve the opening slide for any category', () => {
+    const { cncf, curated } = buildPool()
+    const runs = 200
+    const random = seededRandom(11)
+    let cncfFirst = 0
+
+    for (let run = 0; run < runs; run++) {
+      if (isCncfSlide(orderBackCatalogueSlides(cncf, curated, random)[0])) {
+        cncfFirst++
+      }
+    }
+
+    const expectedShare = cncf.length / (cncf.length + curated.length)
+    expect(cncfFirst / runs).toBeGreaterThan(expectedShare - 0.2)
+    expect(cncfFirst / runs).toBeLessThan(expectedShare + 0.2)
+  })
+
+  it('keeps consecutive CNCF slides on different events', () => {
+    const { cncf, curated } = buildPool()
+    const ordered = orderBackCatalogueSlides(cncf, curated, seededRandom(13))
+    const cncfOnly = ordered.filter(isCncfSlide)
+
+    const adjacentSameEvent = cncfOnly.filter((item, index) =>
+      index > 0 && item.title.split('_')[2] === cncfOnly[index - 1].title.split('_')[2]).length
+
+    expect(adjacentSameEvent).toBeLessThan(cncfOnly.length * 0.1)
+  })
+
+  it('preserves the authored hero rotation order', () => {
+    const cncf = Array.from({ length: 40 }, (_, index) => slide('cncf', index, `KC+CNC_EU_24031${index % 4}`))
+    const heroes = Array.from({ length: 6 }, (_, index) => slide('hero', index))
+
+    const ordered = orderBackCatalogueSlides(cncf, heroes, seededRandom(17))
+    const heroIds = ordered.filter(item => item.kind === 'hero').map(item => item.id)
+
+    expect(heroIds).toEqual(heroes.map(item => item.id))
+  })
+})

--- a/src/tests/galleryCaptions.test.ts
+++ b/src/tests/galleryCaptions.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest'
+import { formatGalleryCaption, getGalleryCaptionLabel } from '@/data/gallery-captions'
+
+describe('formatGalleryCaption', () => {
+  it('reads the event, session and date out of a CNCF export filename', () => {
+    expect(formatGalleryCaption('KC+CNC_EU_240319_KCS_GroupPhoto_MN_001'))
+      .toBe('KubeCon EU · Contributor Summit · Group Photo · March 2024')
+  })
+
+  it('splits camel-cased session names', () => {
+    expect(formatGalleryCaption('KC+CNC_NA_251109_MaintainerSummitGroupPhoto_ML-MN_008'))
+      .toBe('KubeCon NA · Maintainer Summit Group Photo · November 2025')
+  })
+
+  it('keeps a city token that is not a region or a counter', () => {
+    expect(formatGalleryCaption('KC+CNC_NA_Detroit_221027_SessionTracks-SIGS-MaintainerTracks_121'))
+      .toBe('KubeCon NA · Detroit · Session Tracks · SIGS · Maintainer Tracks · October 2022')
+  })
+
+  // A bare Flickr id encodes nothing. Rendering it, or guessing at it, are both
+  // worse than showing no caption.
+  it('suppresses a title-cased Flickr identifier', () => {
+    expect(formatGalleryCaption('32433026808 C8529aca08 K')).toBe('')
+    expect(formatGalleryCaption('53322730377 Ca5b65a035 K')).toBe('')
+  })
+
+  it('suppresses an empty or missing title', () => {
+    expect(formatGalleryCaption('')).toBe('')
+    expect(formatGalleryCaption(undefined)).toBe('')
+  })
+
+  it('reads a leading ISO-style date out of a generated basename', () => {
+    expect(formatGalleryCaption('20260709 Osc26 Distrobox 1')).toBe('Osc26 · Distrobox · July 2026')
+  })
+
+  it('passes authored titles through untouched', () => {
+    expect(formatGalleryCaption('Bluefin Advisor Chris Aniszczyk')).toBe('Bluefin Advisor Chris Aniszczyk')
+    expect(formatGalleryCaption('Duality (Day & Night) by Dr. Natalia Jagielska and Delphic Melody (M. Gopal)'))
+      .toBe('Duality (Day & Night) by Dr. Natalia Jagielska and Delphic Melody (M. Gopal)')
+  })
+
+  it('never returns a raw underscore-delimited export name', () => {
+    const captions = [
+      'KC+CNC_EU_260322_MaintainerSummitEveningReception_024_MN',
+      'KC+CNC_NA_251109_MaintainerSummitBreakoutsB206_ML-MN_029',
+    ].map(formatGalleryCaption)
+
+    for (const caption of captions) {
+      expect(caption).not.toContain('_')
+      expect(caption.length).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe('getGalleryCaptionLabel', () => {
+  it('credits the CNCF stream for CNCF-sourced slides', () => {
+    expect(getGalleryCaptionLabel({ kind: 'cncf' })).toBe('CNCF STREAM //')
+  })
+
+  // 38 CNCF conference photos are mirrored under wolves/people/. Keying the
+  // credit on file locality attributed those to Bluefin.
+  it('credits the CNCF stream even when the file is stored locally', () => {
+    expect(getGalleryCaptionLabel({ kind: 'cncf', isLocal: true })).toBe('CNCF STREAM //')
+  })
+
+  it('separates commissioned art from product showcase', () => {
+    expect(getGalleryCaptionLabel({ kind: 'showcase' })).toBe('BLUEFIN SHOWCASE //')
+    expect(getGalleryCaptionLabel({ kind: 'curated' })).toBe('BLUEFIN SHOWCASE //')
+    expect(getGalleryCaptionLabel({ kind: 'mascot' })).toBe('BLUEFIN ORIGINAL //')
+    expect(getGalleryCaptionLabel({ kind: 'hero' })).toBe('BLUEFIN ORIGINAL //')
+  })
+
+  it('falls back to locality for slides with no provenance, preserving Wolves behaviour', () => {
+    expect(getGalleryCaptionLabel({ isLocal: true })).toBe('BLUEFIN SHOWCASE //')
+    expect(getGalleryCaptionLabel({ isLocal: false })).toBe('CNCF STREAM //')
+  })
+})
+
+describe('formatGalleryCaption against the shipped feeds', () => {
+  it('handles the second photographer grammar in the CNCF feed', () => {
+    expect(formatGalleryCaption('2024-06-06_OHSNAP_KuberTENes_BirthdayBash_HL_0038'))
+      .toBe('OHSNAP · KuberTENes · Birthday Bash · June 2024')
+  })
+
+  it('does not split an all-caps run inside a word', () => {
+    expect(formatGalleryCaption('KC+CNC_NA_251109_KuberTENes_MN_001'))
+      .toBe('KubeCon NA · KuberTENes · November 2025')
+  })
+
+  it('splits a trailing room code off a session name', () => {
+    expect(formatGalleryCaption('KC+CNC_NA_251109_MaintainerSummitBreakoutsB206_ML-MN_029'))
+      .toBe('KubeCon NA · Maintainer Summit Breakouts B206 · November 2025')
+  })
+})
+
+describe('formatGalleryCaption suppresses file identifiers', () => {
+  it('suppresses a phone camera filename even though it encodes a date', () => {
+    expect(formatGalleryCaption('PXL 20240720 181225593')).toBe('')
+  })
+
+  it('suppresses a scratch export with a uuid', () => {
+    expect(formatGalleryCaption('Temp Image 20230915 011731 Aeb0b8f4 E66a 455b Ab39 3122768e6825')).toBe('')
+  })
+
+  it('suppresses source-prefixed Flickr ids', () => {
+    expect(formatGalleryCaption('Cncf 54927603143')).toBe('')
+    expect(formatGalleryCaption('Kubecon 54927705495')).toBe('')
+  })
+
+  it('suppresses in-camera filenames', () => {
+    expect(formatGalleryCaption('0R0A9083')).toBe('')
+    expect(formatGalleryCaption('DSC04181')).toBe('')
+    expect(formatGalleryCaption('CRJ07242')).toBe('')
+  })
+
+  it('keeps a short authored title that happens to contain a number', () => {
+    expect(formatGalleryCaption('Summit 03')).toBe('Summit 03')
+    expect(formatGalleryCaption('Erin Boyd')).toBe('Erin Boyd')
+  })
+})

--- a/src/tests/wolvesComicReader.test.ts
+++ b/src/tests/wolvesComicReader.test.ts
@@ -662,6 +662,35 @@ describe('wolvesComicReader', () => {
     expect(wrapper.find('.flickr-caption').exists()).toBe(false)
   })
 
+  // The caption derivation withholds a caption for titles that encode nothing,
+  // and 25 photos in the Wolves later-track rotation carry camera-roll names.
+  // Applying it to the frozen show would take the CNCF credit off screen with
+  // them, so the derivation belongs to the back catalogue only.
+  it('keeps raw photo titles and the CNCF credit in the frozen Wolves show', async () => {
+    const cameraRollPhotos = [
+      { id: 'photo-a', server: '1', secret: 'a', title: 'A7V06139' },
+      { id: 'photo-b', server: '2', secret: 'b', title: 'CRJ07242' },
+    ]
+    mockGalleryData([coverTrack, {
+      id: 'later-track-one',
+      title: 'Later Track One',
+      artist: 'Artist 1',
+      artwork: 'wolves-artwork/later-track-one.jpg',
+      youtubeVideoId: '1',
+    }], new Response(JSON.stringify(cameraRollPhotos)))
+
+    const wrapper = mount(WolvesComicReader, {
+      props: { trackIndex: 1, trackId: '1', playlistCurrentTime: 1 },
+    })
+    await flushPromises()
+    await nextTick()
+
+    const caption = wrapper.find('.flickr-caption')
+    expect(caption.exists()).toBe(true)
+    expect(caption.text()).toContain('CNCF STREAM //')
+    expect(caption.text()).toMatch(/A7V06139|CRJ07242/)
+  })
+
   it('switches an active later track to Flickr when the cache finishes loading', async () => {
     // The later-track gallery shuffles with Math.random; pin it so the
     // per-track photo assertions below are deterministic.

--- a/src/tests/wolvesGalleryCycle.test.ts
+++ b/src/tests/wolvesGalleryCycle.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest'
+import { buildWolvesGalleryCycle, getWolvesGalleryEventKey, separateAdjacentEvents } from '@/data/wolves-gallery-cycle'
+
+/** Deterministic PRNG: the spread relies on jitter, so a constant breaks it. */
+function seededRandom(seed = 1) {
+  let state = seed
+  return () => {
+    state = (state * 1664525 + 1013904223) % 4294967296
+    return state / 4294967296
+  }
+}
+
+function cncfPhoto(event: string, index: number) {
+  return { id: `${event}-${index}`, title: `${event}_Breakouts_MN_${String(index).padStart(3, '0')}` }
+}
+
+describe('getWolvesGalleryEventKey', () => {
+  it('identifies a shoot from the first three filename segments', () => {
+    expect(getWolvesGalleryEventKey({
+      id: '1',
+      title: 'KC+CNC_EU_240319_KCS_GroupPhoto_MN_001',
+    })).toBe('KC+CNC_EU_240319')
+  })
+
+  it('groups frames from the same shoot together despite differing counters', () => {
+    const first = getWolvesGalleryEventKey({ id: '1', title: 'KC+CNC_NA_251109_MaintainerSummit_ML-MN_029' })
+    const second = getWolvesGalleryEventKey({ id: '2', title: 'KC+CNC_NA_251109_MaintainerSummit_ML-MN_036' })
+    expect(first).toBe(second)
+  })
+
+  // Authored titles carry no underscore structure, so they group by the whole
+  // title. Distinct portraits each form their own single-item group, while
+  // several pieces sharing one credit line ("Bluefin created by ...") group
+  // together and get spread apart — which is the desired behaviour.
+  it('groups authored prose titles by the title itself', () => {
+    expect(getWolvesGalleryEventKey({
+      id: 'wolves/people/advisor.webp',
+      title: 'Bluefin Advisor Chris Aniszczyk',
+    })).toBe('Bluefin Advisor Chris Aniszczyk')
+  })
+
+  it('falls back to the photo id when a title is empty', () => {
+    expect(getWolvesGalleryEventKey({ id: 'wolves/people/untitled.webp', title: '' }))
+      .toBe('wolves/people/untitled.webp')
+  })
+})
+
+describe('buildWolvesGalleryCycle', () => {
+  it('never repeats an event back-to-back while other events remain', () => {
+    const photos = [
+      ...Array.from({ length: 8 }, (_, index) => cncfPhoto('KC+CNC_EU_240319', index)),
+      ...Array.from({ length: 8 }, (_, index) => cncfPhoto('KC+CNC_NA_251109', index)),
+      ...Array.from({ length: 8 }, (_, index) => cncfPhoto('KC+CNC_EU_260322', index)),
+    ]
+
+    const cycle = buildWolvesGalleryCycle(photos, seededRandom())
+
+    for (let index = 1; index < cycle.length; index++) {
+      expect(getWolvesGalleryEventKey(cycle[index])).not.toBe(getWolvesGalleryEventKey(cycle[index - 1]))
+    }
+  })
+
+  // Round-robin dealt every event once per round, so the hundreds of
+  // single-photo events in the live feed all landed in round one and filled the
+  // opening stretch. Stratified placement spreads them across the whole run.
+  it('does not front-load single-photo events', () => {
+    const photos = [
+      ...Array.from({ length: 40 }, (_, index) => cncfPhoto('KC+CNC_EU_240319', index)),
+      ...Array.from({ length: 40 }, (_, index) => ({ id: `solo-${index}`, title: `Untitled ${index}` })),
+    ]
+
+    const cycle = buildWolvesGalleryCycle(photos, seededRandom())
+    const soloInFirstQuarter = cycle.slice(0, 20).filter(photo => photo.id.startsWith('solo-')).length
+
+    expect(soloInFirstQuarter).toBeLessThan(18)
+  })
+
+  // Regression guard for 255f61fb, which replaced this module with a plain
+  // Fisher-Yates and silently dropped event diversity. A bare shuffle deals
+  // long same-event runs; this asserts the pool is genuinely interleaved.
+  it('beats a plain shuffle on same-event adjacency', () => {
+    const photos = Array.from({ length: 60 }, (_, index) =>
+      cncfPhoto(`KC+CNC_EU_2403${index % 3}0`, index))
+
+    const cycle = buildWolvesGalleryCycle(photos, seededRandom(7))
+    const adjacentSameEvent = cycle.filter((photo, index) =>
+      index > 0 && getWolvesGalleryEventKey(photo) === getWolvesGalleryEventKey(cycle[index - 1])).length
+
+    // A plain shuffle over three events averages ~⅓ of pairs on the same event.
+    expect(adjacentSameEvent).toBe(0)
+  })
+
+  it('preserves every photo exactly once', () => {
+    const photos = Array.from({ length: 25 }, (_, index) => cncfPhoto(`event-${index % 4}`, index))
+    const cycle = buildWolvesGalleryCycle(photos, seededRandom(3))
+
+    expect(cycle).toHaveLength(photos.length)
+    expect(new Set(cycle.map(photo => photo.id)).size).toBe(photos.length)
+  })
+
+  it('returns an empty cycle for an empty pool', () => {
+    expect(buildWolvesGalleryCycle([])).toEqual([])
+  })
+})
+
+describe('separateAdjacentEvents', () => {
+  it('breaks up a same-event run', () => {
+    const photos = [
+      { id: '1', title: 'KC+CNC_EU_240319_A_MN_1' },
+      { id: '2', title: 'KC+CNC_EU_240319_A_MN_2' },
+      { id: '3', title: 'KC+CNC_NA_251109_A_MN_1' },
+      { id: '4', title: 'KC+CNC_EU_260322_A_MN_1' },
+    ]
+
+    const separated = separateAdjacentEvents(photos)
+
+    for (let index = 1; index < separated.length; index++) {
+      expect(getWolvesGalleryEventKey(separated[index]))
+        .not
+        .toBe(getWolvesGalleryEventKey(separated[index - 1]))
+    }
+  })
+
+  it('leaves a single-event pool untouched rather than looping', () => {
+    const photos = [
+      { id: '1', title: 'KC+CNC_EU_240319_A_MN_1' },
+      { id: '2', title: 'KC+CNC_EU_240319_A_MN_2' },
+    ]
+
+    expect(separateAdjacentEvents(photos).map(photo => photo.id)).toEqual(['1', '2'])
+  })
+})


### PR DESCRIPTION
Audits the eleven back-catalogue album experiences and rebuilds how their slideshow is composed, ordered and captioned.

## What the audit found

**The pool was missing three of its five parts.** Albums showed the CNCF stream plus the curated portraits in `wolves/people/`. The showcase screenshots and mascot art were excluded by a `/people/` filter; the comic hero shots were never wired into a catalogue pool at all.

**The opening segment had a coded preference.** It pinned three showcase slides to the front and interleaved the rest on a fixed 1:2 ratio.

**Event diversity had been silently regressed.** `33a63532` shipped `wolves-gallery-cycle.ts`, which spread photos across events. `255f61fb` ("retime intro and shuffle galleries") deleted it and pointed the call site at `shuffleWolvesGalleryPhotos` — a bare Fisher-Yates whose name implies an event-awareness its body does not have. Long same-event runs have been shipping since.

**Captions were filenames.** `KC+CNC_EU_240319_KCS_GroupPhoto_MN_001`, `0R0A9083`, `Cncf 54927603143` — rendered verbatim, at projection size.

**Provenance was inferred from disk location.** 136 of the 213 files in `wolves/people/` came from CNCF albums; all were credited `BLUEFIN SHOWCASE //`.

**The catalogue was never scheduled.** `update-content.yml` refreshed Flickr weekly while `update:back-catalogue` was wired into nothing. One regeneration pulled six track changes and replaced a `[ Redacted ]` subtitle upstream had already resolved.

## What changed

One draw across all five pools, under three independent passes:

1. **No category weighting** — curated slides are placed into gaps between CNCF slides, each gap equally likely. CNCF leads because it outnumbers everything else.
2. **No two non-CNCF slides adjacent** — across the combined curated set, because a screenshot followed by a dinosaur reads from the back row as "the photos stopped".
3. **No two consecutive CNCF slides from the same event.**

Captions are now derived from what a filename literally encodes, and withheld entirely when it encodes nothing. Provenance credit keys on explicit classification, not locality. The weekly job gains a `--metadata-only` mode that needs no `yt-dlp`.

## Two traps worth reading the diff for

**Re-drawing is not a fix.** Re-shuffling until a predicate holds is rejection sampling: it biases the distribution and breaks rule 1 while appearing to enforce rule 2. Placement is correct by construction, repaired only deterministically.

**Concatenation order is a preference.** Gaps fill in ascending order, so passing the pool as portraits-then-showcase-then-mascot-then-heroes put the first dinosaur at **slide 745 of 808**. Every membership-based test passed. Only probing the real data caught it.

## Verification

Measured against the shipped feeds — 808 slides, **0** adjacent non-CNCF pairs, **0** adjacent same-event pairs, 79 of 786 titles legitimately uncaptioned.

Chromium at 1920x1080: grid, launch, gallery and captions render with no console errors; all 11 covers load; all 23 hero shots load between 0.94 and 1.62 aspect against a 3:2 portal under `object-fit: contain`, so none are cropped.

`lint`, `typecheck`, `test:gate` (0 new failures) and `build` all pass. New distribution tests are seeded so they cannot flake.

## Scope

The frozen `/wolves/` presentation is untouched — every change gates on a non-Wolves experience, and its authored timeline, reserved slides and featured opening are unchanged.

Not touched, deliberately: the remaining `[ Redacted ]` subtitle on *Harbringer: Requiem* is authored upstream and may be intentional lore; album cover art is a byte-faithful mirror of the documentation repo.

## Correction to my own earlier analysis

I initially reported the `mixedPhotos` block as unreachable dead code. It is not — `TheaterExperience` does pass `track-index` (kebab-case, which my first grep missed), and the block's "NOT DEAD CODE" comment was correct and did its job. It has been rewritten in place rather than deleted.