### PR TITLE
fix(wolves): remove the transparent book artifact

### DIFF
--- a/docs/skills/wolves-teaser/SKILL.md
+++ b/docs/skills/wolves-teaser/SKILL.md
@@ -111,7 +111,8 @@ the letterboxed frame.
 - Day cards use `top: 58%` directly because they are on the full-frame
   wallpaper, not the letterboxed picture.
 - Book anchor `[1030,443]` maps to `left: 53.6%; top: 41%` in the 16:9 frame.
-- The second book anchor is `[1000,470]`.
+- The second book record keeps source anchor `[1000,470]` but its rendered PNG
+  has no alpha pixels; it is timing metadata, not a visible box.
 
 All plate type sizes key off **player width**. Every card clamp resolves to its
 maximum at 1920px. Put `container-type: inline-size` on the player and express
@@ -163,7 +164,7 @@ authored token unless the owner asks to reproduce the render host's fallback.
 | `maintitle-a` | 11.0–15.4 | title only; credits hidden |
 | `maintitle-b` | 15.4–22.6 | credits and sear appear; title must not move |
 | `book-a` | 26.9–33.64 | four-line box at `[1030,443]` |
-| `book-b` | 31.0–34.9 | empty box at `[1000,470]`; overlaps `book-a` |
+| `book-b` | 31.0–34.9 | transparent timing continuation at `[1000,470]`; never render |
 | `daycard-extinction` | 88.8–93.8 | fade in 0.4; fade out 0.5 |
 | `daycard-survival` | 94.4–100.6 | fade in 0.5; fade out 0.6 |
 | `endcard-event` | 102.2–110.02 | title, subtitle, hairline |
@@ -236,6 +237,7 @@ element can collapse below the available width and wrap unexpectedly.
 - Day cards appear over the music video instead of the March wallpaper.
 - Plate type uses Michroma.
 - A plate has a full-card translucent background.
+- An empty `book-b` record renders as a collapsed box.
 - The title or *Extinction* wraps only when the helm is present.
 - YouTube chrome occupies the frame's black bars or overlays the picture.
 - A second teaser-only transport copies `MediaWidget` markup or styles.
@@ -248,7 +250,8 @@ element can collapse below the available width and wrap unexpectedly.
 - [ ] Compare the browser against `renders/trailer-1.mp4` at 16, 29, 91, and
       107 seconds through `window.__wolvesTeaser.seekTo()`.
 - [ ] Main title occupies exactly one computed line-height.
-- [ ] Book box centre is 53.6% / 41% for `book-a`.
+- [ ] Book box centre is 53.6% / 41% for `book-a`; transparent `book-b`
+      produces no `.wt-book` element.
 - [ ] Both day cards report the same vertical centre; only one has a helm, so a
       mismatch means the inline mark is wrapping.
 - [ ] Player is fully above the fold on desktop and mobile.

--- a/src/WolvesTeaserApp.vue
+++ b/src/WolvesTeaserApp.vue
@@ -327,7 +327,7 @@ onBeforeUnmount(() => {
       </p>
 
       <MediaWidget
-        title="Trailer 1 — Seven Days to the Wolves"
+        title="November 2026"
         :artwork="heroBackground"
         :elapsed="now"
         :duration="TRAILER_DURATION_SECONDS"

--- a/src/data/wolves-trailer-plates.ts
+++ b/src/data/wolves-trailer-plates.ts
@@ -135,8 +135,9 @@ export const TRAILER_PLATES: readonly TrailerPlate[] = [
     ],
   },
   {
-    // The box alone, carrying no copy: it keeps the book's printed words
-    // covered as the shot moves on. Empty `lines` is the authored state.
+    // Authored timing continuation with no visible pixels: the rendered
+    // plate_book-b.png has an empty alpha channel. Keep the record for fidelity
+    // to the source manifest, but never turn it into a collapsed empty box.
     id: 'book-b',
     kind: 'bookline',
     start: 31.0,
@@ -194,7 +195,11 @@ export function activeTrailerPlates(timeSeconds: number): TrailerPlate[] {
   if (!Number.isFinite(timeSeconds)) {
     return []
   }
-  return TRAILER_PLATES.filter(plate => timeSeconds >= plate.start && timeSeconds < plate.end)
+  return TRAILER_PLATES.filter(plate =>
+    timeSeconds >= plate.start
+    && timeSeconds < plate.end
+    && !(plate.kind === 'bookline' && plate.lines?.length === 0),
+  )
 }
 
 export type TrailerSegment = 'picture' | 'bridge' | 'endcard'

--- a/src/tests/wolvesTrailerPlates.test.ts
+++ b/src/tests/wolvesTrailerPlates.test.ts
@@ -50,17 +50,15 @@ describe('wolves trailer plates', () => {
     ])
   })
 
-  // The second book plate carries no copy: it is the box alone, keeping the
-  // page covered as the shot moves on. It deliberately overlaps book-a.
-  it('overlaps the two book boxes and gives the second one no copy', () => {
-    expect(activeTrailerPlates(32).map(p => p.id)).toEqual(['book-a', 'book-b'])
-    const [, boxOnly] = activeTrailerPlates(32)
-    expect(boxOnly.lines).toEqual([])
-    expect(activeTrailerPlates(34).map(p => p.id)).toEqual(['book-b'])
-    expect(activeTrailerPlates(34.9)).toEqual([])
+  // The second source record has no alpha pixels. It remains in the manifest
+  // but is not an active visible plate and must never collapse to a tiny box.
+  it('does not render the transparent book timing continuation', () => {
+    expect(activeTrailerPlates(32).map(p => p.id)).toEqual(['book-a'])
+    expect(activeTrailerPlates(34)).toEqual([])
+    expect(TRAILER_PLATES.find(p => p.id === 'book-b')?.lines).toEqual([])
   })
 
-  it('walks each book box to its own anchor in the authoring frame', () => {
+  it('preserves both source anchors in the authoring record', () => {
     expect(TRAILER_PLATES.find(p => p.id === 'book-a')?.anchor).toEqual([1030, 443])
     expect(TRAILER_PLATES.find(p => p.id === 'book-b')?.anchor).toEqual([1000, 470])
   })


### PR DESCRIPTION
## Summary

- rename the teaser media-widget label to **November 2026**
- stop rendering `book-b` as an empty 57×37 box during the book intro
- preserve the `book-b` source record and anchor, but filter it from visible active plates because its rendered PNG has no alpha pixels

## Evidence

- source `plate_book-b.png` alpha bbox: `None` (fully transparent)
- 32s browser probe before: four-line box plus empty 57×37 box
- 32s browser probe after: exactly one four-line box
- widget browser text: `NOVEMBER 2026`
- zero page errors

## Validation

- focused trailer/widget tests — pass
- `npm run check:docs` — pass
- `npm run lint` — pass
- `npm run typecheck` — pass
- `npm run test:gate` — no new failures (baseline 0)
- `npm run build` — pass
- `npm run check:git-hygiene` — pass

Exact-head CI: https://github.com/projectbluefin/website/actions/runs/32146701155 — success (test/coverage/build and wolves-movie-flow).

## Merge authority

The owner requested this iteration in the current merge-authorized session.

