### PR TITLE
chore(git): enforce worktree cleanup at session close

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,13 @@ handoff artifacts. Do not write session artifacts to `/tmp`.
   timeline, or generated-data references.
 - Stage explicit paths only.
 - Never use `git add .` or `git add -A`.
+- Never reuse a merged or closed PR branch for new work. Move preserved edits
+  to a fresh branch first, then remove the old branch and worktree.
+- A linked worktree must have dirty work or an open PR. A clean worktree with
+  no open PR is stale even when its branch still exists.
+- After every merge and before every handoff, remove the completed worktree and
+  branch, run `git worktree prune`, then run `npm run check:git-hygiene`. A
+  failure blocks completion; do not dismiss it as local housekeeping.
 - Do not use destructive reset or restore commands. To resync local `main`
   after a squash merge — which always diverges, because the squash is not your
   commits — use `git reset --keep upstream/main`. It aborts rather than

--- a/docs/skills/agent-workflow/SKILL.md
+++ b/docs/skills/agent-workflow/SKILL.md
@@ -67,6 +67,20 @@ runtime, or hands work to another agent.
    no page errors or failed module requests; a successful Vite build is not
    sufficient.
 
+9. **Close the git session.** A squash merge does not make the feature branch
+   an ancestor of `main`, so `git branch --merged` cannot identify completed
+   PR branches reliably. After a merge, move any preserved edits to a fresh
+   branch, remove the completed worktree and branch, and prune Git's metadata.
+   Before every handoff, run:
+   ```bash
+   git worktree prune
+   npm run check:git-hygiene
+   ```
+   The checker uses GitHub PR state as well as Git ancestry. It fails on
+   merged/closed PR branches, clean worktrees with no open PR, unpublished
+   clean branches, detached worktrees, and prunable metadata. It never deletes
+   automatically because dirty state and unique commits require human review.
+
 ## Commit attribution
 
 Every AI-authored commit carries both trailers, naming the model and tool
@@ -181,6 +195,8 @@ an API token scoped to the target zone. Do not compensate by deploying a Worker.
 - A local build is treated as proof that route initialization succeeds.
 - A commit authored by an agent is missing the `Assisted-by` or
   `Co-authored-by` trailer.
+- A merged/closed PR branch remains checked out, or a clean worktree has no
+  open PR and is kept "just in case."
 - A PR opened speculatively past a factory gate, or review requested without
   the five evidence items.
 - A fork or feature-branch checkout of `common` cited as the shared contract.
@@ -196,6 +212,8 @@ an API token scoped to the target zone. Do not compensate by deploying a Worker.
 - [ ] Cloudflare changes used `wrangler` and documented permissions.
 - [ ] The exact commit's CI/deploy status is reported.
 - [ ] Every AI-authored commit carries both attribution trailers.
+- [ ] `npm run check:git-hygiene` passes after completed branches/worktrees are
+      removed and `git worktree prune` runs.
 - [ ] Gate stops were signalled (`hold` + `needs-human/agent-ready`) and
       explicitly approved before any PR was opened.
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "update:back-catalogue": "node scripts/update-back-catalogue.js",
     "record:wolves": "node record-wolves.cjs",
     "generate:wolves-qrs": "node scripts/generate-qrs.js",
-    "check:docs": "node scripts/check-docs.mjs"
+    "check:docs": "node scripts/check-docs.mjs",
+    "check:git-hygiene": "node scripts/check-git-hygiene.mjs",
+    "test:git-hygiene": "node scripts/check-git-hygiene.mjs --self-test"
   },
   "dependencies": {
     "@fontsource/michroma": "^5.2.8",

--- a/scripts/check-git-hygiene.mjs
+++ b/scripts/check-git-hygiene.mjs
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+
+/**
+ * Fail closed when a local agent session leaves stale branches or worktrees.
+ *
+ * This is deliberately a checker, not a cleaner. Deleting a worktree is safe
+ * only after its dirty state, unique commits, and PR state have been reviewed.
+ */
+import assert from 'node:assert/strict'
+import { execFileSync, spawnSync } from 'node:child_process'
+import { realpathSync } from 'node:fs'
+
+const BASE_REF = process.env.GIT_HYGIENE_BASE ?? 'upstream/main'
+
+function run(command, args, options = {}) {
+  return execFileSync(command, args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    ...options,
+  }).trim()
+}
+
+function git(args, cwd = process.cwd()) {
+  return run('git', ['-C', cwd, ...args])
+}
+
+export function classifyWorktree({ branch, dirty, ahead, prState, prNumber, prUrl, detached, isBase }) {
+  if (prState === 'MERGED' || prState === 'CLOSED') {
+    return {
+      ok: false,
+      reason: `PR #${prNumber} is ${prState.toLowerCase()} (${prUrl}); move any new edits to a fresh branch, then remove this worktree and branch`,
+    }
+  }
+  if (prState === 'OPEN') {
+    return { ok: true, reason: `active PR #${prNumber} (${prUrl})` }
+  }
+  if (detached) {
+    return dirty
+      ? { ok: true, reason: 'dirty detached worktree (preserved, but attach a branch before handoff)' }
+      : { ok: false, reason: 'clean detached worktree with no open PR' }
+  }
+  if (isBase) {
+    return dirty
+      ? { ok: true, reason: 'base branch has local edits' }
+      : { ok: true, reason: 'base branch' }
+  }
+  if (dirty) {
+    return { ok: true, reason: 'dirty work in progress on a fresh branch' }
+  }
+  if (ahead === 0) {
+    return { ok: false, reason: `clean branch ${branch} has no commits beyond ${BASE_REF} and no open PR` }
+  }
+  return {
+    ok: false,
+    reason: `clean branch ${branch} is ${ahead} commit(s) ahead of ${BASE_REF} but has no open PR`,
+  }
+}
+
+function parseWorktrees(text) {
+  return text.split(/\n{2,}/).filter(Boolean).map((record) => {
+    const fields = new Map()
+    for (const line of record.split('\n')) {
+      const space = line.indexOf(' ')
+      fields.set(space === -1 ? line : line.slice(0, space), space === -1 ? true : line.slice(space + 1))
+    }
+    return {
+      path: fields.get('worktree'),
+      branch: typeof fields.get('branch') === 'string'
+        ? fields.get('branch').replace('refs/heads/', '')
+        : null,
+      detached: fields.has('detached'),
+      prunable: fields.has('prunable'),
+    }
+  })
+}
+
+function repositorySlug(cwd) {
+  const url = git(['remote', 'get-url', 'upstream'], cwd)
+  const match = url.match(/github\.com(?::|\/)([^/]+\/[^/]+?)(?:\.git)?$/)
+  if (!match) {
+    throw new Error(`cannot derive GitHub repository from upstream URL: ${url}`)
+  }
+  return match[1]
+}
+
+function prForBranch(slug, branch, cwd) {
+  if (!branch) {
+    return null
+  }
+  const result = spawnSync('gh', [
+    'pr',
+    'list',
+    '--repo',
+    slug,
+    '--head',
+    branch,
+    '--state',
+    'all',
+    '--limit',
+    '1',
+    '--json',
+    'number,state,url,mergedAt,closedAt',
+  ], { cwd, encoding: 'utf8' })
+  if (result.error?.code === 'ENOENT') {
+    throw new Error('gh is required to distinguish active branches from squash-merged PRs')
+  }
+  if (result.status !== 0) {
+    throw new Error(`gh PR lookup failed for ${branch}: ${result.stderr.trim()}`)
+  }
+  return JSON.parse(result.stdout)[0] ?? null
+}
+
+function selfTest() {
+  const base = { branch: 'feat/x', dirty: false, ahead: 1, prState: null, prNumber: null, prUrl: null, detached: false, isBase: false }
+  assert.equal(classifyWorktree({ ...base, prState: 'OPEN', prNumber: 1 }).ok, true)
+  assert.equal(classifyWorktree({ ...base, dirty: true, ahead: 0 }).ok, true)
+  assert.equal(classifyWorktree({ ...base, ahead: 0 }).ok, false)
+  assert.equal(classifyWorktree(base).ok, false)
+  assert.equal(classifyWorktree({ ...base, prState: 'MERGED', prNumber: 1 }).ok, false)
+  assert.equal(classifyWorktree({ ...base, detached: true, ahead: 0 }).ok, false)
+  assert.equal(classifyWorktree({ ...base, branch: 'main', ahead: 0, isBase: true }).ok, true)
+  console.info('git-hygiene self-test: pass')
+}
+
+function main() {
+  if (process.argv.includes('--self-test')) {
+    selfTest()
+    return
+  }
+
+  const cwd = realpathSync(process.cwd())
+  git(['rev-parse', '--verify', BASE_REF], cwd)
+  const slug = repositorySlug(cwd)
+  const worktrees = parseWorktrees(git(['worktree', 'list', '--porcelain'], cwd))
+  const failures = []
+  const active = []
+
+  const prune = git(['worktree', 'prune', '--dry-run', '--verbose'], cwd)
+  if (prune) {
+    failures.push(`stale worktree metadata:\n${prune}`)
+  }
+
+  for (const worktree of worktrees) {
+    if (worktree.prunable) {
+      failures.push(`${worktree.path}: marked prunable by git`)
+      continue
+    }
+    const dirty = git(['status', '--porcelain'], worktree.path).length > 0
+    const ahead = worktree.branch
+      ? Number(git(['rev-list', '--count', `${BASE_REF}..${worktree.branch}`], cwd))
+      : 0
+    const pr = prForBranch(slug, worktree.branch, cwd)
+    const result = classifyWorktree({
+      branch: worktree.branch,
+      dirty,
+      ahead,
+      prState: pr?.state ?? null,
+      prNumber: pr?.number ?? null,
+      prUrl: pr?.url ?? null,
+      detached: worktree.detached,
+      isBase: worktree.branch === 'main',
+    })
+    const label = `${worktree.path} [${worktree.branch ?? 'detached'}]`
+    ;(result.ok ? active : failures).push(`${label}: ${result.reason}`)
+  }
+
+  console.info('Git hygiene: active work')
+  for (const item of active) {
+    console.info(`  ✓ ${item}`)
+  }
+  if (failures.length) {
+    console.error('\nGit hygiene: FAIL')
+    for (const failure of failures) {
+      console.error(`  ✗ ${failure}`)
+    }
+    console.error('\nResolve each item, run `git worktree prune`, then rerun this check.')
+    process.exitCode = 1
+    return
+  }
+  console.info('\nGit hygiene: pass')
+}
+
+main()


### PR DESCRIPTION
## Summary

- add `npm run check:git-hygiene`, a read-only gate combining local worktree state, Git ancestry, and GitHub PR state
- reject merged/closed PR branches, clean worktrees without open PRs, clean unpublished branches, detached worktrees, and prunable metadata
- preserve dirty fresh WIP and worktrees backed by open PRs
- require cleanup and the gate after every merge and before every handoff

## Why Git ancestry is insufficient

This repository squash-merges PRs. A completed feature branch is therefore not an ancestor of `main`, so `git branch --merged` misses exactly the stale branches agents leave behind. The checker uses `gh pr list` to identify squash-merged and closed branches.

## Safety

The command never removes a branch or worktree automatically. It reports the exact reason and requires explicit review before deletion.

## Validation

- `npm run lint` — pass
- `npm run typecheck` — pass
- `npm run check:docs` — pass (102 Markdown files, 12 skills)
- `npm run test:git-hygiene` — pass
- negative check — correctly rejects this clean branch before its PR exists

CI run: https://github.com/projectbluefin/website/actions/runs/32097544812 — success (test/coverage/build and wolves-movie-flow).

## Merge authority

The owner explicitly granted session-scoped authority earlier in this session: **“commit, push, merge.”**

