### PR TITLE
fix(wolves): stop the day/night wallpaper fading to NaN in albums

### DIFF
--- a/docs/reference/wolves-slide-scheduling.md
+++ b/docs/reference/wolves-slide-scheduling.md
@@ -179,6 +179,50 @@ slide without repeating` is **flaky on `main` too**: it allows 250ms for a
 decode-gated crossfade of a large photo and fails roughly a third of the time on
 either branch. Measure over several runs before blaming a change for it.
 
+## The day/night fade needs a window the album actually has
+
+The night half of a `daynight` wallpaper dissolves over its own slide window:
+`(playlistCurrentTime - startTime) / duration`. Only the Track 0 timeline
+authors `startTime` and `duration`. `laterTrackPhotos` and `mixedPhotos` are
+plain photo records that carry neither, and `backCatalogueCuratedPhotos` does
+not filter day/night art out — it excludes `/people/` and `.gif`, and the
+wallpapers are showcase art. So the same wallpaper that fades correctly in the
+show reaches a catalogue album with `startTime === undefined`, the expression
+evaluates to `NaN`, and Vue emits `opacity: NaN`. That is an invalid
+declaration, so the browser drops it and the night half stays at its stylesheet
+value: the wallpaper stops changing instead of turning.
+
+A `NaN` here is silent in every way that normally catches a defect. It throws
+nothing, logs nothing, and passes any test that only walks the clock — the fade
+is evaluated for the slide **in a buffer**, so a walk across an ~800-slide pool
+can miss every day/night record and prove nothing. Put one on the stage
+(`vm.photoA = <daynight slide>`) and assert `Number.isFinite`.
+
+Outside the authored timeline a slide's window is the same hold the deck
+indexes on, so `daynightNightOpacity()` derives the fade from
+`standardSlideHold` and falls back to `slideIndex * hold`. `activeFlickrIndex`
+reads that same computed: if the deck and the fade disagree about the hold, the
+wallpaper dissolves against a window the deck is not using.
+
+## Albums borrow the Wolves manifest's tempo by index
+
+`currentTrack` resolves the Wolves show by **identity** (`trackId`), which is
+correct and load-bearing. Its fallback is `manifest.tracks[trackIndex]`, and
+that fallback is what every other album gets — so an unrelated album's track 3
+is paced by the BPM and `phraseBeats` of *Wolves* track 3, which is the only
+manifest ever loaded. It is clamped to 5.5–11.5 s by `laterTrackSlideHold`, so
+it degrades to a plausible-looking hold rather than an obvious break.
+
+Two consequences worth knowing before touching slide pacing:
+
+- Album slide pacing is not derived from the album. It is a foreign tempo.
+- `manifest` loads asynchronously, so `currentTrack` is null until it lands.
+  The hold therefore changes from the `[7, 8, 10]` fallback to the BPM-derived
+  value mid-track, and `activeFlickrIndex` is `floor(time / hold)` — a hold
+  that changes under a running clock moves the index discontinuously. That is a
+  one-time jump per run, not a steady drift, which is exactly the kind of
+  symptom that gets reported as "it skipped" and then fails to reproduce.
+
 ## WolvesComicReader serves more than Wolves
 
 `WolvesComicReader.vue` drives three different shows and only one is the

--- a/src/components/wolves/WolvesComicReader.vue
+++ b/src/components/wolves/WolvesComicReader.vue
@@ -889,6 +889,13 @@ const laterTrackSlideHold = computed(() => {
   return [7, 8, 10][trackIndex % 3]
 })
 
+/**
+ * The hold every non-timeline slide runs on. `activeFlickrIndex` and the
+ * day/night fade must read the same value, or the wallpaper dissolves against
+ * a window the deck is not actually using.
+ */
+const standardSlideHold = computed(() => laterTrackSlideHold.value ?? 7)
+
 const currentSlideTransitionDuration = computed(() => {
   if ((props.trackIndex ?? 0) > 0) {
     const hold = laterTrackSlideHold.value ?? 7
@@ -903,27 +910,35 @@ const currentSlideTransitionDuration = computed(() => {
   return Math.min(crossfadeCap, slide.duration * 300)
 })
 
-const daynightNightOpacityA = computed(() => {
-  const slide = photoA.value
+/**
+ * The night half's dissolve across a day/night wallpaper's own window.
+ *
+ * Only the Track 0 timeline authors `startTime` and `duration`. The
+ * back-catalogue pools are plain photo records, and `backCatalogueCuratedPhotos`
+ * does not filter day/night art out — so the same wallpaper reaches an album
+ * with neither field, `curTime - undefined` is NaN, and the binding emitted an
+ * invalid `opacity: NaN` that the browser drops. The night half then stranded
+ * at its stylesheet value instead of dissolving, and the wallpaper stopped
+ * changing. Outside the authored timeline the slide's window is the same hold
+ * the deck indexes on, so the fade is derived from that.
+ */
+function daynightNightOpacity(slide: any, slideIndex: number): number {
   if (!slide || slide.type !== 'daynight') {
     return 0
   }
-  const curTime = props.playlistCurrentTime ?? 0
-  const elapsed = curTime - slide.startTime
-  const ratio = Math.min(1.0, Math.max(0.0, elapsed / slide.duration))
-  return ratio
-})
+  const duration = slide.duration ?? standardSlideHold.value
+  const startTime = slide.startTime ?? Math.max(0, slideIndex) * standardSlideHold.value
+  if (!(duration > 0)) {
+    return 0
+  }
+  const elapsed = (props.playlistCurrentTime ?? 0) - startTime
+  const ratio = elapsed / duration
+  return Number.isFinite(ratio) ? Math.min(1.0, Math.max(0.0, ratio)) : 0
+}
 
-const daynightNightOpacityB = computed(() => {
-  const slide = photoB.value
-  if (!slide || slide.type !== 'daynight') {
-    return 0
-  }
-  const curTime = props.playlistCurrentTime ?? 0
-  const elapsed = curTime - slide.startTime
-  const ratio = Math.min(1.0, Math.max(0.0, elapsed / slide.duration))
-  return ratio
-})
+const daynightNightOpacityA = computed(() => daynightNightOpacity(photoA.value, slideAIndex.value))
+
+const daynightNightOpacityB = computed(() => daynightNightOpacity(photoB.value, slideBIndex.value))
 
 const activeTimelineSlideIndex = computed(() => {
   if (trackZeroSlides.value.length === 0) {
@@ -986,7 +1001,7 @@ const activeFlickrIndex = computed(() => {
   if (props.playlistCurrentTime === undefined) {
     return 0
   }
-  const standardHold = laterTrackSlideHold.value ?? 7
+  const standardHold = standardSlideHold.value
   const hasFeaturedOpening = isWolvesExperience.value
     && props.trackIndex === ghostsInTheMistOpeningSlide.trackIndex
     && laterTrackPhotos.value[0]?.id === ghostsInTheMistOpeningSlide.photoId

--- a/src/tests/wolvesComicReader.test.ts
+++ b/src/tests/wolvesComicReader.test.ts
@@ -1985,3 +1985,50 @@ describe('showcase slide predicate', () => {
     expect(slideAspectFromNaturalSize(3000, 0)).toBeNull()
   })
 })
+
+// The day/night wallpapers carry their fade on a timeline: the night half's
+// opacity is (currentTime - slide.startTime) / slide.duration. Only Track 0
+// builds slides with `startTime` and `duration`. The back-catalogue pools are
+// plain photo records without them, and `backCatalogueCuratedPhotos` does not
+// filter day/night art out — so the same wallpaper that fades correctly in the
+// show reaches a catalogue album with `startTime === undefined`, and the fade
+// evaluates to NaN. An NaN opacity is an invalid style the browser drops,
+// which strands the night half at its stylesheet value instead of dissolving.
+describe('day/night wallpapers outside the authored timeline', () => {
+  it('never computes a NaN fade for a catalogue album slide', async () => {
+    const wrapper = mount(WolvesComicReader, {
+      props: {
+        trackIndex: 0,
+        playlistCurrentTime: 0,
+        experienceId: 'album-daynight',
+        wolvesExperience: false,
+      },
+    })
+    await flushPromises()
+
+    const vm = wrapper.vm as any
+    const pool = vm.mixedPhotosToUse as Array<{ type?: string, startTime?: number }>
+    const daynight = pool.filter(slide => slide?.type === 'daynight')
+
+    expect(daynight.length, 'catalogue pool carries day/night wallpapers').toBeGreaterThan(0)
+    for (const slide of daynight) {
+      expect(slide.startTime, 'catalogue day/night slide has no authored startTime').toBeUndefined()
+    }
+
+    // Put one on the stage. The fade is only evaluated for the slide actually
+    // in a buffer, so walking the clock alone can miss every day/night record
+    // in an 800-slide pool and prove nothing.
+    vm.photoA = daynight[0]
+    await nextTick()
+
+    for (const time of [0, 7, 14, 21, 28, 35, 42, 60, 90, 128]) {
+      await wrapper.setProps({ playlistCurrentTime: time })
+      await flushPromises()
+
+      expect(
+        Number.isFinite(vm.daynightNightOpacityA),
+        `night-layer opacity is ${vm.daynightNightOpacityA} at ${time}s`,
+      ).toBe(true)
+    }
+  })
+})


### PR DESCRIPTION
## The defect

The night half of a `daynight` wallpaper dissolves over its own slide window:

```
(playlistCurrentTime - startTime) / duration
```

Only the **Track 0 timeline** authors `startTime` and `duration`. The back-catalogue pools (`laterTrackPhotos`, `mixedPhotos`) are plain photo records that carry neither — and `backCatalogueCuratedPhotos` does not filter day/night art out, because it excludes `/people/` and `.gif` and the wallpapers are showcase art.

So the same wallpaper that turns correctly in the show reaches a catalogue album with `startTime === undefined`, the expression evaluates to `NaN`, and Vue emits `opacity: NaN`. The browser drops the invalid declaration, and the night half stays at its stylesheet value: **the wallpaper stops changing instead of turning.**

## The change

Outside the authored timeline, a slide's window is the same hold the deck indexes on, so the fade derives from it and falls back to `slideIndex * hold`. `activeFlickrIndex` now reads that same `standardSlideHold` computed — a deck and a fade that disagree about the hold dissolve against different windows.

Track 0 is untouched: it authors both fields and takes the path it always did.

## Why it shipped

The `NaN` is silent in every way that normally catches a defect. It throws nothing and logs nothing, and a test that only walks the clock proves nothing — the fade is evaluated for the slide **in a buffer**, and a walk across an ~800-slide pool can miss every day/night record. My first attempt at this test passed vacuously for exactly that reason.

The regression test puts one on the stage (`vm.photoA = <daynight slide>`) and asserts the fade stays finite across the album clock.

## Verification

`wolvesComicReader.test.ts` 84/84 (the new test fails with `night-layer opacity is NaN at 0s` before the fix). `lint`, `typecheck`, `test:gate` (no new failures) and `build` pass.

`docs/reference/wolves-slide-scheduling.md` updated in the same commit, including a second finding not fixed here: **albums borrow the Wolves manifest's tempo by index** (`currentTrack` falls back to `manifest.tracks[trackIndex]`), so an unrelated album's track 3 is paced by *Wolves* track 3's BPM. It is clamped to 5.5–11.5s so it degrades to a plausible hold rather than an obvious break. Changing it moves slide pacing, so it is documented rather than changed here.

Assisted-by: Claude Opus 5 via GitHub Copilot CLI