### PR TITLE
feat(wolves): audit every authored frame in a browser

### DIFF
--- a/docs/reference/wolves-intro-and-overlay.md
+++ b/docs/reference/wolves-intro-and-overlay.md
@@ -387,13 +387,10 @@ coordination at the conjunction) so every line now holds. No wording changed —
 `wolvesDirectorsCutIntro.test.ts` checks wording independently of lining, on a
 whitespace-normalized form, precisely so re-lining stays a projection decision.
 
-**`emphasis: 'dominant'` is retired from this prologue, and that is a
-measurement rather than a taste.** It renders at 81px, leaving ~1075px of usable
-box, and *every* line of this narration is wider than that at 81px —
-`New Children arose` alone is 1417px. A dominant cue therefore cannot honour its
-own line breaks; it is re-wrapped mid-phrase and the beat lands as a ragged
-block. The 4:41 crescendo cue was the worst case: 13 words at 81px over the
-Collapse crossfade. It now plays at 45px in four authored lines, widest 1048px.
+**`emphasis: 'dominant'` is reserved for the prologue's current crescendo.**
+The 1:49 cue carries 13 words in four authored lines; its desktop treatment
+keeps those lines intact, and the narrow-viewport rule rescales rather than
+blanking them. `wolves-directors-cut-prologue.mjs` measures both layouts.
 
 `DIRECTORS_CUT_MAX_CUE_WORDS` (13) still bounds a cue's total words. It was
 derived from rendered *pixel height* in a 720p frame, so it answers whether a

--- a/docs/reference/wolves-test-harnesses.md
+++ b/docs/reference/wolves-test-harnesses.md
@@ -399,7 +399,12 @@ shipped:
 - **It measures inside the settle predicate**, not in a second call after it. The
   show clock keeps running against a live player, so anything measured after the
   wait resolves is a *different frame* than the one that satisfied it. That drift
-  made a correct cut report the wrong plate on two shots.
+  made a correct cut report the wrong plate on two shots. This works because
+  `page.waitForFunction` resolves to a **`JSHandle` of the truthy value** the
+  predicate returned, so the predicate can return its measurements and the caller
+  reads them with `.jsonValue()` — verified against current Playwright docs
+  (`source: /microsoft/playwright`), which use the same
+  `waitForFunction(...).then(h => h.jsonValue())` shape in their own suite.
 - **A wordless shot is not a shot with no text on screen.** A cue's words outlive
   its shot by a fade, so the previous line is still clearing at the start of the
   next one. Demanding an empty caption stalls past the end of a short window and

--- a/docs/reference/wolves-test-harnesses.md
+++ b/docs/reference/wolves-test-harnesses.md
@@ -371,8 +371,43 @@ node scripts/wolves-cue-at.mjs prologue --all
 It loads the authored modules through Vite's `ssrLoadModule`, so aliases and
 TypeScript resolve exactly as the app resolves them and the answer cannot drift
 from the show. Use it to find the cue, then use a harness or Chromium to judge
-how that cue reads. Registration for further videos is the `VIDEOS` table in the
-script.
+how that cue reads. Registration for further videos is the `VIDEOS` table in
+`scripts/wolves-videos.mjs`, shared with the frame audit below so the two tools
+cannot disagree about what "video 1" means.
+
+## Auditing every shot of a video in a browser
+
+`scripts/wolves-frame-audit.mjs` is the other half: it walks *every* cue of a
+video in Chromium and checks the things a projected show fails on — the intended
+plate is the one on screen, the painting is full-bleed, the caption sits inside
+the frame with at least 24px of clearance, nothing errored and nothing 404ed.
+
+```bash
+npm run dev -- --port 5173 --strictPort
+node scripts/wolves-frame-audit.mjs                             # exits non-zero on any problem
+node scripts/wolves-frame-audit.mjs prologue --viewport 1280x720 --shots
+```
+
+Three things in it are load-bearing, and each is a bug this repository already
+shipped:
+
+- **It settles on two conditions**, the intended caption *and* the intended
+  decoded plate. Either alone samples a crossfade in progress, where the outgoing
+  shot's words sit over the incoming shot's picture. The same probe has reported a
+  collision that did not exist and hidden one that did, depending on which single
+  condition it used.
+- **It measures inside the settle predicate**, not in a second call after it. The
+  show clock keeps running against a live player, so anything measured after the
+  wait resolves is a *different frame* than the one that satisfied it. That drift
+  made a correct cut report the wrong plate on two shots.
+- **A wordless shot is not a shot with no text on screen.** A cue's words outlive
+  its shot by a fade, so the previous line is still clearing at the start of the
+  next one. Demanding an empty caption stalls past the end of a short window and
+  measures the following shot instead.
+
+Only the app's own requests count toward the request check: the embedded player
+beats its telemetry endpoints constantly and they fail for reasons that have
+nothing to do with the show.
 
 `tests/wolves-intro-silence.mjs` covers the other half of that: the cinematic
 buffers are prewarmed *during* the intro, so it watches them through that window

--- a/docs/reference/wolves-test-harnesses.md
+++ b/docs/reference/wolves-test-harnesses.md
@@ -357,14 +357,13 @@ stale unnoticed. All of them take `WOLVES_BASE_URL` (default
 The harnesses above seek and screenshot. That is the right tool for *how it
 looks* and the wrong one for *what is scheduled*: a probe only sees the seconds
 it was told to visit, and a timestamp the owner reported can sit in the gap
-between two of them. That has happened — 263s, 266s and 320s were captured while
-the 281s cue under discussion never rendered at all.
+between two of them. Nearby screenshots are not evidence for the exact second.
 
 `scripts/wolves-cue-at.mjs` answers the scheduling question directly, with no
 browser and no seek:
 
 ```bash
-node scripts/wolves-cue-at.mjs 4:41        # defaults to the prologue
+node scripts/wolves-cue-at.mjs 1:50        # defaults to the prologue
 node scripts/wolves-cue-at.mjs prologue --all
 ```
 
@@ -409,6 +408,13 @@ shipped:
   its shot by a fade, so the previous line is still clearing at the start of the
   next one. Demanding an empty caption stalls past the end of a short window and
   measures the following shot instead.
+- **Full-bleed means painted pixels, not the `<img>` rectangle.** `object-fit:
+  contain` leaves the element at 1280×720 while a 4:3 image paints only 960×720.
+  Derive the painted box from natural dimensions, fit, and object position; the
+  audit's `--self-test` pins both contain and cover geometry.
+- **Page exceptions are independent evidence.** Capture `pageerror` as well as
+  console errors and failed local requests; an uncaught application exception
+  can otherwise leave both network arrays empty and produce a false green.
 
 Only the app's own requests count toward the request check: the embedded player
 beats its telemetry endpoints constantly and they fail for reasons that have

--- a/docs/reference/wolves-video-order.md
+++ b/docs/reference/wolves-video-order.md
@@ -49,15 +49,14 @@ be used to decide whether a video exists.
 ## What is on screen at a timestamp
 
 Do not hand-simulate the mark grid, and do not screenshot nearby seconds and
-infer. Both have failed here: one session probed 263s, 266s and 320s and stepped
-straight over the 281s cue the owner was asking about, then reported the
-timestamp as checked.
+infer. A probe that samples only nearby frames can step over the exact cue the
+owner named and still report the timestamp as checked.
 
 Ask the show:
 
 ```bash
-node scripts/wolves-cue-at.mjs 4:41        # defaults to the prologue
-node scripts/wolves-cue-at.mjs prologue 281
+node scripts/wolves-cue-at.mjs 1:50        # defaults to the prologue
+node scripts/wolves-cue-at.mjs prologue 110
 node scripts/wolves-cue-at.mjs prologue --all
 ```
 
@@ -65,7 +64,7 @@ It loads the authored modules through Vite, so it reads the same data the app
 does and cannot drift from it. It reports the cue window, the exact text, its
 word and line counts, the longest line, the emphasis, and whether the words are
 still up at the second you asked about — a cue's *shot* outlives its *text*, so
-"the shot contains 4:41" and "words are on screen at 4:41" are different
+"the shot contains 1:50" and "words are on screen at 1:50" are different
 questions.
 
 Only the prologue is registered so far. Add a video to the `VIDEOS` table in the

--- a/docs/skills/wolves-content/SKILL.md
+++ b/docs/skills/wolves-content/SKILL.md
@@ -32,22 +32,20 @@ player synchronization, or generated manifests.
 
 ## Resolve the artifact before you audit it
 
-"The first video" is the prologue, and videos 1 and 2 exist only on the
-`wolves-directors-cut` branch. The running order and the branch map are in
-`../../reference/wolves-video-order.md` — read it before opening a file for any
-request naming a video ordinal or a timestamp.
+"The first video" is the Director's Cut prologue. The running order and source
+ownership are in `../../reference/wolves-video-order.md` — read it before
+opening a file for any request naming a video ordinal or a timestamp.
 
 Answer "what is on screen at m:ss" with the show's own data, never by eye:
 
 ```bash
-node scripts/wolves-cue-at.mjs 4:41
+node scripts/wolves-cue-at.mjs 1:50
 ```
 
-Screenshotting the seconds *around* a reported timestamp is not verification: a
-prior session probed 263s, 266s and 320s, never rendered the 281s cue in
-question, and reported it as checked. Quote the cue text in your report. Note
-that a cue's shot outlives its text, so "the shot contains 4:41" and "words are
-on screen at 4:41" are different questions; the tool answers the second.
+Screenshotting the seconds *around* a reported timestamp is not verification.
+Quote the cue text in your report. A cue's shot outlives its text, so "the shot
+contains 1:50" and "words are on screen at 1:50" are different questions; the
+tool answers the second.
 
 ## Red Flags
 

--- a/docs/skills/wolves-runtime-engineering/SKILL.md
+++ b/docs/skills/wolves-runtime-engineering/SKILL.md
@@ -6,6 +6,7 @@ metadata:
     - https://developer.mozilla.org/en-US/docs/Web/CSS/text-wrap (text-wrap balance six-line cap)
   context7-sources:
     - /websites/developers_google_youtube
+    - /microsoft/playwright (waitForFunction resolves to a JSHandle of the truthy value; read with jsonValue)
 ---
 
 # Wolves runtime engineering

--- a/docs/skills/wolves-runtime-engineering/references/red-flags.md
+++ b/docs/skills/wolves-runtime-engineering/references/red-flags.md
@@ -117,8 +117,10 @@ Grouped roughly by surface: boundaries and scheduling, transport and buffers, im
   a live player the show clock keeps running, so the frame measured is not the
   frame that satisfied the wait — a correct cut reported the wrong plate on two
   shots that way. Return the measurements *from* the settle predicate, so the
-  frame checked is the frame that settled. `scripts/wolves-frame-audit.mjs` does
-  this.
+  frame checked is the frame that settled — `page.waitForFunction` resolves to a
+  `JSHandle` of whatever truthy value the predicate returned, so read it with
+  `.jsonValue()` (`source: /microsoft/playwright`).
+  `scripts/wolves-frame-audit.mjs` does this.
 - A probe treats a wordless shot as a shot with no text on screen. A cue's words
   outlive its shot by a fade, so the previous line is still clearing at the start
   of the next one; requiring an empty caption stalls past the end of a short

--- a/docs/skills/wolves-runtime-engineering/references/red-flags.md
+++ b/docs/skills/wolves-runtime-engineering/references/red-flags.md
@@ -113,6 +113,21 @@ Grouped roughly by surface: boundaries and scheduling, transport and buffers, im
 - A base `opacity` below 1 on the painting layer. It reads as "dimming" but it
   is compositing against the black overlay beneath, and any shot whose own
   animation does not override it is silently the haziest frame in the show.
+- A probe settles on its conditions and then measures in a *second* call. Against
+  a live player the show clock keeps running, so the frame measured is not the
+  frame that satisfied the wait — a correct cut reported the wrong plate on two
+  shots that way. Return the measurements *from* the settle predicate, so the
+  frame checked is the frame that settled. `scripts/wolves-frame-audit.mjs` does
+  this.
+- A probe treats a wordless shot as a shot with no text on screen. A cue's words
+  outlive its shot by a fade, so the previous line is still clearing at the start
+  of the next one; requiring an empty caption stalls past the end of a short
+  window and measures the following shot. Require the outgoing text to be gone
+  **or visibly clearing**, not instantly absent.
+- A browser probe counts every failed request as a defect. The embedded player
+  beats its own telemetry endpoints constantly and they fail for reasons that
+  have nothing to do with the show; scope the check to the app's own origin or
+  the real 404 drowns.
 - A closing animation is computed per clock tick. The transport stops publishing
   time in the final `PRE_END_THRESHOLD_S` of a segment and a YouTube clock
   plateaus before that anyway, so `(time - start) / span` freezes the show

--- a/scripts/wolves-cue-at.mjs
+++ b/scripts/wolves-cue-at.mjs
@@ -2,16 +2,15 @@
 /**
  * Answer "what is on screen at m:ss" for a Wolves video, from the real show data.
  *
- * Every previous audit of a timestamp was done by hand-simulating the mark grid, or by
- * screenshotting nearby seconds and hoping. Both fail silently: one session probed 263s,
- * 266s and 320s and stepped straight over the 281s cue the owner was asking about.
+ * Hand-simulating the mark grid and screenshotting nearby seconds both fail silently:
+ * either can step straight over the exact cue the owner named.
  *
  * This loads the authored modules through Vite (so the aliases and TypeScript resolve
  * exactly as the app sees them) and reports the cue whose window contains the timestamp.
  * If it disagrees with the show, the show is what changed — fix the caller, not this.
  *
- *   node scripts/wolves-cue-at.mjs 4:41
- *   node scripts/wolves-cue-at.mjs prologue 281
+ *   node scripts/wolves-cue-at.mjs 1:50
+ *   node scripts/wolves-cue-at.mjs prologue 110
  *   node scripts/wolves-cue-at.mjs prologue --all
  */
 
@@ -21,7 +20,7 @@ import { isKnownVideo, knownVideoNames, resolveVideo } from './wolves-videos.mjs
 
 const ROOT = fileURLToPath(new URL('..', import.meta.url))
 
-/** Accept `281`, `4:41`, or `4m41s`. Timestamps are how the owner reports defects. */
+/** Accept `110`, `1:50`, or `1m50s`. Timestamps are how the owner reports defects. */
 function parseTimestamp(value) {
   const colon = /^(\d+):(\d{1,2}(?:\.\d+)?)$/.exec(value)
   if (colon) {
@@ -100,7 +99,7 @@ async function main() {
   const wantsAll = args.includes('--all')
   const stamp = positional.find(arg => arg !== named && !Number.isNaN(parseTimestamp(arg)))
   if (!wantsAll && stamp == null) {
-    console.error('give a timestamp (4:41 or 281) or --all')
+    console.error('give a timestamp (1:50 or 110) or --all')
     process.exit(1)
   }
 

--- a/scripts/wolves-cue-at.mjs
+++ b/scripts/wolves-cue-at.mjs
@@ -17,20 +17,9 @@
 
 import { fileURLToPath } from 'node:url'
 import { createServer } from 'vite'
+import { isKnownVideo, knownVideoNames, resolveVideo } from './wolves-videos.mjs'
 
 const ROOT = fileURLToPath(new URL('..', import.meta.url))
-
-/** Ordinal running order of the show's videos. Keep in step with docs/reference/wolves-video-order.md. */
-const VIDEOS = {
-  prologue: {
-    ordinal: 1,
-    title: 'The Gardener and the Winnower (scored Gayane prologue)',
-    load: async loadModule => (await loadModule('/src/data/wolves-directors-cut-intro.ts'))
-      .buildDirectorsCutPrologueSegment(),
-  },
-}
-
-const ALIASES = { 1: 'prologue', first: 'prologue', gardener: 'prologue', winnower: 'prologue' }
 
 /** Accept `281`, `4:41`, or `4m41s`. Timestamps are how the owner reports defects. */
 function parseTimestamp(value) {
@@ -68,7 +57,7 @@ function describeCue(cue, at) {
     emphasis: cue.emphasis ?? 'normal',
     position: cue.textPosition ?? 'default',
     image: cue.backgroundImage ?? (cue.backgroundCrossfade ? '(crossfade)' : '(none)'),
-    textUp: at == null ? null : at < holdEnd,
+    textUp: at == null || !cue.text ? null : at < holdEnd,
     holdEnds: cue.textHoldSeconds != null ? formatTimestamp(holdEnd) : '(holds the shot)',
   }
 }
@@ -91,20 +80,25 @@ async function main() {
   const args = process.argv.slice(2)
   if (args.length === 0 || args.includes('--help')) {
     console.info('usage: node scripts/wolves-cue-at.mjs [video] <m:ss | seconds | --all>')
-    console.info(`videos: ${Object.keys(VIDEOS).join(', ')} (default: prologue)`)
+    console.info(`videos: ${knownVideoNames()} (default: prologue)`)
     process.exit(args.length === 0 ? 1 : 0)
   }
 
-  const named = args.find(arg => !arg.startsWith('-') && Number.isNaN(parseTimestamp(arg)))
-  const key = ALIASES[named] ?? named ?? 'prologue'
-  const video = VIDEOS[key]
+  const positional = args.filter(arg => !arg.startsWith('-'))
+
+  // Resolve the video before reading anything as a timestamp: `1` is both a valid
+  // ordinal for the prologue and a valid timestamp, and parsing first makes the
+  // ordinal unreachable.
+  const named = positional.find(arg => isKnownVideo(arg))
+    ?? positional.find(arg => Number.isNaN(parseTimestamp(arg)))
+  const { key, video } = resolveVideo(named)
   if (!video) {
-    console.error(`unknown video "${named}". known: ${Object.keys(VIDEOS).join(', ')}`)
+    console.error(`unknown video "${named}". known: ${knownVideoNames()}`)
     process.exit(1)
   }
 
   const wantsAll = args.includes('--all')
-  const stamp = args.find(arg => !arg.startsWith('-') && !Number.isNaN(parseTimestamp(arg)))
+  const stamp = positional.find(arg => arg !== named && !Number.isNaN(parseTimestamp(arg)))
   if (!wantsAll && stamp == null) {
     console.error('give a timestamp (4:41 or 281) or --all')
     process.exit(1)
@@ -127,7 +121,20 @@ async function main() {
     const cue = cues.find(candidate => at >= candidate.start && at < candidate.end)
     console.info(`at ${formatTimestamp(at)} (${at}s):\n`)
     if (!cue) {
-      console.info('  nothing scheduled — the timestamp is past the end of this video.\n')
+      // Say which kind of gap this is. "Past the end" for a timestamp that falls before
+      // the first shot, or inside a hole in the grid, sends the reader looking for a
+      // missing cue at the wrong end of the video.
+      const first = cues[0]
+      const last = cues[cues.length - 1]
+      if (first && at < first.start) {
+        console.info(`  nothing scheduled — the first shot starts at ${formatTimestamp(first.start)}.\n`)
+      }
+      else if (last && at >= last.end) {
+        console.info(`  nothing scheduled — the last shot ends at ${formatTimestamp(last.end)}.\n`)
+      }
+      else {
+        console.info('  nothing scheduled — the timestamp falls in a gap between shots.\n')
+      }
       return
     }
     print(cue, at)

--- a/scripts/wolves-frame-audit.mjs
+++ b/scripts/wolves-frame-audit.mjs
@@ -68,6 +68,53 @@ function normalise(text) {
   return String(text ?? '').replace(/[^a-z0-9]+/gi, ' ').replace(/\s+/g, ' ').trim().toLowerCase()
 }
 
+function objectPosition(token, free) {
+  if (token === 'left' || token === 'top') {
+    return 0
+  }
+  if (token === 'right' || token === 'bottom') {
+    return free
+  }
+  if (token === 'center') {
+    return free / 2
+  }
+  return free * (Number.parseFloat(token) / 100)
+}
+
+/** The pixels the image actually paints inside its element box. */
+export function paintedBox({ elementBox, naturalWidth, naturalHeight, objectFit, objectPosition: position }) {
+  if (!naturalWidth || !naturalHeight || objectFit === 'fill') {
+    return elementBox
+  }
+  const contain = Math.min(elementBox.width / naturalWidth, elementBox.height / naturalHeight)
+  const scale = objectFit === 'cover'
+    ? Math.max(elementBox.width / naturalWidth, elementBox.height / naturalHeight)
+    : objectFit === 'none'
+      ? 1
+      : objectFit === 'scale-down'
+        ? Math.min(1, contain)
+        : contain
+  const width = naturalWidth * scale
+  const height = naturalHeight * scale
+  const [x = '50%', y = '50%'] = position.split(/\s+/)
+  const left = elementBox.left + objectPosition(x, elementBox.width - width)
+  const top = elementBox.top + objectPosition(y, elementBox.height - height)
+  return { left, top, right: left + width, bottom: top + height, width, height }
+}
+
+function selfTest() {
+  const elementBox = { left: 0, top: 0, right: 1280, bottom: 720, width: 1280, height: 720 }
+  const contained = paintedBox({ elementBox, naturalWidth: 1024, naturalHeight: 768, objectFit: 'contain', objectPosition: '50% 50%' })
+  if (contained.left !== 160 || contained.width !== 960 || contained.height !== 720) {
+    throw new Error(`contain self-test failed: ${JSON.stringify(contained)}`)
+  }
+  const covered = paintedBox({ elementBox, naturalWidth: 1024, naturalHeight: 768, objectFit: 'cover', objectPosition: '50% 50%' })
+  if (covered.left !== 0 || covered.top !== -120 || covered.width !== 1280 || covered.height !== 960) {
+    throw new Error(`cover self-test failed: ${JSON.stringify(covered)}`)
+  }
+  console.info('wolves-frame-audit self-test: pass')
+}
+
 async function loadCues(videoKey) {
   const server = await createServer({
     root: ROOT,
@@ -77,8 +124,10 @@ async function loadCues(videoKey) {
   })
   try {
     const { video } = resolveVideo(videoKey)
-    const segment = await video.load(specifier => server.ssrLoadModule(specifier))
-    return { segment, cues: segment.overlays }
+    const loadModule = specifier => server.ssrLoadModule(specifier)
+    const segment = await video.load(loadModule)
+    const geometry = video.loadGeometry ? await video.loadGeometry(loadModule) : []
+    return { segment, cues: segment.overlays, geometry }
   }
   finally {
     await server.close()
@@ -87,8 +136,12 @@ async function loadCues(videoKey) {
 
 async function main() {
   const args = process.argv.slice(2)
+  if (args.includes('--self-test')) {
+    selfTest()
+    return
+  }
   if (args.includes('--help')) {
-    console.info('usage: node scripts/wolves-frame-audit.mjs [video] [--base URL] [--viewport WxH] [--shots]')
+    console.info('usage: node scripts/wolves-frame-audit.mjs [video] [--base URL] [--viewport WxH] [--shots] [--self-test]')
     console.info(`videos: ${knownVideoNames()} (default: prologue)`)
     process.exit(0)
   }
@@ -105,7 +158,8 @@ async function main() {
   const viewport = parseViewport(flagValue(args, '--viewport')) ?? { width: 1920, height: 1080 }
   const wantsShots = args.includes('--shots')
 
-  const { segment, cues } = await loadCues(key)
+  const { segment, cues, geometry } = await loadCues(key)
+  const expectedGeometry = new Map(geometry.map(record => [record.file, record]))
 
   // Imported lazily so `--help` and a bad argument do not require a browser.
   const { chromium } = await import('playwright')
@@ -113,6 +167,7 @@ async function main() {
   const page = await browser.newPage({ viewport })
 
   const consoleErrors = []
+  const pageErrors = []
   const badRequests = []
   const appOrigin = new URL(baseUrl).origin
   page.on('console', (message) => {
@@ -120,6 +175,7 @@ async function main() {
       consoleErrors.push(message.text())
     }
   })
+  page.on('pageerror', error => pageErrors.push(error.message))
   // Only the app's own requests. The embedded player beats its telemetry endpoints
   // constantly and they fail for reasons that have nothing to do with this show.
   page.on('requestfailed', (request) => {
@@ -135,7 +191,7 @@ async function main() {
 
   const problems = []
   try {
-    await page.goto(`${baseUrl}/wolves/`, { waitUntil: 'domcontentloaded', timeout: 30000 })
+    await page.goto(`${baseUrl}/wolves/experience/`, { waitUntil: 'domcontentloaded', timeout: 30000 })
     await page.getByRole('button', { name: /DIRECTOR'S CUT/i }).click()
     await page.waitForSelector('.wolves-intro-overlay', { state: 'attached', timeout: 20000 })
     await page.waitForFunction(() => typeof window.__wolvesIntro?.seekTo === 'function', null, { timeout: 20000 })
@@ -203,7 +259,9 @@ async function main() {
                   src: decodeURIComponent(image.currentSrc).split('/').pop(),
                   width: image.naturalWidth,
                   height: image.naturalHeight,
-                  box: box(image),
+                  elementBox: box(image),
+                  objectFit: getComputedStyle(image).objectFit,
+                  objectPosition: getComputedStyle(image).objectPosition,
                 },
                 // Report and geometry-check the caption whenever this cue has words — the
                 // predicate above already proved they are the right ones, even mid fade-in.
@@ -243,15 +301,28 @@ async function main() {
         continue
       }
 
-      const painting = shot.image.box
-      const bledOff = Math.abs(painting.left) > 1
-        || Math.abs(painting.top) > 1
-        || Math.abs(painting.width - shot.frame.width) > 1
-        || Math.abs(painting.height - shot.frame.height) > 1
-      if (bledOff) {
+      const painting = paintedBox({
+        elementBox: shot.image.elementBox,
+        naturalWidth: shot.image.width,
+        naturalHeight: shot.image.height,
+        objectFit: shot.image.objectFit,
+        objectPosition: shot.image.objectPosition,
+      })
+      const letterboxed = painting.left > 1
+        || painting.top > 1
+        || painting.right < shot.frame.width - 1
+        || painting.bottom < shot.frame.height - 1
+      if (letterboxed) {
         problems.push(
           `${label}: painting is not full-bleed `
           + `(${Math.round(painting.left)},${Math.round(painting.top)} ${Math.round(painting.width)}x${Math.round(painting.height)})`,
+        )
+      }
+      const ledger = expectedGeometry.get(shot.image.src)
+      if (ledger && (shot.image.width !== ledger.width || shot.image.height !== ledger.height)) {
+        problems.push(
+          `${label}: decoded geometry ${shot.image.width}x${shot.image.height} `
+          + `does not match ledger ${ledger.width}x${ledger.height}`,
         )
       }
       if (shot.caption) {
@@ -281,12 +352,12 @@ async function main() {
 
   const unique = list => [...new Set(list)]
   console.info(`\nduration ${segment.duration}s, ${cues.length} shots checked`)
-  for (const [heading, list] of [['console errors', consoleErrors], ['bad requests', badRequests], ['problems', problems]]) {
+  for (const [heading, list] of [['console errors', consoleErrors], ['page errors', pageErrors], ['bad requests', badRequests], ['problems', problems]]) {
     console.info(`\n${heading}:`)
     console.info(unique(list).length ? unique(list).map(entry => `  ${entry}`).join('\n') : '  (none)')
   }
 
-  process.exit(problems.length || consoleErrors.length || badRequests.length ? 1 : 0)
+  process.exit(problems.length || consoleErrors.length || pageErrors.length || badRequests.length ? 1 : 0)
 }
 
 main().catch((error) => {

--- a/scripts/wolves-frame-audit.mjs
+++ b/scripts/wolves-frame-audit.mjs
@@ -1,0 +1,295 @@
+#!/usr/bin/env node
+/**
+ * Prove a Wolves video's shots reach the screen correctly, in a real browser.
+ *
+ * The unit suites pin the data. They cannot see the screen, and this show has shipped
+ * three defects under a fully green suite: a cascade rule that lost on source order, a
+ * caption bound to the previous shot's geometry, and a rule stranded inside a
+ * `@media (max-width: 640px)` block. Layout, cascade and paint need a browser.
+ *
+ * For every cue it checks the things a projected show actually fails on:
+ *
+ *   - the intended plate is the one on screen, in the intended order
+ *   - the painting is full-bleed, so no letterbox bar appears at projector size
+ *   - the caption sits inside the painting, clear of the frame edge
+ *   - the plate decodes at the geometry the ledger claims
+ *   - nothing errored, and nothing 404ed
+ *
+ * The seek settles on TWO conditions — the intended caption *and* the intended decoded
+ * plate. Either alone samples a crossfade mid-transition, where the outgoing shot's
+ * words sit over the incoming shot's picture; that has produced both a false collision
+ * report and a hidden real one from the same probe.
+ *
+ *   npm run dev -- --port 5173 --strictPort
+ *   node scripts/wolves-frame-audit.mjs
+ *   node scripts/wolves-frame-audit.mjs prologue --base http://localhost:5173
+ *   node scripts/wolves-frame-audit.mjs prologue --viewport 1280x720 --shots
+ *
+ * Exits non-zero if anything is wrong, so it can gate a change.
+ */
+
+/*
+ * innerText, not textContent, throughout the in-page probes below: it is the *rendered*
+ * text, carrying the CSS text-transform and line breaking the audience actually sees.
+ * textContent would assert the source string, which is not what is on the screen.
+ */
+/* eslint-disable unicorn/prefer-dom-node-text-content */
+
+import { fileURLToPath } from 'node:url'
+import { createServer } from 'vite'
+import { isKnownVideo, knownVideoNames, resolveVideo } from './wolves-videos.mjs'
+
+const ROOT = fileURLToPath(new URL('..', import.meta.url))
+
+/** Minimum gap between a caption and the frame edge. Below this it reads as a collision. */
+const EDGE_CLEARANCE_PX = 24
+
+/** How long to wait for a seek to settle on both conditions before calling it stuck. */
+const SETTLE_TIMEOUT_MS = 6000
+const SETTLE_ATTEMPTS = 3
+
+function parseViewport(value) {
+  const match = /^(\d+)x(\d+)$/.exec(value ?? '')
+  return match ? { width: Number(match[1]), height: Number(match[2]) } : null
+}
+
+function flagValue(args, name) {
+  const index = args.indexOf(name)
+  return index === -1 ? null : args[index + 1] ?? null
+}
+
+/** The plate a cue puts on screen. A crossfade shot settles on its night plate. */
+function plateFor(cue) {
+  const image = cue.backgroundImage ?? cue.backgroundCrossfade?.[0]?.night ?? null
+  return image ? image.split('/').pop() : null
+}
+
+function normalise(text) {
+  return String(text ?? '').replace(/[^a-z0-9]+/gi, ' ').replace(/\s+/g, ' ').trim().toLowerCase()
+}
+
+async function loadCues(videoKey) {
+  const server = await createServer({
+    root: ROOT,
+    server: { middlewareMode: true },
+    appType: 'custom',
+    logLevel: 'error',
+  })
+  try {
+    const { video } = resolveVideo(videoKey)
+    const segment = await video.load(specifier => server.ssrLoadModule(specifier))
+    return { segment, cues: segment.overlays }
+  }
+  finally {
+    await server.close()
+  }
+}
+
+async function main() {
+  const args = process.argv.slice(2)
+  if (args.includes('--help')) {
+    console.info('usage: node scripts/wolves-frame-audit.mjs [video] [--base URL] [--viewport WxH] [--shots]')
+    console.info(`videos: ${knownVideoNames()} (default: prologue)`)
+    process.exit(0)
+  }
+
+  const positional = args.filter(arg => !arg.startsWith('-') && arg !== flagValue(args, '--base') && arg !== flagValue(args, '--viewport'))
+  const named = positional.find(arg => isKnownVideo(arg)) ?? positional[0]
+  const { key, video } = resolveVideo(named)
+  if (!video) {
+    console.error(`unknown video "${named}". known: ${knownVideoNames()}`)
+    process.exit(1)
+  }
+
+  const baseUrl = flagValue(args, '--base') ?? 'http://localhost:5173'
+  const viewport = parseViewport(flagValue(args, '--viewport')) ?? { width: 1920, height: 1080 }
+  const wantsShots = args.includes('--shots')
+
+  const { segment, cues } = await loadCues(key)
+
+  // Imported lazily so `--help` and a bad argument do not require a browser.
+  const { chromium } = await import('playwright')
+  const browser = await chromium.launch()
+  const page = await browser.newPage({ viewport })
+
+  const consoleErrors = []
+  const badRequests = []
+  const appOrigin = new URL(baseUrl).origin
+  page.on('console', (message) => {
+    if (message.type() === 'error') {
+      consoleErrors.push(message.text())
+    }
+  })
+  // Only the app's own requests. The embedded player beats its telemetry endpoints
+  // constantly and they fail for reasons that have nothing to do with this show.
+  page.on('requestfailed', (request) => {
+    if (request.url().startsWith(appOrigin)) {
+      badRequests.push(`FAILED ${request.url()}`)
+    }
+  })
+  page.on('response', (response) => {
+    if (response.status() >= 400 && response.url().startsWith(appOrigin)) {
+      badRequests.push(`${response.status()} ${response.url()}`)
+    }
+  })
+
+  const problems = []
+  try {
+    await page.goto(`${baseUrl}/wolves/`, { waitUntil: 'domcontentloaded', timeout: 30000 })
+    await page.getByRole('button', { name: /DIRECTOR'S CUT/i }).click()
+    await page.waitForSelector('.wolves-intro-overlay', { state: 'attached', timeout: 20000 })
+    await page.waitForFunction(() => typeof window.__wolvesIntro?.seekTo === 'function', null, { timeout: 20000 })
+
+    console.info(`\nvideo ${video.ordinal}: ${key} — ${video.title}`)
+    console.info(`${cues.length} shots at ${viewport.width}x${viewport.height}, against ${baseUrl}\n`)
+
+    for (const [index, cue] of cues.entries()) {
+      const label = `${String(index + 1).padStart(2, '0')} @${String(cue.start).padStart(7)}s`
+      const wantPlate = plateFor(cue)
+      const wantText = normalise(cue.text)
+      const mid = cue.start + Math.min(3, (cue.end - cue.start) / 2)
+
+      let shot = null
+      for (let attempt = 0; attempt < SETTLE_ATTEMPTS && !shot; attempt += 1) {
+        // Re-seek each attempt: a slow settle otherwise lets the show clock run on and
+        // hands back a different shot than the one being measured.
+        await page.evaluate(seconds => window.__wolvesIntro.seekTo(seconds), mid)
+        shot = await page
+          .waitForFunction(
+            ({ plate, text }) => {
+              // rendered text: it carries the CSS text-transform and the line breaking the
+              // audience actually sees. textContent would assert the source string instead.
+              const strip = value => String(value ?? '').replace(/[^a-z0-9]+/gi, ' ').replace(/\s+/g, ' ').trim().toLowerCase()
+              const root = document.querySelector('.wolves-intro-overlay')
+              if (!root) {
+                return false
+              }
+              const image = [...root.querySelectorAll('img.wolves-intro-overlay-background')]
+                .find(candidate => candidate.naturalWidth > 0 && Number(getComputedStyle(candidate).opacity) > 0.99)
+              if (!image) {
+                return false
+              }
+              if (plate && !decodeURIComponent(image.currentSrc).endsWith(plate)) {
+                return false
+              }
+              const caption = root.querySelector('.wolves-intro-overlay-text')
+              const captionText = strip(caption?.innerText)
+              const captionOpacity = caption ? Number(getComputedStyle(caption).opacity) : 0
+              if (text) {
+                if (captionText !== text) {
+                  return false
+                }
+              }
+              else {
+                // A wordless shot is not "no text on screen": a cue's words outlive its
+                // shot by a fade, so the previous line is still clearing here. Require it
+                // to be gone or visibly on its way out, not instantly absent — demanding
+                // that stalls past the end of a short window and measures the next shot.
+                if (captionText && captionOpacity > 0.5) {
+                  return false
+                }
+              }
+
+              // Measure here, inside the predicate, rather than in a second call after
+              // it. The show clock keeps running against a live player, so anything
+              // measured after the wait resolves is a different frame than the one that
+              // satisfied it — which is how a probe reports the shot it did not check.
+              const box = (element) => {
+                const rect = element.getBoundingClientRect()
+                return { left: rect.left, top: rect.top, right: rect.right, bottom: rect.bottom, width: rect.width, height: rect.height }
+              }
+              return {
+                image: {
+                  src: decodeURIComponent(image.currentSrc).split('/').pop(),
+                  width: image.naturalWidth,
+                  height: image.naturalHeight,
+                  box: box(image),
+                },
+                // Report and geometry-check the caption whenever this cue has words — the
+                // predicate above already proved they are the right ones, even mid fade-in.
+                // The opacity tolerance belongs only to a wordless shot, where any text is
+                // the previous shot's line on its way out.
+                caption: caption && captionText && (text || captionOpacity > 0.5)
+                  ? { text: caption.innerText.replace(/\s+/g, ' ').trim(), box: box(caption) }
+                  : null,
+                frame: { width: window.innerWidth, height: window.innerHeight },
+              }
+            },
+            { plate: wantPlate, text: wantText },
+            { timeout: SETTLE_TIMEOUT_MS, polling: 200 },
+          )
+          .then(handle => handle.jsonValue())
+          .catch(() => null)
+      }
+
+      if (!shot) {
+        // Report what was actually on screen, so a failure names the frame it found.
+        const found = await page.evaluate(() => {
+          const root = document.querySelector('.wolves-intro-overlay')
+          const image = [...root?.querySelectorAll('img.wolves-intro-overlay-background') ?? []]
+            .map(candidate => ({ element: candidate, opacity: Number(getComputedStyle(candidate).opacity) }))
+            .sort((a, b) => b.opacity - a.opacity)[0]
+            ?.element ?? null
+          const caption = root?.querySelector('.wolves-intro-overlay-text')
+          return {
+            plate: image ? decodeURIComponent(image.currentSrc).split('/').pop() : 'none',
+            text: caption?.innerText.replace(/\s+/g, ' ').trim() || '(wordless)',
+          }
+        })
+        problems.push(`${label}: never settled on ${wantPlate ?? 'its plate'} — found ${found.plate} / "${found.text}"`)
+        if (wantsShots) {
+          console.info(`${label}  UNSETTLED, found ${found.plate}`)
+        }
+        continue
+      }
+
+      const painting = shot.image.box
+      const bledOff = Math.abs(painting.left) > 1
+        || Math.abs(painting.top) > 1
+        || Math.abs(painting.width - shot.frame.width) > 1
+        || Math.abs(painting.height - shot.frame.height) > 1
+      if (bledOff) {
+        problems.push(
+          `${label}: painting is not full-bleed `
+          + `(${Math.round(painting.left)},${Math.round(painting.top)} ${Math.round(painting.width)}x${Math.round(painting.height)})`,
+        )
+      }
+      if (shot.caption) {
+        const caption = shot.caption.box
+        const clearance = Math.min(
+          caption.left - painting.left,
+          painting.right - caption.right,
+          caption.top - painting.top,
+          painting.bottom - caption.bottom,
+        )
+        if (clearance < EDGE_CLEARANCE_PX) {
+          problems.push(`${label}: caption is ${Math.round(clearance)}px from the frame edge, wants >=${EDGE_CLEARANCE_PX}px`)
+        }
+      }
+
+      if (wantsShots) {
+        console.info(
+          `${label}  ${shot.image.width}x${shot.image.height} ${shot.image.src}`
+          + `  |  ${shot.caption?.text || '(wordless)'}`,
+        )
+      }
+    }
+  }
+  finally {
+    await browser.close()
+  }
+
+  const unique = list => [...new Set(list)]
+  console.info(`\nduration ${segment.duration}s, ${cues.length} shots checked`)
+  for (const [heading, list] of [['console errors', consoleErrors], ['bad requests', badRequests], ['problems', problems]]) {
+    console.info(`\n${heading}:`)
+    console.info(unique(list).length ? unique(list).map(entry => `  ${entry}`).join('\n') : '  (none)')
+  }
+
+  process.exit(problems.length || consoleErrors.length || badRequests.length ? 1 : 0)
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/scripts/wolves-videos.mjs
+++ b/scripts/wolves-videos.mjs
@@ -1,0 +1,51 @@
+/**
+ * The show's videos, in running order, and how to load each one's authored data.
+ *
+ * This is the single registry both `wolves-cue-at.mjs` and `wolves-frame-audit.mjs`
+ * resolve against. It exists because the alternative — a second lookup table in the
+ * second tool — is how two tools start disagreeing about what "video 1" means, and
+ * this repository has already lost days to that exact ambiguity.
+ *
+ * Keep it in step with docs/reference/wolves-video-order.md. Add a video here when
+ * its data becomes addressable, rather than growing a private table somewhere else.
+ */
+
+/** Ordinal running order of the show's videos. */
+export const VIDEOS = {
+  prologue: {
+    ordinal: 1,
+    title: 'The Gardener and the Winnower (scored prologue)',
+    load: async loadModule =>
+      (await loadModule('/src/data/wolves-directors-cut-intro.ts')).buildDirectorsCutPrologueSegment(),
+  },
+}
+
+export const ALIASES = { 1: 'prologue', first: 'prologue', gardener: 'prologue', winnower: 'prologue' }
+
+/**
+ * Resolve a caller's name for a video to its registry entry.
+ *
+ * Returns `{ key, video }` so a caller can report the canonical name it resolved to,
+ * rather than echoing back whatever alias the user typed.
+ */
+export function resolveVideo(named) {
+  const key = ALIASES[named] ?? named ?? 'prologue'
+  return { key, video: VIDEOS[key] ?? null }
+}
+
+export function knownVideoNames() {
+  return Object.keys(VIDEOS).join(', ')
+}
+
+/**
+ * Is this argument a video the registry knows?
+ *
+ * Callers need this to resolve a video name *before* they try to read an argument as a
+ * timestamp. Numeric ordinals like `1` are legitimate video names and also parse as
+ * timestamps, so a parse-first parser silently swallows the ordinal and answers about
+ * the default video — which is exactly the class of confident-but-wrong answer these
+ * tools exist to prevent.
+ */
+export function isKnownVideo(named) {
+  return named != null && (Object.hasOwn(ALIASES, named) || Object.hasOwn(VIDEOS, named))
+}

--- a/scripts/wolves-videos.mjs
+++ b/scripts/wolves-videos.mjs
@@ -17,6 +17,14 @@ export const VIDEOS = {
     title: 'The Gardener and the Winnower (scored prologue)',
     load: async loadModule =>
       (await loadModule('/src/data/wolves-directors-cut-intro.ts')).buildDirectorsCutPrologueSegment(),
+    loadGeometry: async (loadModule) => {
+      const artwork = await loadModule('/src/data/wolves-directors-cut-artwork.ts')
+      return artwork.DIRECTORS_CUT_DESTINY_CONCEPTS.map(record => ({
+        file: record.localPath.split('/').pop(),
+        width: record.sourceWidth,
+        height: record.sourceHeight,
+      }))
+    },
   },
 }
 


### PR DESCRIPTION
## Replaces #730

#730 was reviewed and found to include 98 files from superseded #728 despite claiming separation. This branch reapplies only its two genuine tooling commits on current `main`, then fixes the review findings.

## Scope

- one shared video registry for cue and frame tools
- `wolves-cue-at.mjs` resolves ordinals before timestamps and reports leading gaps accurately
- `wolves-frame-audit.mjs` walks every authored cue in Chromium
- current Director prologue examples and source ownership documentation

## Review fixes

- target `/wolves/experience/`, not the retired lobby route
- fail on uncaught `pageerror` events
- measure painted image pixels from natural dimensions, `object-fit`, and object position rather than the `<img>` box
- compare decoded dimensions to the artwork ledger
- self-test 4:3 contain (160px bars) and cover geometry
- update impossible 4:41/281 examples to current 1:50/110 cue
- remove inherited nonexistent scene-renderer scope

## Validation

- `npm run check:docs` — pass
- `npm run lint` — pass
- `npm run typecheck` — pass
- `node scripts/wolves-frame-audit.mjs --self-test` — pass
- 1920×1080 full audit — 16 shots, no console errors, page errors, bad requests, or frame problems
- 1280×720 full audit — 16 shots, no console errors, page errors, bad requests, or frame problems
- `npm run test:gate` — no new failures (baseline 0)
- `npm run build` — pass
- `npm run check:git-hygiene` — pass

Exact-head CI: https://github.com/projectbluefin/website/actions/runs/32103571723 — success (test/coverage/build and wolves-movie-flow).

## Merge authority

The owner requested review and merge of the open PRs in this session and granted session-scoped merge authority.

