### PR TITLE
Integrate the reviewable open branches: devcontainer and content-validation tests

### DIFF
--- a/.devcontainer/Containerfile
+++ b/.devcontainer/Containerfile
@@ -1,0 +1,20 @@
+FROM cgr.dev/chainguard/wolfi-base:latest
+
+USER root
+
+RUN apk add --no-cache \
+    bash \
+    git \
+    nodejs \
+    npm \
+    bun \
+    just \
+    github-cli \
+    shadow \
+    sudo
+
+RUN useradd -m -u 1000 -s /bin/bash vscode && \
+    echo "vscode ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/vscode
+
+USER vscode
+WORKDIR /home/vscode

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://raw.githubusercontent.com/devcontainers/spec/refs/heads/main/schemas/devContainer.schema.json",
+  "name": "bluefin-website",
+  "build": {
+    "dockerfile": "Containerfile",
+    "context": "."
+  },
+
+  "runArgs": [
+    "--userns=keep-id",
+    "--security-opt=label=disable"
+  ],
+  "containerUser": "vscode",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspaces/bluefin-website,type=bind,Z",
+  "workspaceFolder": "/workspaces/bluefin-website",
+
+  "postCreateCommand": "npm install",
+  "forwardPorts": [5173],
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "astro-build.astro-vscode",
+        "bradlc.vscode-tailwindcss",
+        "github.vscode-github-actions",
+        "github.vscode-pull-request-github"
+      ],
+      "settings": {
+        "editor.formatOnSave": true
+      }
+    }
+  }
+}

--- a/src/tests/content-links.test.ts
+++ b/src/tests/content-links.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import * as content from '../content'
+
+describe('content.ts — exported constants', () => {
+  it('LangLandingBluefinImageURLs contains valid paths', () => {
+    expect(content.LangLandingBluefinImageURLs.length).toBeGreaterThan(0)
+    for (const url of content.LangLandingBluefinImageURLs) {
+      expect(url).toMatch(/^\.\/characters\/header\/.*\.webp$/)
+    }
+  })
+
+  it('LangUsersBluefinImageURL is a valid path', () => {
+    expect(content.LangUsersBluefinImageURL).toMatch(/\.webp$/)
+  })
+
+  it('LangMissionBluefinImageURL is a valid path', () => {
+    expect(content.LangMissionBluefinImageURL).toMatch(/\.webp$/)
+  })
+
+  it('social links have valid URLs', () => {
+    const socialLinks = (content as any).LangSocialLinks ?? []
+    for (const link of socialLinks) {
+      if (link?.href) {
+        expect(link.href).toMatch(/^https?:\/\//)
+      }
+    }
+  })
+
+  it('markdown content does not have broken link syntax', () => {
+    const markdownFields = [
+      content.LangUsersAppendix,
+      content.LangDevsAppendix,
+      content.LangMissionText,
+    ]
+    for (const field of markdownFields) {
+      // Check for [text](url) where url is not empty
+      const links = field.match(/\[([^\]]+)\]\(([^)]*)\)/g) ?? []
+      for (const link of links) {
+        const url = link.match(/\]\(([^)]*)\)/)?.[1]
+        expect(url, `Broken link in: ${link}`).toBeTruthy()
+        expect(url).toMatch(/^https?:\/\/|^#/)
+      }
+    }
+  })
+})

--- a/src/tests/content-links.test.ts
+++ b/src/tests/content-links.test.ts
@@ -2,18 +2,18 @@ import { describe, expect, it } from 'vitest'
 import * as content from '../content'
 
 describe('content.ts — exported constants', () => {
-  it('LangLandingBluefinImageURLs contains valid paths', () => {
+  it('langLandingBluefinImageURLs contains valid paths', () => {
     expect(content.LangLandingBluefinImageURLs.length).toBeGreaterThan(0)
     for (const url of content.LangLandingBluefinImageURLs) {
       expect(url).toMatch(/^\.\/characters\/header\/.*\.webp$/)
     }
   })
 
-  it('LangUsersBluefinImageURL is a valid path', () => {
+  it('langUsersBluefinImageURL is a valid path', () => {
     expect(content.LangUsersBluefinImageURL).toMatch(/\.webp$/)
   })
 
-  it('LangMissionBluefinImageURL is a valid path', () => {
+  it('langMissionBluefinImageURL is a valid path', () => {
     expect(content.LangMissionBluefinImageURL).toMatch(/\.webp$/)
   })
 

--- a/src/tests/locale-completeness.test.ts
+++ b/src/tests/locale-completeness.test.ts
@@ -1,0 +1,57 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const here = fileURLToPath(new URL('.', import.meta.url))
+const localesDir = resolve(here, '../locales')
+
+function loadLocale(filename: string): Record<string, unknown> {
+  const content = readFileSync(resolve(localesDir, filename), 'utf8')
+  return JSON.parse(content)
+}
+
+function flatKeys(obj: Record<string, unknown>, prefix = ''): string[] {
+  const keys: string[] = []
+  for (const [key, value] of Object.entries(obj)) {
+    const fullKey = prefix ? `${prefix}.${key}` : key
+    if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+      keys.push(...flatKeys(value as Record<string, unknown>, fullKey))
+    } else {
+      keys.push(fullKey)
+    }
+  }
+  return keys.sort()
+}
+
+const localeFiles = readdirSync(localesDir).filter(f => f.endsWith('.json'))
+const enUS = loadLocale('en-US.json')
+const enKeys = flatKeys(enUS)
+
+describe('locale files', () => {
+  it('en-US.json exists and has keys', () => {
+    expect(enKeys.length).toBeGreaterThan(0)
+  })
+
+  for (const file of localeFiles) {
+    if (file === 'en-US.json') continue
+
+    it(`${file} has all keys from en-US.json`, () => {
+      const locale = loadLocale(file)
+      const localeKeys = flatKeys(locale)
+      const missing = enKeys.filter(k => !localeKeys.includes(k))
+      if (missing.length > 0) {
+        // Warn but don't fail — incomplete translations are expected
+        console.warn(`${file} missing ${missing.length} keys: ${missing.slice(0, 5).join(', ')}...`)
+      }
+      // At minimum, the locale should have SOME keys
+      expect(localeKeys.length).toBeGreaterThan(0)
+    })
+  }
+
+  it('all locale files are valid JSON', () => {
+    for (const file of localeFiles) {
+      expect(() => loadLocale(file)).not.toThrow()
+    }
+  })
+})

--- a/src/tests/locale-completeness.test.ts
+++ b/src/tests/locale-completeness.test.ts
@@ -1,9 +1,8 @@
 import { readdirSync, readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 
-const here = fileURLToPath(new URL('.', import.meta.url))
+const here = resolve(process.cwd(), 'src/tests')
 const localesDir = resolve(here, '../locales')
 
 function loadLocale(filename: string): Record<string, unknown> {
@@ -17,7 +16,8 @@ function flatKeys(obj: Record<string, unknown>, prefix = ''): string[] {
     const fullKey = prefix ? `${prefix}.${key}` : key
     if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
       keys.push(...flatKeys(value as Record<string, unknown>, fullKey))
-    } else {
+    }
+    else {
       keys.push(fullKey)
     }
   }
@@ -34,7 +34,9 @@ describe('locale files', () => {
   })
 
   for (const file of localeFiles) {
-    if (file === 'en-US.json') continue
+    if (file === 'en-US.json') {
+      continue
+    }
 
     it(`${file} has all keys from en-US.json`, () => {
       const locale = loadLocale(file)


### PR DESCRIPTION
Reviews and integrates the open branch backlog. Of 23 unmerged branches, these are the ones that are both non-redundant and green.

## Merged here

- **`consolidate-content-workflows`** — adds a Podman devcontainer. Purely additive, no runtime impact.
- **`quality/test-content-validation`** — adds `content-links` and `locale-completeness` suites (19 tests).

Plus one fix of my own: the locale-completeness suite used `new URL('.', import.meta.url)`, which throws *"The URL must be of scheme file"* under this repo's vitest setup — **the suite could not run at all**. It now resolves from `process.cwd()`, matching `wallpaperGenerator.test.ts`.

## Reviewed and deliberately not merged

**`quality/tests-615`** — merges clean, but **16 of its 27 tests fail**. It asserts that no locale has keys absent from `en-US`, and `eo`, `ja-JP`, `nl-NL` and `ru-RU` all do. The invariant is reasonable; the repo just doesn't satisfy it yet. There is already a `fix-locale-extra-keys-629` branch for exactly this, so this test belongs *after* that cleanup, not before it. Merging it now would put main permanently red.

**`renovate/npm-js-yaml-vulnerability`** — redundant. Main is already on js-yaml 4.3.1 via #710.

**`copilot/fix-b81d0527…`** — empty ("Initial plan", 0 files changed).

**`renovate/antfu-eslint-config-9.x`** — a three-major-version jump on the linter (^6.2.0 → v9). Not something to slip into an integration PR; it wants its own run with the resulting lint churn visible.

**15 branches conflict with main** and are between 3 and 12 months old: `bugfix/issue-530-540`, `trim/agents-md`, `docs/contributing-guide`, `docs/readme-structure`, `feat/server-page-rename`, `feature/our-flock-section`, `fix-locale-extra-keys-629`, `automated/update-content`, `chore/prototype-slider`, `ci-wolves-movie-flow-strict-locator`, `quality/*`, `renovate/*`, `resolve-contributing-conflicts`. Each needs a human decision on whether the intent still applies before anyone spends time rebasing.

## Verification

`lint`, `typecheck`, `test:gate` (0 new failures), `build` all pass.