### PR TITLE
Stop the 48.4s handoff assertion racing an image decode

### DIFF
--- a/docs/skills/validation/SKILL.md
+++ b/docs/skills/validation/SKILL.md
@@ -347,3 +347,27 @@ that runs on the pull request.
 
 When touching any cached path, enumerate every workflow that restores that key
 before editing the one that saves it. Grep the key, not the filename.
+
+
+## A red integration branch is not automatically your fault
+
+Before debugging a CI failure on a branch that merges other people's work,
+check whether `main` is green at the same code. `gh run list --branch main
+--workflow CI --limit 3` answers it in one call.
+
+An integration of a devcontainer and two test files failed
+`wolves-movie-flow` on an assertion about a slide handoff at 48.4 seconds — in
+code the branch did not touch. `main` was green at the identical runtime, and a
+re-run with no change passed. It was a flake, not a regression.
+
+The cause is worth knowing, because the harness has more assertions shaped like
+this one: slide swaps are gated on the incoming image decoding, and `seekStage`
+settles for a fixed 250 ms. Any assertion that seeks to a boundary and then
+immediately reads the active layer is racing a decode. On a cold runner the
+decode loses.
+
+The fix is to wait for the state you expect and then assert, rather than
+asserting on a timer — a genuine regression still fails, it just takes the
+timeout to get there. When adding a boundary assertion to
+`tests/wolves-movie-flow.mjs`, wait for the transition rather than trusting the
+settle time.

--- a/tests/wolves-movie-flow.mjs
+++ b/tests/wolves-movie-flow.mjs
@@ -891,7 +891,20 @@ try {
   })
   assertTruthy('Jorge MN047 holds through 48.399 seconds', ghostsBeforeHandoff?.includes('55164222671_32d7ace307_c.jpg'))
 
+  // The slide swap is gated on the incoming image decoding, so at the 48.4s
+  // boundary the handoff is a race against `seekStage`'s fixed settle time.
+  // On a cold runner the decode loses and the assertion reports a regression
+  // that is really just a slow frame. Wait for the swap, then assert, so a
+  // genuine failure still fails — it just takes the timeout to get there.
   await seekStage(48.4)
+  await page
+    .waitForFunction(() => {
+      const layers = [...document.querySelectorAll('.flickr-photo-layer')]
+      const activeLayer = layers.find(layer => getComputedStyle(layer).zIndex === '2')
+      const src = activeLayer?.querySelector('img')?.getAttribute('src') ?? ''
+      return !src.includes('55164222671_32d7ace307_c.jpg')
+    }, null, { timeout: 5000 })
+    .catch(() => {})
   const ghostsAtHandoff = await page.locator('.flickr-photo-layer').evaluateAll((layers) => {
     const activeLayer = layers.find(layer => getComputedStyle(layer).zIndex === '2')
     return activeLayer?.querySelector('img')?.getAttribute('src')


### PR DESCRIPTION
The `wolves-movie-flow` harness seeks to a boundary, waits a fixed 250 ms, then reads which slide is active. But slide swaps are gated on the **incoming image decoding**, so on a cold runner the decode loses the race and the assertion reports a regression that is really just a slow frame.

Seen for real during this session: #719 — an integration branch touching only a devcontainer and two test files — failed `Jorge MN047 hands off at 48.4 seconds`, in code it does not touch. `main` was green at the identical runtime, and a re-run with no change passed.

Now it waits for the handoff and then asserts, with a 5 s ceiling. A genuine regression still fails; it just takes the timeout to get there.

Recorded in `docs/skills/validation/SKILL.md`, including the general shape:
- check whether `main` is green before debugging a red integration branch;
- never assert on a settle timer where the runtime gates on decode.

The harness has more assertions shaped like this one, so the note matters more than the single fix.