### PR TITLE
fix(wolves): let the title land once on the teaser

### DIFF
--- a/docs/skills/wolves-teaser/SKILL.md
+++ b/docs/skills/wolves-teaser/SKILL.md
@@ -198,6 +198,34 @@ resulting iframe through the wrapper's `:deep(iframe)` rule.
 YouTube rejects numeric loopback origins. Test at
 `http://projectbluefin.io.localhost:5173/wolves/`, not `localhost`.
 
+## The Title Lands Once
+
+The page and the cut both know the film's name, and for a while both said it.
+`.wt-heading` (page `h1`), `.wt-poster-title` (poster overlay) and the authored
+`maintitle` plate each spelled *Seven Days to the Wolves*, so two of them were
+legible together at every measured beat — the `h1` sat above the frame for the
+eleven seconds before the title card, and the card then "revealed" words the
+audience had already read. The page read as glitchy and the reveal did nothing.
+
+A theater darkens before the title hits. The rules that keep it that way:
+
+- **Exactly one surface may carry the film title at any instant.** The poster
+  is a kicker (`TRAILER 1`) and controls only; it does not name the film.
+- **The heading is fully down before the card opens**, never cross-faded with
+  it. A dissolve still puts two copies on screen at once, which is the defect.
+  `TRAILER_HEADING_YIELD_SECONDS` is the lead, and it ends *at* the card's start.
+- **The yield is opacity, never `display` or `v-if`.** The heading keeps its box
+  so the measured viewport budget that holds the whole frame above the fold does
+  not move when the words leave.
+- **The heading does not return mid-picture.** Restoring it when the card closes
+  pops a full-width title back in over a running film. It returns only when the
+  trailer is not playing, where it is page furniture again.
+
+`trailerHeadingOpacity()` owns this and derives its beat from the `maintitle`
+plate's own window, so re-porting the cut moves the heading with the card. The
+invariant is pinned in `wolvesTrailerPlates.test.ts`, which sweeps the whole
+110 s at 0.1 s and asserts the heading and the card are never both legible.
+
 ## Reuse the Wolves Media Widget
 
 `MediaWidget.vue` is store-backed by default and is also the teaser transport.
@@ -244,6 +272,7 @@ element can collapse below the available width and wrap unexpectedly.
 | "A dark scrim makes the words safer." | The owner explicitly removed it. Use the authored glyph halo. |
 | "The helm is just an image; default image CSS is fine." | Preflight makes it block-level and breaks the word. |
 | "The title looks centred." | Measure line count and bounds; visual inspection missed the three-line helm break. |
+| "The page needs its `h1`, so the duplicate title is unavoidable." | Keep the `h1` for page identity and yield it on a timer. Identity and the reveal are not in conflict. |
 
 ## Red Flags
 
@@ -259,6 +288,9 @@ element can collapse below the available width and wrap unexpectedly.
 - Fullscreen targets the iframe, causing the title, overlays, or widget to disappear.
 - Ended state shows the poster or a faded/empty end card instead of the URL.
 - The iframe accepts pointer events.
+- The page heading and the authored title card are legible at the same time, or
+  the poster names the film.
+- The heading is hidden with `display`/`v-if`, moving the frame up the page.
 - The event title's B/F is recoloured, or the CTA's b/f is blue.
 - Plate timings are adjusted locally rather than re-ported from destiny-vids.
 
@@ -266,6 +298,9 @@ element can collapse below the available width and wrap unexpectedly.
 
 - [ ] Compare the browser against `renders/trailer-1.mp4` at 16, 29, 91, and
       107 seconds through `window.__wolvesTeaser.seekTo()`.
+- [ ] Exactly one surface spells the film title at 0, 12, 18, 24, and 107
+      seconds, measured from folded opacity and bounds, not by eye.
+- [ ] The heading's box is unchanged across the yield at 1920×1080 and 390×844.
 - [ ] Main title occupies exactly one computed line-height.
 - [ ] Book box centre is 53.6% / 41% for `book-a`; transparent `book-b`
       produces no `.wt-book` element.

--- a/src/WolvesTeaserApp.vue
+++ b/src/WolvesTeaserApp.vue
@@ -18,6 +18,7 @@ import {
   TRAILER_TITLE_LINE,
   TRAILER_VIDEO_ID,
   trailerBridgeState,
+  trailerHeadingOpacity,
   trailerPlateOpacity,
   trailerSegmentAt,
 } from '@/data/wolves-trailer-plates'
@@ -60,6 +61,11 @@ function opacityOf(id: string): number {
 }
 
 const creditVisible = computed(() => visualTime.value >= TRAILER_CREDIT_JOIN_SECONDS)
+
+// The page heading steps aside before the cut's own main title arrives, so the
+// film's name is only ever on screen once. See trailerHeadingOpacity().
+const headingOpacity = computed(() =>
+  trailerHeadingOpacity(visualTime.value, { playing: trailerPhase.value === 'playing' }))
 
 // The cut leaves the music video at 88.2 s and never returns to it: the day
 // cards and the end card play over the March Bluefin wallpaper at full frame.
@@ -236,9 +242,10 @@ onBeforeUnmount(() => {
 <template>
   <div class="wt-page" :style="{ '--wt-hero-background': `url('${heroBackground}')` }">
     <!-- Keep the film title above the trailer without restoring the old
-         full-height hero that pushed the video below the fold. -->
+         full-height hero that pushed the video below the fold. It yields
+         before the cut's own title card so the title lands once. -->
     <section ref="stageHost" class="wt-stage" aria-label="Official teaser trailer">
-      <h1 class="wt-heading">
+      <h1 class="wt-heading" :style="{ opacity: headingOpacity }">
         Seven Days to the Wolves
       </h1>
       <div class="wt-player wc-plate" data-wolves-trailer>
@@ -272,7 +279,6 @@ onBeforeUnmount(() => {
 
         <div v-if="posterVisible" class="wt-poster">
           <span class="wc-label wt-poster-kicker">TRAILER 1</span>
-          <span class="wt-poster-title">SEVEN DAYS TO THE WOLVES</span>
           <div v-if="trailerPhase === 'idle' || trailerPhase === 'paused'" class="wt-convenience-controls">
             <button class="wt-convenience-play wc-cta--primary" type="button" @click="toggleTrailer">
               <span aria-hidden="true">▶</span>
@@ -437,6 +443,11 @@ onBeforeUnmount(() => {
   line-height: 1.02;
   text-align: center;
   text-transform: uppercase;
+
+  // The yield is a dissolve, not a cut: the heading is already gone by the
+  // time the cut's title card opens. Opacity only — the box stays, so the
+  // frame does not jump up the page when the words leave.
+  transition: opacity 320ms ease;
 }
 
 .wt-player {
@@ -541,14 +552,6 @@ onBeforeUnmount(() => {
 .wt-poster-kicker {
   font-size: clamp(0.9rem, 1vw, 1.2rem);
   letter-spacing: 0.4em;
-}
-
-.wt-poster-title {
-  font-family: var(--wc-font-weyland);
-  font-size: clamp(1.6rem, 3vw, 3.2rem);
-  letter-spacing: 0.2em;
-  color: var(--wc-white);
-  text-align: center;
 }
 
 .wt-convenience-controls {
@@ -859,8 +862,7 @@ onBeforeUnmount(() => {
     letter-spacing: 0.2em;
   }
 
-  .wt-poster-kicker,
-  .wt-poster-title {
+  .wt-poster-kicker {
     display: none;
   }
 }

--- a/src/data/wolves-trailer-plates.ts
+++ b/src/data/wolves-trailer-plates.ts
@@ -256,6 +256,60 @@ export function trailerPlateOpacity(plate: TrailerPlate, timeSeconds: number): n
 }
 
 /**
+ * THE PAGE HEADING YIELDS TO THE PICTURE.
+ *
+ * The teaser page carries the film's name in an `h1` above the frame, and the
+ * cut carries the same four words in its own main-title card at 11.0 s. Both
+ * were on screen at once, so the title card revealed a title the audience had
+ * already been reading for eleven seconds — the reveal had nothing left to
+ * reveal, and the page read as if it were stuttering.
+ *
+ * A theater darkens before the title hits. The heading is therefore fully down
+ * BEFORE the card opens, rather than cross-fading with it: a dissolve would
+ * still put two copies of the title on screen together, which is the defect.
+ * It stays down for the rest of a running picture and returns once the picture
+ * is not playing.
+ *
+ * The heading keeps its box either way; this is an opacity, never a `display`,
+ * so the measured viewport budget that keeps the whole frame above the fold
+ * does not move when it goes.
+ */
+export const TRAILER_HEADING_YIELD_SECONDS = 1.2
+
+/**
+ * The page heading's opacity at a given trailer time. Derived from the
+ * main-title plate's own window, so re-porting the cut moves the heading with
+ * the card instead of stranding a hand-copied beat here.
+ *
+ * `playing` keeps the heading out of the running picture after the card has
+ * closed. Restoring it the instant the card ends would pop a full-width title
+ * back in over a film still in progress — the same class of stutter this fix
+ * exists to remove. It returns whenever the picture is not running (idle,
+ * paused, ended), where it is page furniture again rather than competition.
+ */
+export function trailerHeadingOpacity(
+  timeSeconds: number,
+  options: { playing?: boolean } = {},
+): number {
+  if (!Number.isFinite(timeSeconds) || timeSeconds <= 0) {
+    return 1
+  }
+  const maintitle = TRAILER_PLATES.find(plate => plate.id === 'maintitle')
+  if (!maintitle) {
+    return 1
+  }
+  const yieldStart = maintitle.start - TRAILER_HEADING_YIELD_SECONDS
+  if (timeSeconds <= yieldStart) {
+    return 1
+  }
+  if (timeSeconds >= maintitle.start) {
+    // Down for the card itself, and for the rest of a running picture.
+    return timeSeconds < maintitle.end || options.playing ? 0 : 1
+  }
+  return Math.max(0, 1 - (timeSeconds - yieldStart) / TRAILER_HEADING_YIELD_SECONDS)
+}
+
+/**
  * Split an authored string on its spaced pipes so the divider can be DRAWN as
  * a rule instead of set as a glyph. The copy is not edited: the same
  * characters are on screen, in the same order, and one of them is a rule.

--- a/src/tests/wolvesTrailerPlates.test.ts
+++ b/src/tests/wolvesTrailerPlates.test.ts
@@ -9,11 +9,13 @@ import {
   TRAILER_CREDIT_LINE,
   TRAILER_DURATION_SECONDS,
   TRAILER_ENDCARD_HOLD_SECONDS,
+  TRAILER_HEADING_YIELD_SECONDS,
   TRAILER_PICTURE_END_SECONDS,
   TRAILER_PLATES,
   TRAILER_TITLE_LABEL,
   TRAILER_VIDEO_ID,
   trailerBridgeState,
+  trailerHeadingOpacity,
   trailerPlateOpacity,
   trailerSegmentAt,
 } from '@/data/wolves-trailer-plates'
@@ -38,6 +40,53 @@ describe('wolves trailer plates', () => {
     expect(activeTrailerPlates(11).map(p => p.id)).toEqual(['maintitle'])
     expect(activeTrailerPlates(TRAILER_CREDIT_JOIN_SECONDS).map(p => p.id)).toEqual(['maintitle'])
     expect(activeTrailerPlates(22.6).map(p => p.id)).toEqual([])
+  })
+
+  // The page heading and the film's own title card say the same four words.
+  // Two surfaces spelling the title at once is what broke the reveal: the
+  // audience had already read the words for eleven seconds before the picture
+  // said them. The heading yields, and it is fully down before the card opens.
+  it('takes the page heading down before the film says its own name', () => {
+    const titleStart = TRAILER_PLATES.find(p => p.id === 'maintitle')!.start
+
+    expect(trailerHeadingOpacity(0)).toBe(1)
+    expect(trailerHeadingOpacity(titleStart - TRAILER_HEADING_YIELD_SECONDS)).toBe(1)
+    expect(trailerHeadingOpacity(titleStart)).toBe(0)
+  })
+
+  it('never lets the heading and the title card both carry the title', () => {
+    const maintitle = TRAILER_PLATES.find(p => p.id === 'maintitle')!
+
+    for (let t = 0; t <= TRAILER_DURATION_SECONDS; t += 0.1) {
+      const seconds = Number(t.toFixed(1))
+      const card = activeTrailerPlates(seconds).some(p => p.id === 'maintitle')
+        ? trailerPlateOpacity(maintitle, seconds)
+        : 0
+
+      for (const playing of [false, true]) {
+        const heading = trailerHeadingOpacity(seconds, { playing })
+        expect(Math.min(card, heading), `both titles legible at ${seconds}s (playing=${playing})`).toBe(0)
+      }
+    }
+  })
+
+  it('keeps the heading down for the card and for the running picture', () => {
+    expect(trailerHeadingOpacity(TRAILER_CREDIT_JOIN_SECONDS)).toBe(0)
+    expect(trailerHeadingOpacity(30, { playing: true })).toBe(0)
+    expect(trailerHeadingOpacity(TRAILER_ENDCARD_HOLD_SECONDS, { playing: true })).toBe(0)
+  })
+
+  // Returning it the instant the card closes would pop a full-width title back
+  // in over a film still running; it returns only when nothing is playing.
+  it('gives the heading back once the picture is not running', () => {
+    expect(trailerHeadingOpacity(30)).toBe(1)
+    expect(trailerHeadingOpacity(TRAILER_ENDCARD_HOLD_SECONDS)).toBe(1)
+  })
+
+  // An unstarted clock must leave the page titled; a NaN one must not blank it.
+  it('leaves the heading up when the trailer has not started', () => {
+    expect(trailerHeadingOpacity(Number.NaN)).toBe(1)
+    expect(trailerHeadingOpacity(-5)).toBe(1)
   })
 
   it('shows the four-line book box over the book shot', () => {


### PR DESCRIPTION
## The defect

Three surfaces spelled the film's name on `/wolves/`:

| Surface | Where | When |
|---|---|---|
| `.wt-heading` `<h1>` | page, above the frame | always |
| `.wt-poster-title` | poster overlay, in frame | idle / paused / first 8s |
| `.wt-title` authored plate | inside the picture, the real title card | 11.0–22.6s |

Measured in Chromium at 1920×1080, **two were legible together at every beat**. The title card therefore "revealed" words the audience had already been reading for eleven seconds, and the page read as if it were stuttering.

## The change

A theater darkens before the title hits. `trailerHeadingOpacity()` takes the heading fully down **before** the card opens rather than cross-fading with it — a dissolve still puts two copies of the title on screen, which is the defect — and derives its beat from the `maintitle` plate's own window, so re-porting the cut moves the heading with the card.

- The yield is **opacity only**. The heading keeps its box, so the viewport budget from #741 that holds the whole frame above the fold does not move.
- The heading does not return mid-picture, where a full-width title popping back in over a running film would be the same stutter again. It returns once nothing is playing.
- The poster keeps its `TRAILER 1` kicker and no longer names the film; dead CSS removed.

`#741` deliberately added that `h1`, so this was confirmed with the owner before the edit rather than silently reverted.

## Verification

Browser-measured from folded opacity and bounds, not by eye, at 1920×1080 and 390×844:

- exactly one title surface at 0 / 24 / 91 / 107s, none doubled at 12 / 18s
- heading box unchanged across the yield (no layout shift), player above the fold, no horizontal scroll

`wolvesTrailerPlates.test.ts` sweeps all 110s at 0.1s and asserts the heading and the card are never both legible. `lint`, `typecheck`, `test:gate` (no new failures) and `build` pass.

Skill doc `docs/skills/wolves-teaser/SKILL.md` updated in the same commit.

Assisted-by: Claude Opus 5 via GitHub Copilot CLI