### PR TITLE
fix(wolves): director's cut autoplay resilience and deep link

### DIFF
--- a/docs/skills/wolves-content/SKILL.md
+++ b/docs/skills/wolves-content/SKILL.md
@@ -117,6 +117,24 @@ record. Do not invent names, scientific facts, pairings, or provenance.
 | "This overlay text is obvious enough to paraphrase." | Wolves content surfaces use exact supplied wording only; changing even a short overlay changes authored content. |
 | "It is only intro data, so I don't need to update tests." | Intro segment ids and timestamps are contract data for store and overlay tests; pin them when they change. |
 
+## Director's Cut does not share the standard intro's title-card quote slide
+
+`buildIntroVideoSequence()` is the standard front-door intro: silent title-card
+quote slide, then the Destiny trailer. The Director's Cut replaces that opening
+with the Gayane Ballet Suite prologue, but it still ends with the same Destiny
+trailer.
+
+Do not build the Director's Cut by prepending the prologue to
+`...buildIntroVideoSequence()`. That places the standard title-card quote slide
+after the prologue, so the show appears to return to the opening after the first
+song has already played. Instead, compose the Director's Cut from its own
+opening segment plus the shared Destiny trailer segment, keeping the two intro
+variants as sibling lists rather than a prefix plus a spread.
+
+When either intro list changes, update the store tests that assert on segment
+identity and duration rather than on segment count, since both variants now have
+the same length.
+
 ## Verification
 
 - [ ] Diff contains only documented content surfaces.

--- a/docs/skills/wolves-content/SKILL.md
+++ b/docs/skills/wolves-content/SKILL.md
@@ -39,6 +39,23 @@ owner-requested tag, and do not invent a repository media directory or a
 separate scratch location. Treat owner-renamed filenames as storyboard IDs:
 preserve them verbatim and use them when referring to the corresponding clip.
 
+When an owner asks to maximize a storyboard clip's quality, use its filename's
+YouTube ID and embedded keep range as the index. First list the available
+formats, then download the highest native video stream into the existing
+`sources/` directory; do not upscale the low-resolution storyboard derivative
+or replace it:
+
+```bash
+yt-dlp -F "https://www.youtube.com/watch?v=<storyboard-id>"
+yt-dlp -f <selected-video-format> \
+  -o "sources/<storyboard-id>.%(ext)s" \
+  "https://www.youtube.com/watch?v=<storyboard-id>"
+```
+
+Trim the downloaded source with the original, absolute keep ranges. A
+constrained social output should downscale from that native source, while a
+master retains its native dimensions.
+
 Before rendering an H.264 review artifact, verify the selected FFmpeg binary
 offers `libx264`:
 
@@ -119,6 +136,7 @@ record. Do not invent names, scientific facts, pairings, or provenance.
 
 - Context7: `/addyosmani/agent-skills` (skill file structure and required sections)
 - Context7: `/websites/ffmpeg_documentation` (encoder discovery and `-c:v libx264`)
+- Context7: `/yt-dlp/yt-dlp` (format selection and output templates)
 
 ## Pages break at thoughts, not at character counts
 

--- a/docs/skills/wolves-content/SKILL.md
+++ b/docs/skills/wolves-content/SKILL.md
@@ -33,9 +33,10 @@ source video's native clock. `startOffset` is the exact source start timestamp
 in seconds, `maxDuration` is the exact source end timestamp in seconds, and any
 overlay cue windows on those segments stay absolute too — do not rebase them to
 segment-relative `0`, or the authored source timing and tests drift.
-When the owner asks to retain a clip with no text edit, put it in its
-`~/Videos/<collection>/` folder and use the owner-requested tag. Do not invent
-a repository media directory or a tagging workflow.
+Use `~/Videos/` as the shared local scratch space for source clips and previews
+the owner needs to review. Keep future video work together there, use the
+owner-requested tag, and do not invent a repository media directory or a
+separate scratch location.
 
 For a visible WebP quality regression, compare the optimized asset with its
 approved source at identical dimensions. Recover only demonstrated high-loss

--- a/docs/skills/wolves-content/SKILL.md
+++ b/docs/skills/wolves-content/SKILL.md
@@ -39,6 +39,18 @@ owner-requested tag, and do not invent a repository media directory or a
 separate scratch location. Treat owner-renamed filenames as storyboard IDs:
 preserve them verbatim and use them when referring to the corresponding clip.
 
+Before rendering an H.264 review artifact, verify the selected FFmpeg binary
+offers `libx264`:
+
+```bash
+ffmpeg -encoders | grep 'libx264'
+```
+
+Some system FFmpeg builds omit external encoders. If that probe is empty, list
+available FFmpeg binaries with `which -a ffmpeg` and use a binary that reports
+`libx264`; do not silently replace the requested codec with a different one.
+Use `-c:v libx264` explicitly in the render command.
+
 For a visible WebP quality regression, compare the optimized asset with its
 approved source at identical dimensions. Recover only demonstrated high-loss
 PNG or screenshot derivatives as lossless WebP; do not upscale assets whose
@@ -106,6 +118,7 @@ record. Do not invent names, scientific facts, pairings, or provenance.
 ## Sources
 
 - Context7: `/addyosmani/agent-skills` (skill file structure and required sections)
+- Context7: `/websites/ffmpeg_documentation` (encoder discovery and `-c:v libx264`)
 
 ## Pages break at thoughts, not at character counts
 

--- a/docs/skills/wolves-content/SKILL.md
+++ b/docs/skills/wolves-content/SKILL.md
@@ -28,6 +28,15 @@ player synchronization, or generated manifests.
 5. Regenerate generated files with their scripts.
 6. Run the relevant tests, build, and browser checks.
 
+Director's Cut keep ranges in `buildDirectorsCutVideoSequence()` stay on the
+source video's native clock. `startOffset` is the exact source start timestamp
+in seconds, `maxDuration` is the exact source end timestamp in seconds, and any
+overlay cue windows on those segments stay absolute too — do not rebase them to
+segment-relative `0`, or the authored source timing and tests drift.
+When the owner asks to retain a clip with no text edit, put it in its
+`~/Videos/<collection>/` folder and use the owner-requested tag. Do not invent
+a repository media directory or a tagging workflow.
+
 For a visible WebP quality regression, compare the optimized asset with its
 approved source at identical dimensions. Recover only demonstrated high-loss
 PNG or screenshot derivatives as lossless WebP; do not upscale assets whose
@@ -69,6 +78,14 @@ record. Do not invent names, scientific facts, pairings, or provenance.
 - A generated manifest is hand-edited.
 - Text moves between signal, thesis, lore, and chat layers.
 
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "These cut windows are short, so rebasing them from zero is simpler." | Director's Cut keep ranges are pinned to absolute YouTube source timestamps; rebasing them breaks playback timing and the intro timeline math. |
+| "This overlay text is obvious enough to paraphrase." | Wolves content surfaces use exact supplied wording only; changing even a short overlay changes authored content. |
+| "It is only intro data, so I don't need to update tests." | Intro segment ids and timestamps are contract data for store and overlay tests; pin them when they change. |
+
 ## Verification
 
 - [ ] Diff contains only documented content surfaces.
@@ -83,6 +100,10 @@ record. Do not invent names, scientific facts, pairings, or provenance.
 - `../editorial-provenance/SKILL.md`
 - `../validation/SKILL.md`
 - `../wolves-runtime-engineering/SKILL.md`
+
+## Sources
+
+- Context7: `/addyosmani/agent-skills` (skill file structure and required sections)
 
 ## Pages break at thoughts, not at character counts
 

--- a/docs/skills/wolves-content/SKILL.md
+++ b/docs/skills/wolves-content/SKILL.md
@@ -36,7 +36,8 @@ segment-relative `0`, or the authored source timing and tests drift.
 Use `~/Videos/` as the shared local scratch space for source clips and previews
 the owner needs to review. Keep future video work together there, use the
 owner-requested tag, and do not invent a repository media directory or a
-separate scratch location.
+separate scratch location. Treat owner-renamed filenames as storyboard IDs:
+preserve them verbatim and use them when referring to the corresponding clip.
 
 For a visible WebP quality regression, compare the optimized asset with its
 approved source at identical dimensions. Recover only demonstrated high-loss

--- a/docs/skills/wolves-runtime-engineering/SKILL.md
+++ b/docs/skills/wolves-runtime-engineering/SKILL.md
@@ -94,6 +94,29 @@ an unidentified player request.
 - A change removes authored content — a segment, lore, prose — without the
   owner's explicit word, or its justification does not match its diff.
 
+## Director's Cut entry points and autoplay resilience
+
+The Director's Cut can be entered in two ways:
+
+1. **Lobby click** — `CinematicLobby` emits `enter-directors-cut`, which calls
+   `enterIntro(null, true)`. The click satisfies browser autoplay policy.
+2. **Deep link** — `/wolves/?directors-cut` auto-starts the Director's Cut on
+   mount. This is intended for projection / recording workflows, but it may
+   lack a user gesture, so the browser may block autoplay.
+
+If the scored prologue's background-audio embed or the Destiny trailer video is
+blocked, `currentTime` stops advancing and the show hangs. The intro overlay
+handles this with bounded fallbacks:
+
+- **Text/audio segments**: if `getCurrentTime()` stays at `0` for more than
+  `MAX_AUDIO_STALL_SECONDS` (5s), pacing falls back to the existing wall-clock
+  derivation. Time never rewinds when the audio player starts late.
+- **Video segments**: if `currentTime` stays within the opening seconds for more
+  than 15s, the segment advances so the cinematic handoff is not stranded.
+
+These fallbacks are last-resort unattended behavior. For normal projection, prefer
+a real user gesture so the authored music and trailer play as intended.
+
 ## Verification
 
 - [ ] Explicit approval exists.

--- a/docs/superpowers/plans/2026-08-10-wolves-directors-cut-montage.md
+++ b/docs/superpowers/plans/2026-08-10-wolves-directors-cut-montage.md
@@ -3,12 +3,14 @@
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Render a 70-second local-review-only Wolves Director's Cut montage
-from the seven approved storyboard clips.
+from the seven approved storyboard clips with the owner-authorized local remix
+track.
 
 **Architecture:** FFmpeg's concat demuxer supplies the seven unchanged clip
-streams in storyboard order. The render maps only the concatenated video and a
-generated silent AAC stream, producing a compatible H.264/AAC review artifact
-without touching the Wolves website or its media registry.
+streams in storyboard order. Homebrew FFmpeg maps that video with a 70-second
+audio range, starting at 08:17, from the owner-authorized local Wolves remix
+source, then encodes a compatible H.264/AAC review artifact without touching
+the Wolves website or its media registry.
 
 **Tech Stack:** FFmpeg 7.1+, FFprobe, H.264 (`libx264`), AAC.
 
@@ -21,8 +23,9 @@ without touching the Wolves website or its media registry.
 - Remove all source audio.
 - Render 640x360 video at 24 fps with an AAC audio stream and a total duration
   of 70 seconds.
-- Use a silent audio stream unless the owner separately supplies an authorized
-  audio file; do not download, extract, or use a YouTube recording.
+- Use `/var/home/jorge/Videos/wolves-directors-cut/Beauty Of The Beast
+  [X3WrCzLIIvk].webm` as the owner-authorized local remix source, starting its
+  audio at source timestamp 08:17. Do not download media.
 - The artifact is `local review` only and must not change the Wolves website,
   register an asset, or imply approval for integration.
 
@@ -34,9 +37,10 @@ without touching the Wolves website or its media registry.
 |---|---|
 | `/var/home/jorge/Videos/wolves-directors-cut/h-5S82ETKvI_*.mp4` | Immutable source clips, identified by storyboard filename. |
 | `/var/tmp/website-agent/wolves-directors-cut-concat.txt` | Temporary FFmpeg concat manifest. Remove after rendering. |
+| `/var/home/jorge/Videos/wolves-directors-cut/Beauty Of The Beast [X3WrCzLIIvk].webm` | Owner-authorized local remix source. |
 | `/var/home/jorge/Videos/wolves-directors-cut/wolves-directors-cut-mockup.mp4` | Local-review output artifact. |
 
-### Task 1: Render the silent storyboard montage
+### Task 1: Render the scored storyboard montage
 
 **Files:**
 - Create: `/var/tmp/website-agent/wolves-directors-cut-concat.txt`
@@ -45,9 +49,10 @@ without touching the Wolves website or its media registry.
 
 **Interfaces:**
 - Consumes: Seven 640x360, 24 fps storyboard clips with the exact filenames
-  listed in the manifest below.
+  listed in the manifest below, plus the owner-authorized local remix source.
 - Produces: `wolves-directors-cut-mockup.mp4`, a 70-second, 640x360, 24 fps
-  H.264 video with silent 44.1 kHz stereo AAC audio.
+  H.264 video with 48 kHz stereo AAC audio beginning at source timestamp
+  08:17 of the authorized remix.
 
 - [ ] **Step 1: Verify every source clip exists and has the expected video stream**
 
@@ -93,15 +98,16 @@ without touching the Wolves website or its media registry.
   Expected: The manifest contains seven `file` lines in the approved
   chronological order.
 
-- [ ] **Step 3: Render the silent H.264/AAC review artifact**
+- [ ] **Step 3: Render the scored H.264/AAC review artifact**
 
   Run:
 
   ```bash
-  ffmpeg -y \
+  /home/linuxbrew/.linuxbrew/bin/ffmpeg -y \
     -f concat -safe 0 \
     -i /var/tmp/website-agent/wolves-directors-cut-concat.txt \
-    -f lavfi -i anullsrc=channel_layout=stereo:sample_rate=44100 \
+    -ss 497 -t 70 \
+    -i '/var/home/jorge/Videos/wolves-directors-cut/Beauty Of The Beast [X3WrCzLIIvk].webm' \
     -map 0:v:0 -map 1:a:0 \
     -c:v libx264 -preset medium -crf 18 -pix_fmt yuv420p -r 24 \
     -c:a aac -b:a 192k -t 70 -movflags +faststart \
@@ -110,7 +116,7 @@ without touching the Wolves website or its media registry.
 
   Expected: FFmpeg exits successfully and writes the output file. Its video
   contains the seven source ranges with no inserted transition frames; its
-  audio comes only from `anullsrc`.
+  audio is the authorized local source from 08:17 through 09:27.
 
 - [ ] **Step 4: Verify the rendered media properties and decode it fully**
 
@@ -125,7 +131,7 @@ without touching the Wolves website or its media registry.
   ```
 
   Expected: Duration is 70 seconds (within one frame), video is H.264 at
-  640x360 and 24 fps, audio is AAC at 44.1 kHz stereo, and the complete decode
+  640x360 and 24 fps, audio is AAC at 48 kHz stereo, and the complete decode
   emits no errors.
 
 - [ ] **Step 5: Remove the temporary concat manifest**

--- a/docs/superpowers/plans/2026-08-10-wolves-directors-cut-montage.md
+++ b/docs/superpowers/plans/2026-08-10-wolves-directors-cut-montage.md
@@ -1,0 +1,140 @@
+# Wolves Director's Cut Montage Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render a 70-second local-review-only Wolves Director's Cut montage
+from the seven approved storyboard clips.
+
+**Architecture:** FFmpeg's concat demuxer supplies the seven unchanged clip
+streams in storyboard order. The render maps only the concatenated video and a
+generated silent AAC stream, producing a compatible H.264/AAC review artifact
+without touching the Wolves website or its media registry.
+
+**Tech Stack:** FFmpeg 7.1+, FFprobe, H.264 (`libx264`), AAC.
+
+## Global Constraints
+
+- Preserve each supplied storyboard filename and its embedded original-source
+  timestamp; do not rename, regenerate, move, or replace source clips.
+- Use the supplied clip order with hard cuts only: no transitions, overlays,
+  titles, effects, speed changes, or authored copy.
+- Remove all source audio.
+- Render 640x360 video at 24 fps with an AAC audio stream and a total duration
+  of 70 seconds.
+- Use a silent audio stream unless the owner separately supplies an authorized
+  audio file; do not download, extract, or use a YouTube recording.
+- The artifact is `local review` only and must not change the Wolves website,
+  register an asset, or imply approval for integration.
+
+---
+
+## File structure
+
+| Path | Responsibility |
+|---|---|
+| `/var/home/jorge/Videos/wolves-directors-cut/h-5S82ETKvI_*.mp4` | Immutable source clips, identified by storyboard filename. |
+| `/var/tmp/website-agent/wolves-directors-cut-concat.txt` | Temporary FFmpeg concat manifest. Remove after rendering. |
+| `/var/home/jorge/Videos/wolves-directors-cut/wolves-directors-cut-mockup.mp4` | Local-review output artifact. |
+
+### Task 1: Render the silent storyboard montage
+
+**Files:**
+- Create: `/var/tmp/website-agent/wolves-directors-cut-concat.txt`
+- Create: `/var/home/jorge/Videos/wolves-directors-cut/wolves-directors-cut-mockup.mp4`
+- Delete: `/var/tmp/website-agent/wolves-directors-cut-concat.txt`
+
+**Interfaces:**
+- Consumes: Seven 640x360, 24 fps storyboard clips with the exact filenames
+  listed in the manifest below.
+- Produces: `wolves-directors-cut-mockup.mp4`, a 70-second, 640x360, 24 fps
+  H.264 video with silent 44.1 kHz stereo AAC audio.
+
+- [ ] **Step 1: Verify every source clip exists and has the expected video stream**
+
+  Run:
+
+  ```bash
+  cd /var/home/jorge/Videos/wolves-directors-cut
+  for clip in \
+    h-5S82ETKvI_0000-0015.mp4 \
+    h-5S82ETKvI_0019-0027.mp4 \
+    h-5S82ETKvI_0030-0055.mp4 \
+    h-5S82ETKvI_0060-0066.mp4 \
+    h-5S82ETKvI_0069-0075.mp4 \
+    h-5S82ETKvI_0082-0088.mp4 \
+    h-5S82ETKvI_0104-0108.mp4
+  do
+    ffprobe -v error -select_streams v:0 \
+      -show_entries stream=codec_name,width,height,r_frame_rate \
+      -of default=noprint_wrappers=1 "$clip"
+  done
+  ```
+
+  Expected: Seven video-stream reports, each showing `width=640`,
+  `height=360`, and `r_frame_rate=24/1`.
+
+- [ ] **Step 2: Create the ordered temporary concat manifest**
+
+  Run:
+
+  ```bash
+  mkdir -p /var/tmp/website-agent
+  cat > /var/tmp/website-agent/wolves-directors-cut-concat.txt <<'EOF'
+  file '/var/home/jorge/Videos/wolves-directors-cut/h-5S82ETKvI_0000-0015.mp4'
+  file '/var/home/jorge/Videos/wolves-directors-cut/h-5S82ETKvI_0019-0027.mp4'
+  file '/var/home/jorge/Videos/wolves-directors-cut/h-5S82ETKvI_0030-0055.mp4'
+  file '/var/home/jorge/Videos/wolves-directors-cut/h-5S82ETKvI_0060-0066.mp4'
+  file '/var/home/jorge/Videos/wolves-directors-cut/h-5S82ETKvI_0069-0075.mp4'
+  file '/var/home/jorge/Videos/wolves-directors-cut/h-5S82ETKvI_0082-0088.mp4'
+  file '/var/home/jorge/Videos/wolves-directors-cut/h-5S82ETKvI_0104-0108.mp4'
+  EOF
+  ```
+
+  Expected: The manifest contains seven `file` lines in the approved
+  chronological order.
+
+- [ ] **Step 3: Render the silent H.264/AAC review artifact**
+
+  Run:
+
+  ```bash
+  ffmpeg -y \
+    -f concat -safe 0 \
+    -i /var/tmp/website-agent/wolves-directors-cut-concat.txt \
+    -f lavfi -i anullsrc=channel_layout=stereo:sample_rate=44100 \
+    -map 0:v:0 -map 1:a:0 \
+    -c:v libx264 -preset medium -crf 18 -pix_fmt yuv420p -r 24 \
+    -c:a aac -b:a 192k -t 70 -movflags +faststart \
+    /var/home/jorge/Videos/wolves-directors-cut/wolves-directors-cut-mockup.mp4
+  ```
+
+  Expected: FFmpeg exits successfully and writes the output file. Its video
+  contains the seven source ranges with no inserted transition frames; its
+  audio comes only from `anullsrc`.
+
+- [ ] **Step 4: Verify the rendered media properties and decode it fully**
+
+  Run:
+
+  ```bash
+  output=/var/home/jorge/Videos/wolves-directors-cut/wolves-directors-cut-mockup.mp4
+  ffprobe -v error \
+    -show_entries format=duration:stream=codec_type,codec_name,width,height,r_frame_rate,sample_rate,channels \
+    -of default=noprint_wrappers=1 "$output"
+  ffmpeg -v error -i "$output" -f null -
+  ```
+
+  Expected: Duration is 70 seconds (within one frame), video is H.264 at
+  640x360 and 24 fps, audio is AAC at 44.1 kHz stereo, and the complete decode
+  emits no errors.
+
+- [ ] **Step 5: Remove the temporary concat manifest**
+
+  Run:
+
+  ```bash
+  rm /var/tmp/website-agent/wolves-directors-cut-concat.txt
+  ```
+
+  Expected: Only the review artifact remains; no temporary render inputs are
+  left in the source-clip directory.

--- a/docs/superpowers/specs/2026-08-10-wolves-directors-cut-montage-design.md
+++ b/docs/superpowers/specs/2026-08-10-wolves-directors-cut-montage-design.md
@@ -1,0 +1,43 @@
+# Wolves Director's Cut Montage Design
+
+## Scope
+
+Create a local-review-only, 70-second montage from these existing storyboard
+clips, in the listed order:
+
+1. `h-5S82ETKvI_0000-0015.mp4`
+2. `h-5S82ETKvI_0019-0027.mp4`
+3. `h-5S82ETKvI_0030-0055.mp4`
+4. `h-5S82ETKvI_0060-0066.mp4`
+5. `h-5S82ETKvI_0069-0075.mp4`
+6. `h-5S82ETKvI_0082-0088.mp4`
+7. `h-5S82ETKvI_0104-0108.mp4`
+
+The filenames and their embedded original-source timestamps remain unchanged.
+The result is a local mockup only; it does not alter the Wolves website,
+register an asset, or approve a clip for integration.
+
+## Edit
+
+The montage uses a chronological sequence of hard cuts at the existing clip
+boundaries. It adds no titles, overlays, transitions, effects, speed changes,
+or new narrative content. Source audio is removed. The output is a
+640x360, 24 fps H.264 MP4 with an AAC audio stream.
+
+If the owner supplies a separately authorized audio file, its playback begins
+at source timestamp 08:17 and runs for the 70-second montage duration. Until
+that authorization is supplied, the output uses a silent AAC track. The
+mockup process must not download, extract, or use a YouTube recording.
+
+## Alternatives considered
+
+- Beat-synchronized cut points: rejected because it changes the supplied clip
+  boundaries and needs approval against an authorized track.
+- Crossfades: rejected because they soften the intended cuts and create new
+  overlap timing.
+
+## Validation
+
+Confirm the rendered file has a 70-second duration, 640x360 video at 24 fps,
+the seven clips in the requested order, muted source audio, and no visual
+transitions or text.

--- a/docs/superpowers/specs/2026-08-10-wolves-directors-cut-montage-design.md
+++ b/docs/superpowers/specs/2026-08-10-wolves-directors-cut-montage-design.md
@@ -24,10 +24,10 @@ boundaries. It adds no titles, overlays, transitions, effects, speed changes,
 or new narrative content. Source audio is removed. The output is a
 640x360, 24 fps H.264 MP4 with an AAC audio stream.
 
-If the owner supplies a separately authorized audio file, its playback begins
-at source timestamp 08:17 and runs for the 70-second montage duration. Until
-that authorization is supplied, the output uses a silent AAC track. The
-mockup process must not download, extract, or use a YouTube recording.
+The owner authorized the local Wolves remix source
+`Beauty Of The Beast [X3WrCzLIIvk].webm`. Its audio begins at source timestamp
+08:17 and runs for the 70-second montage duration. The mockup process uses
+that existing local source only and does not download media.
 
 ## Alternatives considered
 

--- a/docs/superpowers/specs/2026-08-10-wolves-directors-cut-quality-variants-design.md
+++ b/docs/superpowers/specs/2026-08-10-wolves-directors-cut-quality-variants-design.md
@@ -1,0 +1,25 @@
+# Wolves Director's Cut Quality Variants Design
+
+## Scope
+
+Download the indexed YouTube source `h-5S82ETKvI` at its native 1080p/24 AVC
+quality, then create two local-review derivatives using the approved source
+ranges. Both retain the seven-clip order, hard cuts, 24 fps cadence, and
+owner-authorized audio range. Neither derivative changes the Wolves website or
+registers an asset.
+
+## Outputs
+
+- `wolves-directors-cut-master.mp4`: source-faithful 1920x1080 H.264 master
+  encoded at CRF 14 with the veryslow preset and 192 kb/s AAC. It uses only
+  native 1080p source frames; no synthetic detail is added.
+- `wolves-directors-cut-social-10mb.mp4`: H.264/AAC social version encoded in
+  two passes at 1,000 kb/s video and 160 kb/s audio, scaled to 1280x720 using
+  Lanczos downscaling. Its final size must not exceed 10 MiB (10,485,760
+  bytes).
+
+## Validation
+
+Both outputs must fully decode, have 70-second H.264 video at 24 fps, and
+preserve 48 kHz stereo AAC audio. The master must be 1920x1080; the social
+derivative must be 1280x720 and at or below the stated byte limit.

--- a/src/WolvesApp.vue
+++ b/src/WolvesApp.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { ExperienceManifest } from '@/config/experience-manifest'
 import type { IntroStatusPayload } from '@/data/wolves-intro-sequence'
-import { computed, nextTick, onBeforeUnmount, ref } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref } from 'vue'
 import CinematicLobby from '@/components/wolves/cinematic/CinematicLobby.vue'
 import CinematicStage from '@/components/wolves/cinematic/CinematicStage.vue'
 import MediaWidget from '@/components/wolves/cinematic/MediaWidget.vue'
@@ -294,6 +294,15 @@ async function handleSegmentSeek(ratio: number) {
     stage.value?.seekToRatio(ratio)
   }
 }
+
+onMounted(() => {
+  // Deep-link into the Director's Cut for projection / recording workflows that
+  // need the cut to start without a lobby click. The default front-door behavior
+  // is unchanged when the parameter is absent.
+  if (typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('directors-cut')) {
+    void enterIntro(null, true)
+  }
+})
 
 onBeforeUnmount(() => {
   unmounted = true

--- a/src/components/wolves/WolvesIntroOverlay.vue
+++ b/src/components/wolves/WolvesIntroOverlay.vue
@@ -611,12 +611,24 @@ async function loadAudioTrack(youtubeVideoId: string | undefined) {
   })
 }
 
+/**
+ * How long a background-audio embed may sit at 0s before we conclude the browser
+ * has blocked autoplay (or an ad/pre-roll has stalled) and fall back to wall-clock
+ * pacing. The show is unattended: waiting forever for audio that will never start
+ * is a black frame the audience cannot recover from.
+ */
+const MAX_AUDIO_STALL_SECONDS = 5
+
 function startTextSegment(segment: Extract<IntroVideoSpec, { kind: 'text' }>) {
   stopTextTimer()
   currentTime.value = 0
   activeSegmentDuration.value = segment.duration
   textClockOriginMs = performance.now()
   void loadAudioTrack(segment.audioYoutubeVideoId)
+
+  let lastAudioTime = -1
+  let lastAudioAdvanceMs = textClockOriginMs
+  let audioStalled = false
 
   textTimer = setInterval(() => {
     const now = performance.now()
@@ -625,13 +637,24 @@ function startTextSegment(segment: Extract<IntroVideoSpec, { kind: 'text' }>) {
       textClockOriginMs = now - currentTime.value * 1000
       return
     }
-    // Ad resilience: when a background audio embed exists, cues key off the
-    // audio's real getCurrentTime(). Pre-roll ads hold it at 0 and mid-roll ads
-    // freeze it, so the cold open waits for the music instead of desyncing.
-    if (audioPlayer && typeof audioPlayer.getCurrentTime === 'function') {
-      currentTime.value = audioPlayer.getCurrentTime() ?? 0
+
+    const audioTime = audioPlayer?.getCurrentTime?.() ?? null
+    if (audioTime != null && !audioStalled) {
+      // Ad resilience: when a background audio embed exists, cues key off the
+      // audio's real getCurrentTime(). Pre-roll ads hold it at 0 and mid-roll ads
+      // freeze it, so the cold open waits for the music instead of desyncing.
+      if (audioTime !== lastAudioTime) {
+        lastAudioTime = audioTime
+        lastAudioAdvanceMs = now
+      }
+      else if (audioTime === 0 && (now - lastAudioAdvanceMs) / 1000 > MAX_AUDIO_STALL_SECONDS) {
+        // Audio never left the origin: treat it as blocked and pace by wall clock
+        // so the cold open does not hang forever.
+        audioStalled = true
+      }
     }
-    else {
+
+    if (audioStalled || audioTime == null) {
       // A silent card (the presenter's welcome slide) has no player to read, so it
       // derives elapsed time from a fixed origin. Two rules this encodes the hard
       // way: never assume the interval fired on schedule — a hardcoded `+= 0.2` on
@@ -639,6 +662,11 @@ function startTextSegment(segment: Extract<IntroVideoSpec, { kind: 'text' }>) {
       // played in 29.5s and nobody in the back row finished a paragraph — and never
       // accumulate deltas, which drifts over a card this long.
       currentTime.value = (now - textClockOriginMs) / 1000
+    }
+    else {
+      // Never rewind: if the audio player starts late (e.g. after a blocked-autoplay
+      // delay) the wall clock may already be ahead; snapping back would restart the card.
+      currentTime.value = Math.max(currentTime.value, audioTime)
     }
     // Authored musical fade: ramp the audio down across the excerpt's final
     // seconds so it ends on the phrase's own decay instead of a hard cut. The
@@ -737,10 +765,28 @@ async function loadVideoSegment(segment: Extract<IntroVideoSpec, { kind: 'video'
         activeSegmentDuration.value = activeVideoCutoffDuration(segment) ?? player?.getDuration?.() ?? 0
         segmentDurations.value[sequenceState.value.index] = activeSegmentDuration.value
         stopPolling()
+        let lastVideoTime = -1
+        let lastVideoAdvanceMs = performance.now()
         pollTimer = setInterval(() => {
           currentTime.value = player?.getCurrentTime?.() ?? 0
+          const now = performance.now()
+          if (currentTime.value !== lastVideoTime) {
+            lastVideoTime = currentTime.value
+            lastVideoAdvanceMs = now
+          }
           updateHandoffFade()
-          if (activeVideoCutoffDuration(segment) != null && currentTime.value >= activeSegmentDuration.value && !isPaused.value) {
+          if (activeVideoCutoffDuration(segment) == null || isPaused.value) {
+            return
+          }
+          if (currentTime.value >= activeSegmentDuration.value) {
+            advance()
+            return
+          }
+          // Unattended fallback: if the video never left its opening seconds,
+          // assume autoplay was blocked and advance so the show does not hang.
+          const stalledSeconds = (now - lastVideoAdvanceMs) / 1000
+          const nearStart = currentTime.value <= Math.min(10, activeSegmentDuration.value / 2)
+          if (stalledSeconds > 15 && nearStart) {
             advance()
           }
         }, 200)

--- a/src/data/wolves-intro-sequence.ts
+++ b/src/data/wolves-intro-sequence.ts
@@ -510,77 +510,81 @@ function buildOpeningTitleCardSegment(): IntroTextSegment {
   }
 }
 
+function buildDestinyTrailerSegment(): IntroVideoSpec {
+  return {
+    // The Destiny segment now defaults to the unvoiced source and carries an optional voiced
+    // toggle. Guardian window timings below were re-verified frame-by-frame
+    // against the real embed (Playwright + the YouTube IFrame API, screenshotting every
+    // ~1-2s) per the Wolves content verification checklist, replacing the
+    // original automated hue/brightness pass that had mismatched two of the six windows:
+    // - Bob Killen's Void Warlock (the first purple, a crystalline void-arm close-up) runs
+    //   5-17.5s footage-wise; the whip-pan cut to a Titan Ward of Dawn bubble forming happens
+    //   at ~17.5s (confirmed via 0.5s-resolution frame capture — 17.0s is still clearly the
+    //   Warlock's caped back, 18.5s is already the Titan crouched inside the bubble).
+    // - Kat Cosgrove's plate is deliberately cued ahead of the frame-verified footage cut,
+    //   at 14.5s (explicit user request, 2026-07-18: her plate replaces Bob's with a quick
+    //   fade instead of overlapping). Bob Killen's window is shortened to match (5-14.5s) —
+    //   neither has a `position`, so two simultaneous cues here would stack on top of each
+    //   other instead of rendering side-by-side. Her plate now runs 14.5-24.5s. This is an
+    //   intentional exception to frame-accurate cueing — do not "fix" the boundary back to
+    //   17.5 without a fresh user request.
+    // - Kaslin Fields' Arc Warlock lightning duel runs 40-48s, beginning on her visible
+    //   electric reveal (previously cut off at
+    //   40s, well before the footage itself ends).
+    // - Laura Santamaria's Solar Hunter window (70.5-77s) was already correct.
+    // - Christoph Blecker (Strand, green) and Natali Vlatko (Behemoth Titan, icy blue) share
+    //   the same shot from ~89.5-90s onward, so their windows overlap (85-95s and
+    //   89.5-96s) with `position` anchoring each to its own side of the frame instead of one
+    //   caption overwriting the other. Christoph's plate ends a second before Natali's so
+    //   the two nameplates do not linger together after his shot has settled. His complete leader plate is gold, while its
+    //   trustee label remains authoritative. His title line carries two segments joined the same way
+    //   ("First Among Equals — The North Star"), rendered on one `wolves-guardian-plate-title`
+    //   line with identical styling so both read with equal visual weight. "Uncompromising
+    //   Purity" and "Platinum Member" (added 2026-07-15, the latter with a `blingTitle`
+    //   shimmer) were removed the same day per a follow-up explicit user request to drop back
+    //   to just the original two titles — do not re-add either without a fresh user request.
+    // - Natali Vlatko's title line is "Punch first, document later.", per explicit user request.
+    // - The default unvoiced source (`BV3BZKbpBns`) runs ~124.0s naturally. Real-player frame
+    //   verification (Playwright + `.wolves-intro-overlay-player` screenshots, 0.1s steps)
+    //   showed its own authored black-frame outro beginning at ~119.0s: 118.8s still carries
+    //   the previous bright frame, 119.0s is fully black and stays there through the end card.
+    //   Cut both sources at 118.8s so YouTube's end-screen layer never becomes visible.
+    id: 'wolves-intro',
+    kind: 'video',
+    youtubeVideoId: 'BV3BZKbpBns',
+    alternateYoutubeVideoId: 'BKm0TPqeOjY',
+    alternateYoutubeVideoLabel: 'Ikora voice over',
+    // The source video opens on Bungie's own ESRB "TEEN" rating card (visible ~0-1.5s,
+    // confirmed frame-by-frame), which isn't part of the Guardian content we want to show.
+    // Starting 2s in skips past it entirely without touching any of the cue windows below,
+    // since those are keyed to the video's absolute/native timeline, not this offset.
+    startOffset: 2,
+    // Stop before YouTube's end-screen layer appears over the final source frames.
+    // Destiny dialogue captions are intentionally disabled; the Comic Hero Shots title card remains timed.
+    maxDuration: 118.8,
+    alternateMaxDuration: 118.8,
+    burnedInCaptions: buildDestinyCaptionCues(),
+    overlays: [
+      { text: 'Voidwalker Warlock — Bob Killen — Reconciler of the Plane', start: 5, end: 14.5, trustee: true },
+      { text: 'Sentinel Titan — Kat Cosgrove — Defender Queen of the Lost', start: 14.5, end: 24.5 },
+      { text: 'Stormcaller Warlock — Kaslin Fields — Rage of the Paradox', start: 40, end: 48 },
+      // #nova4ever easter egg: the default "fighting for something greater than themselves" status briefly
+      // glitches out to the hashtag a few times during the 48-70.5 montage, then snaps back.
+      { text: '#nova4ever', start: 52, end: 52.45, nameplateTitle: '#nova4ever', statusOnly: true, glitch: true },
+      { text: '#nova4ever', start: 60.6, end: 61.05, nameplateTitle: '#nova4ever', statusOnly: true, glitch: true },
+      { text: '#nova4ever', start: 68.1, end: 68.55, nameplateTitle: '#nova4ever', statusOnly: true, glitch: true },
+      { text: 'Gunslinger Hunter — Laura Santamaria — The Order of Seven', start: 70.5, end: 77 },
+      { text: 'Broodweaver Warlock — Christoph Blecker — First Among Equals — The North Star', start: 85, end: 95, position: 'left', trustee: true, leader: true },
+      { text: 'Behemoth Titan — Natali Vlatko — Shipwright of Kubernetes', start: 89.5, end: 96, position: 'right', raised: true },
+      { text: 'Follow the path, we\'ve got your back', start: 106.5, end: 118.8, nameplateDetail: 'Legends Sought', nameplateTitle: 'Follow the path, we\'ve got your back', statusOnly: true },
+    ],
+  }
+}
+
 export function buildIntroVideoSequence(): readonly IntroVideoSpec[] {
   return [
     buildOpeningTitleCardSegment(),
-    {
-      // The Destiny segment now defaults to the unvoiced source and carries an optional voiced
-      // toggle. Guardian window timings below were re-verified frame-by-frame
-      // against the real embed (Playwright + the YouTube IFrame API, screenshotting every
-      // ~1-2s) per the Wolves content verification checklist, replacing the
-      // original automated hue/brightness pass that had mismatched two of the six windows:
-      // - Bob Killen's Void Warlock (the first purple, a crystalline void-arm close-up) runs
-      //   5-17.5s footage-wise; the whip-pan cut to a Titan Ward of Dawn bubble forming happens
-      //   at ~17.5s (confirmed via 0.5s-resolution frame capture — 17.0s is still clearly the
-      //   Warlock's caped back, 18.5s is already the Titan crouched inside the bubble).
-      // - Kat Cosgrove's plate is deliberately cued ahead of the frame-verified footage cut,
-      //   at 14.5s (explicit user request, 2026-07-18: her plate replaces Bob's with a quick
-      //   fade instead of overlapping). Bob Killen's window is shortened to match (5-14.5s) —
-      //   neither has a `position`, so two simultaneous cues here would stack on top of each
-      //   other instead of rendering side-by-side. Her plate now runs 14.5-24.5s. This is an
-      //   intentional exception to frame-accurate cueing — do not "fix" the boundary back to
-      //   17.5 without a fresh user request.
-      // - Kaslin Fields' Arc Warlock lightning duel runs 40-48s, beginning on her visible
-      //   electric reveal (previously cut off at
-      //   40s, well before the footage itself ends).
-      // - Laura Santamaria's Solar Hunter window (70.5-77s) was already correct.
-      // - Christoph Blecker (Strand, green) and Natali Vlatko (Behemoth Titan, icy blue) share
-      //   the same shot from ~89.5-90s onward, so their windows overlap (85-95s and
-      //   89.5-96s) with `position` anchoring each to its own side of the frame instead of one
-      //   caption overwriting the other. Christoph's plate ends a second before Natali's so
-      //   the two nameplates do not linger together after his shot has settled. His complete leader plate is gold, while its
-      //   trustee label remains authoritative. His title line carries two segments joined the same way
-      //   ("First Among Equals — The North Star"), rendered on one `wolves-guardian-plate-title`
-      //   line with identical styling so both read with equal visual weight. "Uncompromising
-      //   Purity" and "Platinum Member" (added 2026-07-15, the latter with a `blingTitle`
-      //   shimmer) were removed the same day per a follow-up explicit user request to drop back
-      //   to just the original two titles — do not re-add either without a fresh user request.
-      // - Natali Vlatko's title line is "Punch first, document later.", per explicit user request.
-      // - The default unvoiced source (`BV3BZKbpBns`) runs ~124.0s naturally. Real-player frame
-      //   verification (Playwright + `.wolves-intro-overlay-player` screenshots, 0.1s steps)
-      //   showed its own authored black-frame outro beginning at ~119.0s: 118.8s still carries
-      //   the previous bright frame, 119.0s is fully black and stays there through the end card.
-      //   Cut both sources at 118.8s so YouTube's end-screen layer never becomes visible.
-      id: 'wolves-intro',
-      kind: 'video',
-      youtubeVideoId: 'BV3BZKbpBns',
-      alternateYoutubeVideoId: 'BKm0TPqeOjY',
-      alternateYoutubeVideoLabel: 'Ikora voice over',
-      // The source video opens on Bungie's own ESRB "TEEN" rating card (visible ~0-1.5s,
-      // confirmed frame-by-frame), which isn't part of the Guardian content we want to show.
-      // Starting 2s in skips past it entirely without touching any of the cue windows below,
-      // since those are keyed to the video's absolute/native timeline, not this offset.
-      startOffset: 2,
-      // Stop before YouTube's end-screen layer appears over the final source frames.
-      // Destiny dialogue captions are intentionally disabled; the Comic Hero Shots title card remains timed.
-      maxDuration: 118.8,
-      alternateMaxDuration: 118.8,
-      burnedInCaptions: buildDestinyCaptionCues(),
-      overlays: [
-        { text: 'Voidwalker Warlock — Bob Killen — Reconciler of the Plane', start: 5, end: 14.5, trustee: true },
-        { text: 'Sentinel Titan — Kat Cosgrove — Defender Queen of the Lost', start: 14.5, end: 24.5 },
-        { text: 'Stormcaller Warlock — Kaslin Fields — Rage of the Paradox', start: 40, end: 48 },
-        // #nova4ever easter egg: the default "fighting for something greater than themselves" status briefly
-        // glitches out to the hashtag a few times during the 48-70.5 montage, then snaps back.
-        { text: '#nova4ever', start: 52, end: 52.45, nameplateTitle: '#nova4ever', statusOnly: true, glitch: true },
-        { text: '#nova4ever', start: 60.6, end: 61.05, nameplateTitle: '#nova4ever', statusOnly: true, glitch: true },
-        { text: '#nova4ever', start: 68.1, end: 68.55, nameplateTitle: '#nova4ever', statusOnly: true, glitch: true },
-        { text: 'Gunslinger Hunter — Laura Santamaria — The Order of Seven', start: 70.5, end: 77 },
-        { text: 'Broodweaver Warlock — Christoph Blecker — First Among Equals — The North Star', start: 85, end: 95, position: 'left', trustee: true, leader: true },
-        { text: 'Behemoth Titan — Natali Vlatko — Shipwright of Kubernetes', start: 89.5, end: 96, position: 'right', raised: true },
-        { text: 'Follow the path, we\'ve got your back', start: 106.5, end: 118.8, nameplateDetail: 'Legends Sought', nameplateTitle: 'Follow the path, we\'ve got your back', statusOnly: true },
-      ],
-    },
+    buildDestinyTrailerSegment(),
   ] as const
 }
 
@@ -588,99 +592,107 @@ export function buildIntroVideoSequence(): readonly IntroVideoSpec[] {
  * Director's Cut video sequence: includes the Gayane Ballet Suite (Adagio) prologue cold open
  * before the Destiny 2 trailer sequence.
  */
-export function buildDirectorsCutVideoSequence(): readonly IntroVideoSpec[] {
-  return [
-    buildOpeningTitleCardSegment(),
-    {
-      id: 'wolves-prologue',
-      kind: 'text',
-      duration: 94,
-      audioFadeOutSeconds: 2.5,
-      audioYoutubeVideoId: 'EB3IokHelRk',
-      overlays: [
-        { text: 'A Gardener and a Winnower walked among the stars.', start: 0, end: 5 },
-        {
-          text: `One to spread life,
+function buildPrologueSegment(): IntroVideoSpec {
+  return {
+    id: 'wolves-prologue',
+    kind: 'text',
+    duration: 94,
+    audioFadeOutSeconds: 2.5,
+    audioYoutubeVideoId: 'EB3IokHelRk',
+    overlays: [
+      { text: 'A Gardener and a Winnower walked among the stars.', start: 0, end: 5 },
+      {
+        text: `One to spread life,
 and one to cull the dross
 to shape the Garden of Earth.`,
-          start: 5,
-          end: 13.75,
-          backgroundCrossfade: [
-            {
-              day: 'img/wallpapers/bluefin-06-day.webp',
-              night: 'img/wallpapers/bluefin-06-night.webp',
-            },
-          ],
-          textPosition: 'bottom-right',
-          highlightSubstrings: ['life', 'dross', 'Garden'],
-        },
-        {
-          text: 'One day changed the Garden forever.',
-          start: 13.75,
-          end: 21.5,
-          backgroundImage: 'wolves-intro/bluefin-collapse-night.webp',
-        },
-        {
-          text: 'New Children arose and filled the pattern.',
-          start: 21.5,
-          end: 29.5,
-          emphasis: 'dominant',
-          textPosition: 'bottom',
-          backgroundImage: 'wolves-intro/bluefin-collapse-night.webp',
-        },
-        {
-          text: 'For eons, Maintainer-Guardians cultivated the Garden...',
-          start: 29.5,
-          end: 36.25,
-          backgroundImage: 'wolves-intro/bluefin-collapse-night.webp',
-        },
-        {
-          text: `Until an AI-fueled Society deemed Guardians unnecessary.
+        start: 5,
+        end: 13.75,
+        backgroundCrossfade: [
+          {
+            day: 'img/wallpapers/bluefin-06-day.webp',
+            night: 'img/wallpapers/bluefin-06-night.webp',
+          },
+        ],
+        textPosition: 'bottom-right',
+        highlightSubstrings: ['life', 'dross', 'Garden'],
+      },
+      {
+        text: 'One day changed the Garden forever.',
+        start: 13.75,
+        end: 21.5,
+        backgroundImage: 'wolves-intro/bluefin-collapse-night.webp',
+      },
+      {
+        text: 'New Children arose and filled the pattern.',
+        start: 21.5,
+        end: 29.5,
+        emphasis: 'dominant',
+        textPosition: 'bottom',
+        backgroundImage: 'wolves-intro/bluefin-collapse-night.webp',
+      },
+      {
+        text: 'For eons, Maintainer-Guardians cultivated the Garden...',
+        start: 29.5,
+        end: 36.25,
+        backgroundImage: 'wolves-intro/bluefin-collapse-night.webp',
+      },
+      {
+        text: `Until an AI-fueled Society deemed Guardians unnecessary.
 And then, a threat.`,
-          start: 36.25,
-          end: 45,
-          backgroundImage: 'wolves-intro/bluefin-collapse-night.webp',
-        },
-        {
-          text: 'Others came to claim a bountiful and unprotected Garden.',
-          start: 45,
-          end: 50,
-        },
-        {
-          text: `In the space of a few days,
+        start: 36.25,
+        end: 45,
+        backgroundImage: 'wolves-intro/bluefin-collapse-night.webp',
+      },
+      {
+        text: 'Others came to claim a bountiful and unprotected Garden.',
+        start: 45,
+        end: 50,
+      },
+      {
+        text: `In the space of a few days,
 humanity had lost its future`,
-          start: 50,
-          end: 59.375,
-          emphasis: 'dominant',
-          textPosition: 'bottom',
-          nameplateTitle: 'From the Age of Dinosaurs to the Pinnacle of Humanity',
-        },
-        {
-          text: `For the heart of any race is destroyed
+        start: 50,
+        end: 59.375,
+        emphasis: 'dominant',
+        textPosition: 'bottom',
+        nameplateTitle: 'From the Age of Dinosaurs to the Pinnacle of Humanity',
+      },
+      {
+        text: `For the heart of any race is destroyed
 And its will to survive is utterly Broken`,
-          start: 59.375,
-          end: 65,
-          emphasis: 'dominant',
-          textPosition: 'bottom',
-        },
-        {
-          text: 'When its children are taken from it',
-          start: 65,
-          end: 72.5,
-          textPosition: 'bottom',
-        },
-        {
-          text: `Now, what's left of a proud order fights for survival,
+        start: 59.375,
+        end: 65,
+        emphasis: 'dominant',
+        textPosition: 'bottom',
+      },
+      {
+        text: 'When its children are taken from it',
+        start: 65,
+        end: 72.5,
+        textPosition: 'bottom',
+      },
+      {
+        text: `Now, what's left of a proud order fights for survival,
 surrounded by predators.`,
-          start: 72.5,
-          end: 78.5,
-          emphasis: 'dominant',
-          textPosition: 'bottom',
-          highlightSubstring: 'fights',
-        },
-        { text: 'PROJECT BLUEFIN\nseven days to the wolves', start: 78.5, end: 94, slim: true },
-      ],
-    },
-    ...buildIntroVideoSequence(),
+        start: 72.5,
+        end: 78.5,
+        emphasis: 'dominant',
+        textPosition: 'bottom',
+        highlightSubstring: 'fights',
+      },
+      { text: 'PROJECT BLUEFIN\nseven days to the wolves', start: 78.5, end: 94, slim: true },
+    ],
+  }
+}
+
+/**
+ * Director's Cut video sequence: the Gayane Ballet Suite (Adagio) prologue cold open
+ * followed by the Destiny 2 trailer sequence. The standard intro's silent title-card
+ * quote slide is intentionally omitted from this cut.
+ */
+export function buildDirectorsCutVideoSequence(): readonly IntroVideoSpec[] {
+  return [
+    buildPrologueSegment(),
+    buildDestinyTrailerSegment(),
   ] as const
 }

--- a/src/tests/wolvesApp.test.ts
+++ b/src/tests/wolvesApp.test.ts
@@ -522,4 +522,23 @@ describe('wolvesApp intro status handling', () => {
       ),
     )
   })
+
+  it('auto-starts the Director\'s Cut when the URL carries ?directors-cut', async () => {
+    const store = useCinematicStore()
+    const originalSearch = window.location.search
+    vi.stubGlobal('location', { ...window.location, search: '?directors-cut' })
+
+    shallowMount(WolvesApp, {
+      global: { stubs: stubs() },
+    })
+    await flushPromises()
+
+    expect(store.phase).toBe('intro')
+    // The Director's Cut (prologue + Destiny) is longer than the standard
+    // title-card + Destiny intro, so the live binding confirms the right list
+    // was published.
+    expect(store.sequenceDuration).toBeGreaterThan(180)
+
+    vi.stubGlobal('location', { ...window.location, search: originalSearch })
+  })
 })

--- a/src/tests/wolvesCinematicStores.test.ts
+++ b/src/tests/wolvesCinematicStores.test.ts
@@ -213,7 +213,11 @@ describe('cinematic store', () => {
     // Cut duration, index clamp, and TOTAL readout described the wrong list.
     const standard = buildIntroVideoSequence()
     const directorsCut = buildDirectorsCutVideoSequence()
-    expect(directorsCut.length).toBeGreaterThan(standard.length)
+    // Both sequences end with the same Destiny trailer; they differ in their
+    // opening segment (silent title card vs. Gayane prologue) and runtime.
+    expect(directorsCut[0]?.id).not.toBe(standard[0]?.id)
+    expect(directorsCut[directorsCut.length - 1]?.id)
+      .toBe(standard[standard.length - 1]?.id)
 
     const store = useCinematicStore()
 

--- a/src/tests/wolvesIntroOverlay.test.ts
+++ b/src/tests/wolvesIntroOverlay.test.ts
@@ -285,6 +285,30 @@ describe('wolvesIntroOverlay video segments', () => {
     expect(wrapper.emitted('complete')).toHaveLength(1)
   })
 
+  it('advances when the video is stuck near its opening frame for too long', async () => {
+    const stuckSequence = [
+      { id: 'wolves-intro', kind: 'video' as const, youtubeVideoId: 'BV3BZKbpBns', maxDuration: 120 },
+    ]
+    const wrapper = mountOverlay(WolvesIntroOverlay, { props: { videos: stuckSequence } })
+    await flushPromises()
+    resolveIframeApi()
+    await flushPromises()
+    players[0].triggerReady()
+    await flushPromises()
+
+    // The mock player never reports a time change, simulating a blocked autoplay.
+    expect(players[0].getCurrentTime()).toBe(0)
+
+    await vi.advanceTimersByTimeAsync(15_000)
+    await flushPromises()
+    expect(wrapper.emitted('complete')).toBeUndefined()
+
+    await vi.advanceTimersByTimeAsync(1_500)
+    await flushPromises()
+
+    expect(wrapper.emitted('complete')).toHaveLength(1)
+  })
+
   it('shows the active overlay text cue synced to playback time', async () => {
     const wrapper = mountOverlay(WolvesIntroOverlay, { props: { videos: videoOnlySequence } })
     await flushPromises()
@@ -966,6 +990,29 @@ surrounded by predators`)
 
     await vi.advanceTimersByTimeAsync(1000)
     await flushPromises()
+    await vi.advanceTimersByTimeAsync(1000)
+    await flushPromises()
+
+    expect(wrapper.emitted('complete')).toHaveLength(1)
+  })
+
+  it('falls back to wall-clock pacing when the scored audio embed is blocked at 0s', async () => {
+    const textSequence = [
+      { id: 'wolves-prologue', kind: 'text' as const, duration: 1, audioYoutubeVideoId: 'EB3IokHelRk' },
+    ]
+    const wrapper = mountOverlay(WolvesIntroOverlay, { props: { videos: textSequence } })
+    await flushPromises()
+    resolveIframeApi()
+    await flushPromises()
+
+    // The mock player reports 0s forever, simulating a browser that blocked autoplay.
+    expect(players[0].getCurrentTime()).toBe(0)
+
+    // Stall grace period (5s) plus the authored 1s duration.
+    await vi.advanceTimersByTimeAsync(5000)
+    await flushPromises()
+    expect(wrapper.emitted('complete')).toBeUndefined()
+
     await vi.advanceTimersByTimeAsync(1000)
     await flushPromises()
 


### PR DESCRIPTION
Add wall-clock fallback when scored audio is blocked at 0s, a near-start video-stall fallback for the Destiny trailer, and a ?directors-cut query parameter that auto-starts the Director's Cut. This lets the unattended projection degrade gracefully instead of hanging when browser autoplay policy blocks the prologue or trailer.

- [x] Removed unwanted FFmpeg artifact.
- [x] Added audio-stall wall-clock fallback for scored prologue.
- [x] Added video-stall fallback for Destiny trailer.
- [x] Added ?directors-cut deep-link auto-start.
- [x] Added tests for new fallback and deep-link behavior.
- [x] Ran lint, typecheck, and focused Wolves tests (68 pass).
- [x] Rebuilt production preview and verified Director's Cut reaches cinematic stage.
- [x] Updated wolves-runtime-engineering skill file.

Assisted-by: Kimi K2.7 Code via GitHub Copilot CLI
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>