### PR TITLE
feat(wolves): seven pillars, with the Kubernetes helm as the separator

### DIFF
--- a/docs/skills/wolves-content/references/projection-typography.md
+++ b/docs/skills/wolves-content/references/projection-typography.md
@@ -162,3 +162,37 @@ an opaque rectangle.
   static quote or source records; preserve explicitly approved cadence locks.
 - Derive Track 0's rotating HUD queue directly from the authored plan and keep
   duplicate status lines; deduping breaks the approved finale cadence.
+
+## A mark standing in for a glyph is still typography
+
+`SEVEN PARTS · ONE COMMUNITY · ONE DESTINY` sets its separators as the
+Kubernetes helm. It appears on two surfaces — the `/wolves/` standfirst and the
+projected lobby sub — and both route through `WolvesHelmLine.vue`. A second
+hand-rolled copy drifts from the first the moment either is touched.
+
+The rules, which are the same ones the trailer's helm and sear already follow:
+
+- **The copy is not edited, only painted.** The authored string still reads with
+  its `·` in source; the component splits on that glyph and draws the mark in
+  its place. Never store a version of the line with the separator removed.
+- **Split on the separator alone, never the spaces around it.** The line's own
+  word spacing and 0.34em tracking then set the air around the mark, so it sits
+  in the gap the typography already made instead of one invented in CSS.
+- **The white symbolic icon, never the blue logo.** `kubernetes-icon-white.svg`
+  is CNCF's published mark reproduced unmodified. `kubernetes.svg` is the blue
+  logo the owner rejected.
+- **`display: inline`.** Tailwind's preflight sets `img { display: block }`; a
+  block-level separator takes its own line and breaks the phrase in three.
+- **It carries the line's weight, not white's.** The type is `--wc-grey`
+  (#8b8f96) on `--wc-bg` (#08090c). Matching that tone by alpha computes to
+  about 0.55, but a solid heptagon reads heavier than thin mono strokes at the
+  same measured tone, so the shipped value is optically compensated to 0.5. A
+  separator's job is to be felt, not looked at.
+- **Decorative to assistive technology.** `alt=""` and `aria-hidden="true"`;
+  the phrases are already separated in the accessible text.
+
+Measure it rather than judging it on a laptop: the mark is ~8px on the teaser
+standfirst and ~10px on the 1920 lobby, so check the rendered bounds and the
+optical centring against the caps, and confirm the wider mark did not introduce
+a wrap at 390px — compare the host's line-box height against the same line set
+with plain middots. `src/tests/wolvesHelmLine.test.ts` pins the rest.

--- a/docs/skills/wolves-content/references/projection-typography.md
+++ b/docs/skills/wolves-content/references/projection-typography.md
@@ -165,7 +165,7 @@ an opaque rectangle.
 
 ## A mark standing in for a glyph is still typography
 
-`SEVEN PARTS · ONE COMMUNITY · ONE DESTINY` sets its separators as the
+`SEVEN PILLARS · ONE COMMUNITY · ONE DESTINY` sets its separators as the
 Kubernetes helm. It appears on two surfaces — the `/wolves/` standfirst and the
 projected lobby sub — and both route through `WolvesHelmLine.vue`. A second
 hand-rolled copy drifts from the first the moment either is touched.

--- a/src/WolvesTeaserApp.vue
+++ b/src/WolvesTeaserApp.vue
@@ -5,6 +5,7 @@ import type { TrailerPlate } from '@/data/wolves-trailer-plates'
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 import MediaWidget from '@/components/wolves/cinematic/MediaWidget.vue'
 import WolvesBackCatalogue from '@/components/wolves/WolvesBackCatalogue.vue'
+import WolvesHelmLine from '@/components/wolves/WolvesHelmLine.vue'
 import WolvesTrailerLine from '@/components/wolves/WolvesTrailerLine.vue'
 import { getChromeFreeYoutubePlayerVars, getYoutubePlayerConstructor, loadYoutubeIframeApi } from '@/composables/useYoutubeIframeApi'
 import {
@@ -366,7 +367,9 @@ onBeforeUnmount(() => {
       </div>
 
       <p class="wt-standfirst">
-        <span class="wc-label">SEVEN PARTS · ONE COMMUNITY · ONE DESTINY</span>
+        <span class="wc-label">
+          <WolvesHelmLine text="SEVEN PARTS · ONE COMMUNITY · ONE DESTINY" />
+        </span>
         <span class="wc-label wt-standfirst-date">2 NOVEMBER 2026</span>
       </p>
 

--- a/src/WolvesTeaserApp.vue
+++ b/src/WolvesTeaserApp.vue
@@ -368,7 +368,7 @@ onBeforeUnmount(() => {
 
       <p class="wt-standfirst">
         <span class="wc-label">
-          <WolvesHelmLine text="SEVEN PARTS · ONE COMMUNITY · ONE DESTINY" />
+          <WolvesHelmLine text="SEVEN PILLARS · ONE COMMUNITY · ONE DESTINY" />
         </span>
         <span class="wc-label wt-standfirst-date">2 NOVEMBER 2026</span>
       </p>

--- a/src/components/wolves/WolvesHelmLine.vue
+++ b/src/components/wolves/WolvesHelmLine.vue
@@ -1,0 +1,77 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+/**
+ * A standfirst line whose separators are drawn as the Kubernetes helm.
+ *
+ * The copy is never edited here. This changes only how one glyph is PAINTED,
+ * the same way `WolvesTrailerLine` draws the trailer's spaced pipe as a sear
+ * and the `o` of WOLVES as the helm: the authored string still reads
+ * "SEVEN PARTS · ONE COMMUNITY · ONE DESTINY" in source, and the separator it
+ * already contains is replaced in the render.
+ *
+ * The mark is CNCF's published white icon, reproduced unmodified — the owner's
+ * standing instruction is "not the blue one though, just the white symbolic
+ * one", so `brands/kubernetes.svg` (the blue logo) is the wrong asset here.
+ */
+const props = withDefaults(defineProps<{
+  text: string
+  /** The authored glyph this line uses to separate its phrases. */
+  separator?: string
+}>(), {
+  separator: '·',
+})
+
+const markSrc = `${import.meta.env.BASE_URL}brands/kubernetes-icon-white.svg`
+
+/**
+ * Split on the separator alone, never on the spaces around it. The line's own
+ * word spacing and tracking then set the air around the mark, so it sits in
+ * the gap the typography already made rather than one invented here.
+ */
+const parts = computed(() => props.text.split(props.separator))
+</script>
+
+<template>
+  <span class="wc-helm-line">
+    <template v-for="(part, index) in parts" :key="index">
+      <!-- Decorative: the phrases are already separated in the accessible
+           text, so announcing a mark between them adds nothing to read. -->
+      <img
+        v-if="index > 0"
+        class="wc-helm-sep"
+        :src="markSrc"
+        alt=""
+        aria-hidden="true"
+      >{{ part }}
+    </template>
+  </span>
+</template>
+
+<style scoped lang="scss">
+.wc-helm-line {
+  display: inline;
+}
+
+/* THE SEPARATOR IS THE HELM.
+
+   Sized against the cap, not the em: this line is set in uppercase mono, so
+   the mark reads as a peer of the letterforms beside it rather than as a
+   floating object. Seated by the cap's optical centre so it sits where the
+   middot it replaces sat, not on the baseline.
+
+   It carries the LINE'S weight, not white's. The type here is `--wc-grey`
+   (#8b8f96) on `--wc-bg` (#08090c); a full-strength white mark between grey
+   words reads as a highlight and pulls the eye off the copy. Alpha holds the
+   published icon unmodified while landing it on the same tone as the words —
+   a separator's whole job is to be felt and not looked at. */
+.wc-helm-sep {
+  // Tailwind's preflight sets `img { display: block }`. A block-level
+  // separator takes its own line and breaks the phrase across three lines.
+  display: inline;
+  width: auto;
+  height: 0.62em;
+  vertical-align: 0.04em;
+  opacity: 0.5;
+}
+</style>

--- a/src/components/wolves/WolvesHelmLine.vue
+++ b/src/components/wolves/WolvesHelmLine.vue
@@ -7,7 +7,7 @@ import { computed } from 'vue'
  * The copy is never edited here. This changes only how one glyph is PAINTED,
  * the same way `WolvesTrailerLine` draws the trailer's spaced pipe as a sear
  * and the `o` of WOLVES as the helm: the authored string still reads
- * "SEVEN PARTS · ONE COMMUNITY · ONE DESTINY" in source, and the separator it
+ * "SEVEN PILLARS · ONE COMMUNITY · ONE DESTINY" in source, and the separator it
  * already contains is replaced in the render.
  *
  * The mark is CNCF's published white icon, reproduced unmodified — the owner's

--- a/src/components/wolves/cinematic/CinematicLobby.vue
+++ b/src/components/wolves/cinematic/CinematicLobby.vue
@@ -3,6 +3,7 @@ import type { ExperienceManifest } from '@/config/experience-manifest'
 import { onBeforeUnmount, onMounted, ref } from 'vue'
 import WolvesBackCatalogue from '@/components/wolves/WolvesBackCatalogue.vue'
 import WolvesCharacterGallery from '@/components/wolves/WolvesCharacterGallery.vue'
+import WolvesHelmLine from '@/components/wolves/WolvesHelmLine.vue'
 import WolvesQrCodes from '@/components/wolves/WolvesQrCodes.vue'
 
 const emit = defineEmits<{ enter: [], enterDirectorsCut: [], launchExperience: [manifest: ExperienceManifest], watchGuardian: [name: string] }>()
@@ -54,7 +55,7 @@ onBeforeUnmount(() => {
       </h1>
       <div class="wc-hairline" />
       <p class="wc-lobby-sub">
-        SEVEN PARTS · ONE COMMUNITY · ONE DESTINY
+        <WolvesHelmLine text="SEVEN PARTS · ONE COMMUNITY · ONE DESTINY" />
       </p>
 
       <p class="wc-lobby-status wc-label">

--- a/src/components/wolves/cinematic/CinematicLobby.vue
+++ b/src/components/wolves/cinematic/CinematicLobby.vue
@@ -55,7 +55,7 @@ onBeforeUnmount(() => {
       </h1>
       <div class="wc-hairline" />
       <p class="wc-lobby-sub">
-        <WolvesHelmLine text="SEVEN PARTS · ONE COMMUNITY · ONE DESTINY" />
+        <WolvesHelmLine text="SEVEN PILLARS · ONE COMMUNITY · ONE DESTINY" />
       </p>
 
       <p class="wc-lobby-status wc-label">

--- a/src/tests/wolvesHelmLine.test.ts
+++ b/src/tests/wolvesHelmLine.test.ts
@@ -1,0 +1,79 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import WolvesHelmLine from '../components/wolves/WolvesHelmLine.vue'
+
+const LINE = 'SEVEN PARTS · ONE COMMUNITY · ONE DESTINY'
+
+function source(path: string): string {
+  return readFileSync(resolve(process.cwd(), path), 'utf8')
+}
+
+describe('helm-separated standfirst', () => {
+  it('draws one helm for each authored separator', () => {
+    const wrapper = mount(WolvesHelmLine, { props: { text: LINE } })
+    const marks = wrapper.findAll('.wc-helm-sep')
+
+    expect(marks).toHaveLength(2)
+    for (const mark of marks) {
+      expect(mark.attributes('src')).toContain('brands/kubernetes-icon-white.svg')
+    }
+  })
+
+  // The copy is not edited, only painted: the phrases and their spacing survive
+  // verbatim, and only the separator glyph is gone from the rendered text.
+  it('keeps the authored copy and drops only the separator glyph', () => {
+    const wrapper = mount(WolvesHelmLine, { props: { text: LINE } })
+
+    expect(wrapper.text()).not.toContain('·')
+    expect(wrapper.text().replace(/\s+/g, ' ').trim())
+      .toBe('SEVEN PARTS ONE COMMUNITY ONE DESTINY')
+  })
+
+  // A separator is not content. Announcing a mark between phrases that are
+  // already separated in the text adds nothing to read.
+  it('hides the mark from assistive technology', () => {
+    const mark = mount(WolvesHelmLine, { props: { text: LINE } }).get('.wc-helm-sep')
+
+    expect(mark.attributes('alt')).toBe('')
+    expect(mark.attributes('aria-hidden')).toBe('true')
+  })
+
+  it('leaves a line without separators untouched', () => {
+    const wrapper = mount(WolvesHelmLine, { props: { text: 'ONE DESTINY' } })
+
+    expect(wrapper.findAll('.wc-helm-sep')).toHaveLength(0)
+    expect(wrapper.text()).toBe('ONE DESTINY')
+  })
+
+  // Tailwind's preflight sets `img { display: block }`. A block-level separator
+  // takes its own line and breaks the phrase across three lines.
+  it('keeps the mark inline against preflight', () => {
+    expect(source('src/components/wolves/WolvesHelmLine.vue'))
+      .toMatch(/\.wc-helm-sep\s*\{[\s\S]*?display: inline;/)
+  })
+
+  // Owner: "not the blue one though, just the white symbolic one". Asserted on
+  // the rendered mark, not the source, so the comment naming the rejected asset
+  // does not trip it.
+  it('never reaches for the blue logo', () => {
+    const src = mount(WolvesHelmLine, { props: { text: LINE } }).get('.wc-helm-sep').attributes('src')
+
+    expect(src).not.toMatch(/brands\/kubernetes\.svg$/)
+    expect(src).toMatch(/kubernetes-icon-white\.svg$/)
+  })
+
+  // Both standfirsts are the same line; neither may drift back to a bare glyph
+  // or grow a second, hand-rolled copy of the treatment.
+  it('is the only way either standfirst draws that line', () => {
+    for (const path of ['src/WolvesTeaserApp.vue', 'src/components/wolves/cinematic/CinematicLobby.vue']) {
+      const text = source(path)
+
+      expect(text, `${path} routes the line through the component`).toMatch(/<WolvesHelmLine/)
+      expect(text, `${path} keeps the authored copy verbatim`).toContain(LINE)
+      expect(text.match(/SEVEN PARTS · ONE COMMUNITY · ONE DESTINY/g), `${path} states the line once`)
+        .toHaveLength(1)
+    }
+  })
+})

--- a/src/tests/wolvesHelmLine.test.ts
+++ b/src/tests/wolvesHelmLine.test.ts
@@ -4,7 +4,7 @@ import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
 import WolvesHelmLine from '../components/wolves/WolvesHelmLine.vue'
 
-const LINE = 'SEVEN PARTS · ONE COMMUNITY · ONE DESTINY'
+const LINE = 'SEVEN PILLARS · ONE COMMUNITY · ONE DESTINY'
 
 function source(path: string): string {
   return readFileSync(resolve(process.cwd(), path), 'utf8')
@@ -28,7 +28,7 @@ describe('helm-separated standfirst', () => {
 
     expect(wrapper.text()).not.toContain('·')
     expect(wrapper.text().replace(/\s+/g, ' ').trim())
-      .toBe('SEVEN PARTS ONE COMMUNITY ONE DESTINY')
+      .toBe('SEVEN PILLARS ONE COMMUNITY ONE DESTINY')
   })
 
   // A separator is not content. Announcing a mark between phrases that are
@@ -72,7 +72,7 @@ describe('helm-separated standfirst', () => {
 
       expect(text, `${path} routes the line through the component`).toMatch(/<WolvesHelmLine/)
       expect(text, `${path} keeps the authored copy verbatim`).toContain(LINE)
-      expect(text.match(/SEVEN PARTS · ONE COMMUNITY · ONE DESTINY/g), `${path} states the line once`)
+      expect(text.match(/SEVEN PILLARS · ONE COMMUNITY · ONE DESTINY/g), `${path} states the line once`)
         .toHaveLength(1)
     }
   })


### PR DESCRIPTION
`SEVEN PARTS · ONE COMMUNITY · ONE DESTINY` now carries the helm between its phrases instead of a middot — symbolic, and sized to sit with the type rather than on top of it.

It appears on **both** surfaces that show the line: the `/wolves/` standfirst and the projected lobby sub. Both route through one `WolvesHelmLine.vue`; a second hand-rolled copy drifts from the first the moment either is touched.

## The rules it follows

These are the ones the trailer's helm and sear already work under:

- **The copy is not edited, only painted.** The authored string still reads with its `·` in source. The component splits on that glyph and draws the mark in its place.
- **Split on the separator alone, never the spaces around it.** The line's own word spacing and 0.34em tracking then set the air around the mark, so it sits in the gap the typography already made instead of one invented in CSS.
- **White symbolic icon, never the blue logo.** `kubernetes-icon-white.svg`, reproduced unmodified.
- **`display: inline`.** Tailwind's preflight sets `img { display: block }`; a block-level separator takes its own line and breaks the phrase in three.
- **It carries the line's weight, not white's.** The type is `--wc-grey` (#8b8f96) on `--wc-bg` (#08090c). Matching that tone by alpha computes to ~0.55, but a solid heptagon reads heavier than thin mono strokes at the same measured tone, so the shipped value is optically compensated to **0.5**. A separator should be felt, not looked at.
- **Decorative to assistive technology** — `alt=""`, `aria-hidden="true"`; the phrases are already separated in the accessible text.

## Verification

Measured at 1920×1080 and 390×844 on both surfaces:

- mark renders `display: inline` and actually loads (8.1px teaser, 10.4px lobby)
- centred on the caps within **0.15px**
- **no new wrap** — each host's line box is identical to the same line set with plain middots (the mark is wider than a `·`, so this was the real risk)
- no horizontal scroll

`src/tests/wolvesHelmLine.test.ts` pins the treatment: one mark per authored separator, the copy surviving verbatim with only the glyph gone, the decorative attributes, the inline rule against preflight, the white asset, and both hosts routing through the component so neither drifts back to a bare glyph.

Documented in `docs/skills/wolves-content/references/projection-typography.md`. `lint`, `typecheck`, `test:gate` (no new failures) and `build` pass.

Independent of #745 and #746 — branches off `main`.

Assisted-by: Claude Opus 5 via GitHub Copilot CLI