### PR TITLE
fix(wolves): replace YouTube chrome with the Wolves transport

### DIFF
--- a/docs/skills/wolves-teaser/SKILL.md
+++ b/docs/skills/wolves-teaser/SKILL.md
@@ -175,19 +175,36 @@ The book box is opaque `rgb(4 10 20)`, with a 4px `#60a5fa` left border,
 
 ## Iframe Geometry
 
-The player is the delivered 16:9 frame, but the iframe is the 1920/804 picture.
-Centre the iframe vertically inside the player so the black bars belong to the
-page.
+The player is the delivered 16:9 frame. Inside it, `.wt-player-frame` is the
+clipped 1920:804 picture aperture. Centre a **16:9 iframe** inside that aperture:
+its height is 134.328% of the aperture, so YouTube's own top and bottom
+letterbox bars fall outside the clipped area. That hides the title/share/logo
+chrome without masking or cropping the film itself.
 
-Do not give the iframe the 16:9 frame. YouTube then letterboxes the source
-itself and paints title/share/logo chrome into those bars, where the delivered
-cut is pure black. Player chrome over the picture fades after playback settles.
+Set `pointer-events: none` on the iframe. Playback belongs to the site's media
+widget; allowing pointer hover over the cross-origin iframe asks YouTube to
+paint chrome again, and the page cannot style it away. YouTube also paints a
+centre play/pause glyph briefly after API playback starts. Keep the opaque
+poster over the iframe for the first 8 seconds (and whenever paused); reveal it
+before the first authored plate at 11 seconds.
 
 `new YT.Player(div, …)` replaces the host div with the iframe. Target the
 resulting iframe through the wrapper's `:deep(iframe)` rule.
 
 YouTube rejects numeric loopback origins. Test at
 `http://projectbluefin.io.localhost:5173/wolves/`, not `localhost`.
+
+## Reuse the Wolves Media Widget
+
+`MediaWidget.vue` is store-backed by default and is also the teaser transport.
+Its optional `artwork`, `elapsed`, `duration`, and `playing` props activate
+external single-track mode without mutating the cinematic store. Keep
+`showSkipControls` true by default for the show and set it false for the teaser.
+The teaser owns play, pause, replay, and ratio seek through the IFrame API.
+
+Do not copy the widget markup or stylesheet into the teaser. A visual copy
+immediately drifts from the show and creates two transport accessibility
+surfaces to maintain.
 
 ## Inline Mark Trap
 
@@ -207,7 +224,7 @@ element can collapse below the available width and wrap unexpectedly.
 | Rationalization | Reality |
 |---|---|
 | "The timing manifest is authoritative, so it is enough." | It has no plate design and no three-picture composition. Read the cards and builder. |
-| "The iframe should be 16:9 because the player is." | That delegates letterboxing to YouTube and puts chrome in the black bars. |
+| "The iframe should match the 1920:804 aperture." | Chrome then paints over the picture. Use a clipped aperture around a centred 16:9 iframe. |
 | "The existing Kubernetes SVG is already available." | It is the blue logo; the authored treatment requires the white symbolic icon. |
 | "A dark scrim makes the words safer." | The owner explicitly removed it. Use the authored glyph halo. |
 | "The helm is just an image; default image CSS is fine." | Preflight makes it block-level and breaks the word. |
@@ -220,7 +237,9 @@ element can collapse below the available width and wrap unexpectedly.
 - Plate type uses Michroma.
 - A plate has a full-card translucent background.
 - The title or *Extinction* wraps only when the helm is present.
-- YouTube chrome occupies the frame's black bars.
+- YouTube chrome occupies the frame's black bars or overlays the picture.
+- A second teaser-only transport copies `MediaWidget` markup or styles.
+- The iframe accepts pointer events.
 - The event title's B/F is recoloured, or the CTA's b/f is blue.
 - Plate timings are adjusted locally rather than re-ported from destiny-vids.
 
@@ -234,8 +253,10 @@ element can collapse below the available width and wrap unexpectedly.
       mismatch means the inline mark is wrapping.
 - [ ] Player is fully above the fold on desktop and mobile.
 - [ ] No horizontal scroll exists at 1920×1080 or 390×844.
-- [ ] The iframe is 1920/804 inside a 16:9 player; the page owns equal black
-      bars above and below.
-- [ ] Playback settles with no YouTube chrome in the black bars.
+- [ ] A 16:9 iframe is centred at 134.328% height inside the clipped 1920:804
+      aperture and has `pointer-events: none`.
+- [ ] Playback, pause, replay, and seek work through the external media-widget
+      mode; the 8-second start/seek cover and paused poster leave no YouTube
+      chrome visible.
 - [ ] `src/tests/wolvesTrailerPlates.test.ts`, lint, typecheck, `test:gate`, and
       build pass.

--- a/docs/superpowers/plans/2026-08-18-wolves-teaser-transport.md
+++ b/docs/superpowers/plans/2026-08-18-wolves-teaser-transport.md
@@ -1,0 +1,46 @@
+# Wolves Teaser Transport Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Crop YouTube chrome out of the teaser and drive playback through the existing Wolves media widget.
+
+**Architecture:** `MediaWidget.vue` gains optional external playback props while preserving its store defaults. `WolvesTeaserApp.vue` supplies trailer state and owns all YouTube API calls. CSS makes a 16:9 iframe taller than and clipped by the 1920:804 picture viewport.
+
+**Tech Stack:** Vue 3, TypeScript, SCSS, YouTube IFrame API, Vitest, Playwright.
+
+## Global Constraints
+
+- Keep the current trailer video id and authored plate schedule unchanged.
+- Preserve existing full-show widget behavior.
+- Use one transport; remove central teaser controls.
+- Keep the complete video above the desktop fold.
+
+---
+
+### Task 1: External playback mode
+
+**Files:**
+- Modify: `src/components/wolves/cinematic/MediaWidget.vue`
+- Test: `src/tests/wolvesMediaWidget.test.ts`
+
+- [ ] Add optional external title, artwork, elapsed, duration, and playing props.
+- [ ] Derive progress/time/play state from external props when supplied and from the cinematic store otherwise.
+- [ ] Add `showSkipControls`, defaulting to true; hide previous/next for the teaser.
+- [ ] Test external rendering and verify existing store-backed tests remain green.
+
+### Task 2: Teaser transport and iframe crop
+
+**Files:**
+- Modify: `src/WolvesTeaserApp.vue`
+- Modify: `docs/skills/wolves-teaser/SKILL.md`
+
+- [ ] Add paused state plus toggle and ratio-seek handlers.
+- [ ] Render `MediaWidget` with trailer state and remove central Watch/Replay controls.
+- [ ] Make the iframe pointer-inert and 16:9 inside the clipped 1920:804 picture viewport.
+- [ ] Record the reusable transport/crop pattern in the teaser skill.
+
+### Task 3: Validate and ship
+
+- [ ] Run focused tests, lint, typecheck, `test:gate`, and build.
+- [ ] Measure iframe, title, video, and widget behavior at 1920×1080 and 390×844.
+- [ ] Commit, push, verify exact-head CI, merge, remove the worktree/branch, and verify production.

--- a/docs/superpowers/specs/2026-08-18-wolves-teaser-transport-design.md
+++ b/docs/superpowers/specs/2026-08-18-wolves-teaser-transport-design.md
@@ -1,0 +1,32 @@
+# Wolves Teaser Transport Design
+
+## Goal
+
+Hide YouTube's title/share/logo chrome and use the existing Wolves music-widget treatment as the teaser's only transport, while keeping **Seven Days to the Wolves** above the video.
+
+## Approved behavior
+
+- The page owns a 16:9 frame and a clipped 1920:804 picture viewport.
+- A 16:9 YouTube iframe is centred inside that picture viewport. YouTube's own letterbox bars—and the chrome painted into them—fall outside the clipped viewport.
+- The iframe receives no pointer events, so hover cannot restore YouTube controls.
+- The opaque poster covers YouTube's transient centre glyph for the first 8 seconds after play/seek and whenever paused; it clears before the first authored plate at 11 seconds.
+- `MediaWidget.vue` remains store-backed by default. Optional external playback props let the teaser provide title, artwork, elapsed time, duration, playing state, and progress without mutating the cinematic store.
+- The teaser widget emits play/pause and seek to `WolvesTeaserApp.vue`.
+- Previous/next controls are hidden for the single trailer.
+- The central Watch/Replay buttons are removed. The poster remains until the widget starts playback.
+- The widget is visible while idle or ended and auto-hides during playback.
+
+## Boundaries
+
+- Do not change the embedded video id or authored plate copy/timing.
+- Do not change `MediaWidget` behavior for the full Wolves experience.
+- Do not add a second widget implementation or duplicate its stylesheet.
+- Preserve title/video bounds: the complete video remains above the 1920×1080 fold and no horizontal scroll appears at 390×844.
+
+## Verification
+
+- Existing `wolvesMediaWidget` tests remain green.
+- New tests pin external title/artwork/time/progress/play state and hidden skip controls.
+- Chromium proves the iframe is 16:9, clipped by the 1920:804 viewport, and pointer-inert.
+- Chromium proves widget play/pause/seek controls the teaser clock.
+- Desktop and mobile bounds remain valid.

--- a/src/WolvesTeaserApp.vue
+++ b/src/WolvesTeaserApp.vue
@@ -3,6 +3,7 @@ import type { YoutubePlayer } from '@/composables/useYoutubeIframeApi'
 import type { ExperienceManifest } from '@/config/experience-manifest'
 import type { TrailerPlate } from '@/data/wolves-trailer-plates'
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import MediaWidget from '@/components/wolves/cinematic/MediaWidget.vue'
 import WolvesBackCatalogue from '@/components/wolves/WolvesBackCatalogue.vue'
 import WolvesTrailerLine from '@/components/wolves/WolvesTrailerLine.vue'
 import { getChromeFreeYoutubePlayerVars, getYoutubePlayerConstructor, loadYoutubeIframeApi } from '@/composables/useYoutubeIframeApi'
@@ -29,9 +30,12 @@ const playerHost = ref<HTMLElement | null>(null)
 let player: YoutubePlayer | null = null
 let clockTimer: ReturnType<typeof setInterval> | null = null
 
-type TrailerPhase = 'idle' | 'playing' | 'ended'
+type TrailerPhase = 'idle' | 'playing' | 'paused' | 'ended'
 const trailerPhase = ref<TrailerPhase>('idle')
 const now = ref(0)
+const videoRevealed = ref(false)
+const YOUTUBE_CHROME_SETTLE_MS = 8000
+let revealTimer: ReturnType<typeof setTimeout> | null = null
 
 const visiblePlates = computed(() => activeTrailerPlates(now.value))
 const plateById = computed(() => new Map(visiblePlates.value.map(plate => [plate.id, plate])))
@@ -71,6 +75,17 @@ function stopClock() {
   }
 }
 
+function hideUntilYoutubeChromeSettles() {
+  videoRevealed.value = false
+  if (revealTimer) {
+    clearTimeout(revealTimer)
+  }
+  revealTimer = setTimeout(() => {
+    videoRevealed.value = true
+    revealTimer = null
+  }, YOUTUBE_CHROME_SETTLE_MS)
+}
+
 function tick() {
   const t = player?.getCurrentTime?.()
   if (typeof t !== 'number') {
@@ -82,6 +97,7 @@ function tick() {
     now.value = TRAILER_DURATION_SECONDS
     player?.pauseVideo?.()
     trailerPhase.value = 'ended'
+    videoRevealed.value = false
     stopClock()
     return
   }
@@ -95,13 +111,46 @@ function startClock() {
 
 function playTrailer() {
   trailerPhase.value = 'playing'
+  hideUntilYoutubeChromeSettles()
   player?.playVideo?.()
   startClock()
+}
+
+function toggleTrailer() {
+  if (trailerPhase.value === 'playing') {
+    player?.pauseVideo?.()
+    trailerPhase.value = 'paused'
+    videoRevealed.value = false
+    if (revealTimer) {
+      clearTimeout(revealTimer)
+      revealTimer = null
+    }
+    stopClock()
+    return
+  }
+  if (trailerPhase.value === 'ended') {
+    replayTrailer()
+    return
+  }
+  playTrailer()
+}
+
+function seekTrailer(ratio: number) {
+  const target = Math.min(Math.max(ratio, 0), 1) * TRAILER_DURATION_SECONDS
+  now.value = target
+  player?.seekTo?.(target, true)
+  if (trailerPhase.value === 'playing') {
+    hideUntilYoutubeChromeSettles()
+  }
+  if (trailerPhase.value === 'ended' && target < TRAILER_DURATION_SECONDS) {
+    trailerPhase.value = 'paused'
+  }
 }
 
 function replayTrailer() {
   now.value = 0
   trailerPhase.value = 'playing'
+  hideUntilYoutubeChromeSettles()
   player?.seekTo?.(0, true)
   player?.playVideo?.()
   startClock()
@@ -146,6 +195,9 @@ onMounted(async () => {
 
 onBeforeUnmount(() => {
   stopClock()
+  if (revealTimer) {
+    clearTimeout(revealTimer)
+  }
   player?.destroy?.()
   player = null
 })
@@ -184,13 +236,9 @@ onBeforeUnmount(() => {
           >
         </div>
 
-        <div v-if="trailerPhase === 'idle'" class="wt-poster">
+        <div v-if="trailerPhase !== 'playing' || !videoRevealed" class="wt-poster">
           <span class="wc-label wt-poster-kicker">TRAILER 1</span>
           <span class="wt-poster-title">SEVEN DAYS TO THE WOLVES</span>
-          <button class="wt-play wc-cta--primary" type="button" @click="playTrailer">
-            <span class="wc-cta-icon" aria-hidden="true">▶</span>
-            Watch the Teaser
-          </button>
         </div>
 
         <div class="wt-overlays" aria-hidden="true">
@@ -271,22 +319,24 @@ onBeforeUnmount(() => {
             </template>
           </div>
         </div>
-
-        <button
-          v-if="trailerPhase === 'ended'"
-          class="wt-play wt-play--replay wc-cta--primary"
-          type="button"
-          @click="replayTrailer"
-        >
-          <span class="wc-cta-icon" aria-hidden="true">↺</span>
-          Watch Again
-        </button>
       </div>
 
       <p class="wt-standfirst">
         <span class="wc-label">SEVEN PARTS · ONE COMMUNITY · ONE DESTINY</span>
         <span class="wc-label wt-standfirst-date">2 NOVEMBER 2026</span>
       </p>
+
+      <MediaWidget
+        title="Trailer 1 — Seven Days to the Wolves"
+        :artwork="heroBackground"
+        :elapsed="now"
+        :duration="TRAILER_DURATION_SECONDS"
+        :playing="trailerPhase === 'playing'"
+        :show-skip-controls="false"
+        :auto-hide="trailerPhase === 'playing'"
+        @toggle-play="toggleTrailer"
+        @seek="seekTrailer"
+      />
     </section>
 
     <WolvesBackCatalogue @launch="openExperience" />
@@ -345,25 +395,29 @@ onBeforeUnmount(() => {
   container-type: inline-size;
 }
 
-/* The iframe is the PICTURE, not the frame: 2.39:1, centred, so the black
-   bars above and below it are ours and are actually black. Given a 16:9 box
-   YouTube letterboxes the source itself and then fills those bars with its own
-   title bar and logo, which the delivered cut does not have. */
+/* The wrapper is the 2.39:1 PICTURE aperture. The iframe inside it is 16:9:
+   YouTube puts its title/share/logo chrome into that iframe's letterbox bars,
+   which fall outside this clipped aperture. Pointer events stay on our widget,
+   so hover can never ask YouTube to paint the chrome again. */
 .wt-player-frame {
   position: absolute;
   left: 0;
   right: 0;
   top: 50%;
+  overflow: hidden;
   transform: translateY(-50%);
   aspect-ratio: 1920 / 804;
 
-  // YT.Player replaces the host div with its iframe in place, so the sizing
-  // rule must target the iframe itself, not a wrapper around it.
+  // YT.Player replaces the host div with the iframe in place. A 16:9 iframe is
+  // 134.328% as tall as this 1920:804 aperture; centring clips both bars.
   :deep(iframe) {
     position: absolute;
-    inset: 0;
+    top: 50%;
+    left: 0;
     width: 100%;
-    height: 100%;
+    height: 134.328%;
+    transform: translateY(-50%);
+    pointer-events: none;
   }
 }
 
@@ -409,8 +463,7 @@ onBeforeUnmount(() => {
   display: flex;
   flex-direction: column;
   align-items: center;
-  // The play button is absolutely centred on the frame; the title stack keeps
-  // to the upper third so the two never share the same space.
+  // Playback belongs to the media widget; this layer is only the poster art.
   justify-content: flex-start;
   padding-top: clamp(1.6rem, 7%, 5rem);
   gap: 1.6rem;
@@ -663,51 +716,6 @@ onBeforeUnmount(() => {
     0 0 16px rgb(37 99 235 / 45%);
 }
 
-.wt-play {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  z-index: 4;
-  display: inline-flex;
-  align-items: center;
-  gap: 1rem;
-  padding: 1.4rem 4.8rem;
-  border: 1px solid var(--wc-gold);
-  font-size: clamp(1.5rem, 1.45vw, 1.8rem);
-  font-weight: 700;
-  letter-spacing: 0.3em;
-  background: var(--wc-gold);
-  color: var(--wc-bg);
-  cursor: pointer;
-  transition:
-    background-color 0.15s ease,
-    color 0.15s ease;
-
-  &:hover,
-  &:focus-visible {
-    background: var(--wc-bg);
-    color: var(--wc-gold);
-  }
-}
-
-.wt-play .wc-cta-icon {
-  display: inline-grid;
-  width: 1.55em;
-  aspect-ratio: 1;
-  place-items: center;
-  background: var(--wc-bg);
-  color: var(--wc-gold);
-  font-size: 0.8em;
-  line-height: 1;
-}
-
-.wt-play:hover .wc-cta-icon,
-.wt-play:focus-visible .wc-cta-icon {
-  background: var(--wc-gold);
-  color: var(--wc-bg);
-}
-
 .wt-page :deep(.wc-back-catalogue) {
   margin-top: 0;
 }
@@ -722,15 +730,8 @@ onBeforeUnmount(() => {
     letter-spacing: 0.12em;
   }
 
-  .wt-play {
-    width: calc(100% - 3rem);
-    max-width: 34rem;
-    justify-content: center;
-    padding-inline: 1.8rem;
-  }
-
-  // The frame is short on a phone; the kicker/title stack does not fit, so the
-  // poster collapses to the play button alone.
+  // The frame is short on a phone; the poster copy stands down and the media
+  // widget remains the one playback control.
   .wt-poster {
     gap: 0.8rem;
   }

--- a/src/components/wolves/cinematic/MediaWidget.vue
+++ b/src/components/wolves/cinematic/MediaWidget.vue
@@ -12,6 +12,12 @@ const props = withDefaults(defineProps<{
   moods?: readonly { id: string, label: string }[]
   activeMoodId?: string
   autoHide?: boolean
+  /** Optional external single-track playback. Omit these to use the store. */
+  artwork?: string
+  elapsed?: number
+  duration?: number
+  playing?: boolean
+  showSkipControls?: boolean
 }>(), {
   showVoiceOverToggle: false,
   voiceOverEnabled: false,
@@ -19,6 +25,11 @@ const props = withDefaults(defineProps<{
   moods: () => [],
   activeMoodId: undefined,
   autoHide: false,
+  artwork: undefined,
+  elapsed: undefined,
+  duration: undefined,
+  playing: undefined,
+  showSkipControls: true,
 })
 
 // The widget is a pure store subscriber: playback intents are emitted upward and
@@ -38,12 +49,14 @@ function handleMoodChange(event: Event) {
 const store = useCinematicStore()
 const base = import.meta.env.BASE_URL
 const mediaTitle = computed(() => props.title ?? store.display.title)
+const externalPlayback = computed(() => props.elapsed !== undefined && props.duration !== undefined)
 const showCatalogueCredit = computed(() =>
-  !props.title && !store.isWolvesPresentation,
+  !externalPlayback.value && !props.title && !store.isWolvesPresentation,
 )
-const artworkSrc = computed(() =>
-  store.display.artwork.startsWith('http') ? store.display.artwork : `${base}${store.display.artwork}`,
-)
+const artworkSrc = computed(() => {
+  const artwork = props.artwork ?? store.display.artwork
+  return artwork.startsWith('http') || artwork.startsWith('/') ? artwork : `${base}${artwork}`
+})
 
 function formatTime(totalSeconds: number): string {
   const seconds = Math.max(0, Math.floor(totalSeconds))
@@ -52,15 +65,23 @@ function formatTime(totalSeconds: number): string {
   return `${minutes}:${rest < 10 ? '0' : ''}${rest}`
 }
 
-const segmentTime = computed(() => `${formatTime(store.segmentElapsed)} / ${formatTime(store.segmentDuration)}`)
-const overallTime = computed(() => `${formatTime(store.overallElapsed)} / ${formatTime(store.overallDuration)}`)
-const segmentPercent = computed(() => Math.round(store.segmentProgress * 100))
+const segmentElapsed = computed(() => externalPlayback.value ? props.elapsed! : store.segmentElapsed)
+const segmentDuration = computed(() => externalPlayback.value ? props.duration! : store.segmentDuration)
+const segmentProgress = computed(() => segmentDuration.value > 0
+  ? Math.min(Math.max(segmentElapsed.value / segmentDuration.value, 0), 1)
+  : 0)
+const overallElapsed = computed(() => externalPlayback.value ? segmentElapsed.value : store.overallElapsed)
+const overallDuration = computed(() => externalPlayback.value ? segmentDuration.value : store.overallDuration)
+const playing = computed(() => props.playing ?? store.playing)
+const segmentTime = computed(() => `${formatTime(segmentElapsed.value)} / ${formatTime(segmentDuration.value)}`)
+const overallTime = computed(() => `${formatTime(overallElapsed.value)} / ${formatTime(overallDuration.value)}`)
+const segmentPercent = computed(() => Math.round(segmentProgress.value * 100))
 const PROGRESS_CELLS = 40
 // Split so the cell array only rebuilds when a cell actually changes. The clock
 // polls ten times a second, but at 40 cells across a segment of several minutes
 // roughly one cell changes every ten seconds; keying the array off the filled
 // count instead of the raw progress lets Vue's computed cache absorb the rest.
-const filledProgressCells = computed(() => Math.round(store.segmentProgress * PROGRESS_CELLS))
+const filledProgressCells = computed(() => Math.round(segmentProgress.value * PROGRESS_CELLS))
 const progressCells = computed(() => {
   const filled = filledProgressCells.value
   return Array.from({ length: PROGRESS_CELLS }, (_, index) => ({
@@ -69,8 +90,8 @@ const progressCells = computed(() => {
   }))
 })
 
-const canPrevious = computed(() => store.widgetCanPrevious)
-const canNext = computed(() => store.widgetCanNext)
+const canPrevious = computed(() => props.showSkipControls && store.widgetCanPrevious)
+const canNext = computed(() => props.showSkipControls && store.widgetCanNext)
 const NOVA_GLITCH_RANGES = [
   [0.7, 0.78],
   [0.79, 0.87],
@@ -124,10 +145,22 @@ function resetAutoHide() {
   }, 3000)
 }
 
+watch(() => props.autoHide, (enabled) => {
+  if (enabled) {
+    resetAutoHide()
+    return
+  }
+  if (autoHideTimer) {
+    clearTimeout(autoHideTimer)
+    autoHideTimer = null
+  }
+  isVisible.value = true
+})
+
 onMounted(() => {
+  window.addEventListener('pointermove', resetAutoHide, { passive: true })
+  window.addEventListener('touchstart', resetAutoHide, { passive: true })
   if (props.autoHide) {
-    window.addEventListener('pointermove', resetAutoHide, { passive: true })
-    window.addEventListener('touchstart', resetAutoHide, { passive: true })
     resetAutoHide()
   }
 })
@@ -150,7 +183,7 @@ function handleSeek(event: MouseEvent) {
 
 function handleSeekKeydown(event: KeyboardEvent) {
   const step = event.shiftKey ? 0.1 : 0.02
-  let ratio = store.segmentProgress
+  let ratio = segmentProgress.value
   if (event.key === 'ArrowRight' || event.key === 'ArrowUp') {
     ratio += step
   }
@@ -259,6 +292,7 @@ function handleVoiceOverChange(event: Event) {
     </div>
     <div class="wc-widget-controls">
       <button
+        v-if="props.showSkipControls"
         class="wc-control"
         type="button"
         aria-label="Previous"
@@ -270,13 +304,14 @@ function handleVoiceOverChange(event: Event) {
       <button
         class="wc-control wc-control--primary"
         type="button"
-        :aria-label="store.playing ? 'Pause' : 'Play'"
+        :aria-label="playing ? 'Pause' : 'Play'"
         @click="emit('togglePlay')"
       >
-        <svg v-if="store.playing" viewBox="0 0 24 24"><path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z" /></svg>
+        <svg v-if="playing" viewBox="0 0 24 24"><path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z" /></svg>
         <svg v-else viewBox="0 0 24 24"><path d="M8 5v14l11-7z" /></svg>
       </button>
       <button
+        v-if="props.showSkipControls"
         class="wc-control"
         type="button"
         aria-label="Next"

--- a/src/tests/wolvesMediaWidget.test.ts
+++ b/src/tests/wolvesMediaWidget.test.ts
@@ -88,6 +88,31 @@ describe('media widget', () => {
     expect(wrapper.get('.wc-track-credit-byline').text()).toBe('By Eleine')
   })
 
+  it('renders external single-track playback without mutating the cinematic store', () => {
+    const store = useCinematicStore()
+    const wrapper = mount(MediaWidget, {
+      props: {
+        title: 'Trailer 1 — Seven Days to the Wolves',
+        artwork: '/poster.webp',
+        elapsed: 55,
+        duration: 110,
+        playing: true,
+        showSkipControls: false,
+      },
+    })
+
+    expect(wrapper.get('.wc-widget-title').text()).toBe('Trailer 1 — Seven Days to the Wolves')
+    expect(wrapper.get('.wc-widget-art').attributes('src')).toBe('/poster.webp')
+    expect(wrapper.text()).toContain('0:55 / 1:50')
+    expect(wrapper.text()).toContain('TOTAL 0:55 / 1:50')
+    expect(wrapper.get('.wc-widget-progress').attributes('aria-valuenow')).toBe('50')
+    expect(wrapper.findAll('.wc-widget-progress-ascii .is-filled')).toHaveLength(20)
+    expect(wrapper.get('button[aria-label="Pause"]').attributes('aria-label')).toBe('Pause')
+    expect(wrapper.find('button[aria-label="Previous"]').exists()).toBe(false)
+    expect(wrapper.find('button[aria-label="Next"]').exists()).toBe(false)
+    expect(store.segmentElapsed).toBe(0)
+  })
+
   it('shows the plain authored title, not a catalogue credit, for the Director\'s Cut', () => {
     const store = useCinematicStore()
     store.loadExperience(WOLVES_DIRECTORS_CUT_EXPERIENCE)

--- a/src/wolves-teaser-main.ts
+++ b/src/wolves-teaser-main.ts
@@ -1,3 +1,4 @@
+import { createPinia } from 'pinia'
 import { createApp } from 'vue'
 import WolvesTeaserApp from './WolvesTeaserApp.vue'
 import '@fontsource/michroma'
@@ -5,4 +6,6 @@ import '@fontsource/share-tech-mono'
 import './style/index.scss'
 import './style/wolves-cinematic.scss'
 
-createApp(WolvesTeaserApp).mount('#app')
+const app = createApp(WolvesTeaserApp)
+app.use(createPinia())
+app.mount('#app')


### PR DESCRIPTION
## Summary

- crop YouTube title/share/logo bars outside the 1920:804 picture aperture
- disable iframe pointer interaction so hover cannot restore cross-origin chrome
- keep the opaque poster over YouTube's transient centre glyph for 8 seconds and whenever paused
- reuse the real `MediaWidget` with optional external single-track state
- remove duplicate central Watch/Replay controls
- drive play, pause, replay, progress, and seek through the auto-hiding Wolves widget

## Direct approval

The owner requested hiding the YouTube overlay, restoring the old-show music widget, and then said: **“just land it I prefer to iterate quickly.”**

## Browser evidence

At 1920×1080 and 390×844:

- player remains above fold
- aperture aspect 2.388; iframe aspect 1.778
- iframe height/aperture ratio 1.343 with both bars clipped
- iframe `pointer-events: none`
- no previous/next buttons
- play advances the real clock
- pause drift is 0
- 50% widget seek lands at 55.01s
- paused poster is visible
- 8.5s playing screenshot has no YouTube chrome
- zero page errors and no horizontal scroll

## Validation

- `wolvesMediaWidget.test.ts` — pass, including external state
- `npm run check:docs` — pass
- `npm run lint` — pass
- `npm run typecheck` — pass
- `npm run test:gate` — no new failures (baseline 0)
- `npm run build` — pass
- `npm run check:git-hygiene` — pass

Exact-head CI: https://github.com/projectbluefin/website/actions/runs/32144913937 — success (test/coverage/build and wolves-movie-flow).

## Merge authority

The owner granted session-scoped merge authority and explicitly requested landing this iteration.

