### PR TITLE
Restore the full live-data cache in previews, and pin cache path parity

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -31,9 +31,15 @@ jobs:
       - name: Restore live data from cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
+          # Must match the save step's path list in update-content.yml exactly,
+          # order included: actions/cache derives the cache version from the
+          # path list, so a mismatch restores nothing and the build silently
+          # falls back to the committed data.
           path: |
             public/stream-versions.yml
             public/dakota-versions.json
+            public/flickr-photos.json
+            public/experiences
             src/assets/svg/growth_bluefins.svg
           key: website-live-data-
           restore-keys: |

--- a/docs/skills/validation/SKILL.md
+++ b/docs/skills/validation/SKILL.md
@@ -323,3 +323,27 @@ pass as proof that real audio is correct, and say so when reporting.
 Two intro harnesses, `tests/wolves-intro-segments.mjs` and
 `tests/wolves-intro-destiny-toggle.mjs`, **fail on `main`** in that environment.
 Baseline them with a worktree before treating either as a regression.
+
+
+## A cache path list is part of the cache key
+
+`actions/cache` derives the cache *version* from the `path` list, not just from
+`key`. A restore step whose path list differs from the save step's — in content
+**or in order** — can never match, and `restore-keys` is version-scoped too, so
+the fallback does not rescue it.
+
+With `fail-on-cache-miss: false` the miss is silent. The build proceeds with
+whatever is committed, and the producing job keeps reporting success while
+delivering nothing.
+
+Adding a single path to the save step in `update-content.yml` broke every
+live-data feed exactly this way, including two that had nothing to do with the
+change. Nothing in CI went red: the workflow that breaks is not the workflow
+that runs on the pull request.
+
+`website-live-data-` has one producer (`update-content.yml`) and two consumers
+(`deploy.yml`, `preview.yml`). All three lists must stay byte-identical;
+`scripts/tests/workflow-cache-parity.test.ts` enforces it.
+
+When touching any cached path, enumerate every workflow that restores that key
+before editing the one that saves it. Grep the key, not the filename.

--- a/scripts/tests/workflow-cache-parity.test.ts
+++ b/scripts/tests/workflow-cache-parity.test.ts
@@ -1,0 +1,78 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { load } from 'js-yaml'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * `actions/cache` derives the cache *version* from the `path` list, not just
+ * from `key`. A restore step whose path list differs from the save step's — in
+ * content or in order — can never match the cache, and `restore-keys` is
+ * version-scoped too, so the fallback does not save it either.
+ *
+ * With `fail-on-cache-miss: false` the miss is silent: the build proceeds with
+ * whatever is committed and the weekly refresh keeps reporting success while
+ * delivering nothing. Adding one path to the save step alone broke every
+ * live-data feed exactly this way, and it was invisible to CI.
+ */
+const WORKFLOWS_DIR = resolve(process.cwd(), '.github/workflows')
+const CACHE_KEY_PREFIX = 'website-live-data-'
+
+interface CacheStep {
+  file: string
+  kind: 'save' | 'restore'
+  paths: string[]
+}
+
+function collectLiveDataCacheSteps(): CacheStep[] {
+  const steps: CacheStep[] = []
+
+  for (const file of readdirSync(WORKFLOWS_DIR).filter(name => name.endsWith('.yml'))) {
+    const workflow = load(readFileSync(join(WORKFLOWS_DIR, file), 'utf8')) as {
+      jobs?: Record<string, { steps?: { uses?: string, with?: Record<string, string> }[] }>
+    }
+
+    for (const job of Object.values(workflow.jobs ?? {})) {
+      for (const step of job.steps ?? []) {
+        const uses = step.uses ?? ''
+        const key = step.with?.key ?? ''
+        if (!uses.includes('actions/cache') || !key.startsWith(CACHE_KEY_PREFIX)) {
+          continue
+        }
+        steps.push({
+          file,
+          kind: uses.includes('/save@') ? 'save' : 'restore',
+          paths: (step.with?.path ?? '').trim().split('\n').map(line => line.trim()).filter(Boolean),
+        })
+      }
+    }
+  }
+
+  return steps
+}
+
+describe('live-data cache wiring', () => {
+  const steps = collectLiveDataCacheSteps()
+
+  it('has exactly one producer and at least one consumer', () => {
+    expect(steps.filter(step => step.kind === 'save')).toHaveLength(1)
+    expect(steps.filter(step => step.kind === 'restore').length).toBeGreaterThan(0)
+  })
+
+  it('uses an identical path list everywhere, order included', () => {
+    const save = steps.find(step => step.kind === 'save')
+    expect(save).toBeDefined()
+
+    for (const step of steps) {
+      expect(
+        step.paths,
+        `${step.file} (${step.kind}) must list the same cache paths, in the same order, as the save step`,
+      ).toEqual(save!.paths)
+    }
+  })
+
+  it('caches the back catalogue alongside the other generated feeds', () => {
+    const save = steps.find(step => step.kind === 'save')!
+    expect(save.paths).toContain('public/experiences')
+    expect(save.paths).toContain('public/flickr-photos.json')
+  })
+})


### PR DESCRIPTION
Follow-up to #715.

## The bug

`preview.yml` restores **three** of the five cached live-data paths. Its list has never matched the save step in `update-content.yml`, and `actions/cache` derives the cache *version* from the path list — so preview builds have never restored any of this data. `fail-on-cache-miss: false` kept it silent.

For `public/flickr-photos.json` this predates #715. Adding `public/experiences` widened the same gap. They're fixed together because they're one defect: three workflows share the `website-live-data-` key with nothing keeping their path lists in step.

## Why CI never caught it

**The workflow that breaks is not the workflow that runs on the pull request.** `test` and `wolves-movie-flow` pass regardless. #715 went green through review and merge with a broken cache contract in it.

So this adds `scripts/tests/workflow-cache-parity.test.ts`, which parses every workflow, finds each step touching the key, and asserts the path lists are identical including order. Verified to fail against the exact shape of the bug that shipped:

```
× uses an identical path list everywhere, order included
  AssertionError: deploy.yml (restore) must list the same cache paths,
  in the same order, as the save step
```

## Verification

`lint`, `typecheck`, `test:gate` (0 new failures) pass. Production from #715 confirmed live and healthy first: 11/11 covers, derived captions rendering (`CNCF STREAM // KubeCon EU · Maintainer Summit Breaks+Lunch · March 2026`), 0 console errors.

Recorded in `docs/skills/validation/SKILL.md`: grep the cache key, not the filename, before editing a cached path.