### PR TITLE
docs(skills): bring every skill to the canonical spec, and enforce it

### DIFF
--- a/docs/skills/agent-workflow/SKILL.md
+++ b/docs/skills/agent-workflow/SKILL.md
@@ -10,6 +10,12 @@ description: Use at session start, before commits, before pushes, at factory gat
 Use for any session that edits code, deploys, changes DNS, touches a shared
 runtime, or hands work to another agent.
 
+## When NOT to Use
+
+Do not use for read-only questions, or for a documentation-only edit that ships
+no commit. Area work still loads its own skill: this one routes a session, it
+does not replace `validation`, `design-gate`, or the Wolves skills.
+
 ## Core Process
 
 1. **Identify the real target.**
@@ -182,6 +188,15 @@ wrangler docs <topic>
 
 If the session lacks DNS-edit permission, stop and request reauthentication with
 an API token scoped to the target zone. Do not compensate by deploying a Worker.
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "The change is obviously right, so it can skip the gate." | Design, Security, Breakage and Merge are decisions someone else owns, not formalities. Stop and get the decision. |
+| "There is a `common` checkout right here." | A fork or feature-branch checkout is not the sidecar. Fetch canonical `main`, or proceed without it and say so. |
+| "It works locally, so it shipped." | A change that exists only in a working tree has shipped nothing. Verify the pushed commit's own deployment. |
+| "That suite failure is unrelated to my change." | Report it anyway. An omitted failure is how a real regression gets attributed to the next person. |
 
 ## Red Flags
 

--- a/docs/skills/cloudflare/SKILL.md
+++ b/docs/skills/cloudflare/SKILL.md
@@ -55,6 +55,13 @@ never deploy a Worker as a substitute for a DNS record.
   documented Cloudflare flow; do not assume GitHub Pages and Cloudflare Pages
   are interchangeable.
 
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "A Worker is the quickest way to make this hostname resolve." | A Worker is a service someone owns forever. Solve a DNS problem with DNS. |
+| "`wrangler deploy` succeeded, so the subdomain works." | Check DNS and the live HTTPS response. An existing redirect can still win. |
+
 ## Red Flags
 
 - Deploying a Worker just to make a hostname exist.

--- a/docs/skills/content-maintenance/SKILL.md
+++ b/docs/skills/content-maintenance/SKILL.md
@@ -29,6 +29,13 @@ prominence, or Wolves runtime engineering.
 Use `import.meta.env.BASE_URL` for public runtime asset paths. Never hand-edit a
 generated file.
 
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "The copy does not fit, so the component needs a small tweak." | Content work never changes design. Get approval, or change the copy. |
+| "It is faster to patch the generated file." | Generated output is overwritten on the next run. Fix the generator or its source data. |
+
 ## Red Flags
 
 - A content diff changes a component or stylesheet.

--- a/docs/skills/editorial-provenance/SKILL.md
+++ b/docs/skills/editorial-provenance/SKILL.md
@@ -31,6 +31,14 @@ Do not use for purely functional data with no authored wording.
 Never invent connective prose, headings, summaries, chapter names, or
 translations presented as authored copy.
 
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "The wording is slightly off, I'll tidy it." | Authored copy is reproduced verbatim. Fix the source record and re-port from it. |
+| "Removing this segment simplifies the code." | Authored content is not yours to delete. A gap in a numbered sequence is the evidence that it happened. |
+| "I remember what the missing line said." | Reconstruction from memory is invention published under someone else's byline. |
+
 ## Red Flags
 
 - New prose has no authoritative source.

--- a/docs/skills/guardian-character-cards/SKILL.md
+++ b/docs/skills/guardian-character-cards/SKILL.md
@@ -88,6 +88,13 @@ the old name. Regenerate (`capture-scenes.mjs` then `generate.mjs <slug>`) —
 and note that capture needs a browser that can actually play the source video,
 which a codec-limited Chromium cannot.
 
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "I'll edit the card markup directly." | `public/wolves/characters/` is generated; the edit disappears on the next run. |
+| "A placeholder keeps the roster complete." | `videoId: "TODO"` stops both generator stages. An absent record beats one that breaks the build. |
+
 ## Red Flags
 
 - Hand-editing files in `public/wolves/characters/` — they are generated.

--- a/docs/skills/skill-authoring/SKILL.md
+++ b/docs/skills/skill-authoring/SKILL.md
@@ -35,6 +35,13 @@ features, or one-off task instructions.
 Use standard GFM Markdown. MCP does not define a skill filesystem layout; this
 layout follows the Agent Skills convention.
 
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "This rule matters here too, so I'll restate it." | Two owners of one rule drift apart. Link to the owner instead. |
+| "The entry file should explain the architecture." | The entry file routes. Detail belongs in a reference beside it. |
+
 ## Red Flags
 
 - A second skill owns the same rule.

--- a/docs/skills/skill-improvement/SKILL.md
+++ b/docs/skills/skill-improvement/SKILL.md
@@ -94,6 +94,14 @@ Delete these on sight; they collect stale text instead of updating skills.
 
 This does not ban product documentation or release notes owned by a human.
 
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "I'll write this up in a follow-up PR." | You will not, and the next agent pays for it. Same PR, or it does not exist. |
+| "This was obvious once I saw it." | You found it by trial and error, which is the definition of not obvious. |
+| "A new doc explains the correct behaviour." | Two docs that disagree are worse than one that is wrong. Correct the skill in place. |
+
 ## Red Flags
 
 - A session ends with a shipped change and no skill update.

--- a/docs/skills/validation/SKILL.md
+++ b/docs/skills/validation/SKILL.md
@@ -54,6 +54,16 @@ npm run test:gate
 npm run build
 ```
 
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "The build passed, so it works." | A build does not run route initialization. An eager `import.meta.glob()` manifest failure only appears in a browser. |
+| "The suite is red anyway, so this failure is expected." | `test:gate` judges against a recorded baseline. Re-derive the count from `tests/known-failures.txt`; never decide safety from a bare `test:run`. |
+| "The deploy is green, so my change is live." | Match the SHA. A green run for a different commit says nothing about yours. |
+| "My change is missing from the browser, so the code is wrong." | Identify the process on the port first. A stale `vite preview` serves a frozen `dist/` and never hot-reloads. |
+| "Nothing references this file, so it is dead code." | `WolvesComicReader.vue` serves eleven non-Wolves albums. A `/wolves/` smoke test will not notice their loss. |
+
 ## Red Flags
 
 - Completion is based only on a local build.

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -66,6 +66,24 @@ for (const path of skillFiles) {
   if (source.split('\n').length > 500) {
     addError(`${relativePath}: exceeds 500 lines`)
   }
+
+  // The canonical skill spec (`/addyosmani/agent-skills`). `## Verification` is
+  // checked for every Markdown file below; these are the rest of it. Eight of
+  // twelve skills had drifted without `## Common Rationalizations`, which is
+  // the section that records the excuse that leads to each Red Flag — the part
+  // an agent actually argues with itself about.
+  const requiredSections = [
+    '## When to Use',
+    '## When NOT to Use',
+    '## Core Process',
+    '## Common Rationalizations',
+    '## Red Flags',
+  ]
+  for (const section of requiredSections) {
+    if (!source.includes(`\n${section}\n`)) {
+      addError(`${relativePath}: missing ${section} section`)
+    }
+  }
 }
 
 for (const path of markdown) {


### PR DESCRIPTION
Eight of twelve skills had no `## Common Rationalizations`, and `agent-workflow` had no `## When NOT to Use`. The canonical spec (`/addyosmani/agent-skills`) asks for both, and `check-docs.mjs` was only enforcing `## Verification` — so the gap was invisible and had been drifting.

## Why this section specifically

**Red Flags** lists what going wrong looks like from the outside. **Common Rationalizations** records the *excuse that gets an agent there* — which is the part it actually argues with itself about at the moment it matters.

Every entry is derived from that skill's own red flags and from defects this repo already paid for. Nothing invented:

- a build that cannot catch an eager `import.meta.glob()` failure
- a stale `vite preview` serving a frozen `dist/`
- `WolvesComicReader.vue` quietly serving eleven non-Wolves albums
- a sibling `common` checkout cited as the shared contract

## Enforcement

`check-docs.mjs` now requires the full spec on every `SKILL.md` — When to Use, When NOT to Use, Core Process, Common Rationalizations, Red Flags — alongside the existing Verification rule and the 500-line cap.

**Verified the gate by breaking it:** removed a section, watched `check:docs` fail with `docs/skills/cloudflare/SKILL.md: missing ## Common Rationalizations section`, restored it, watched it pass. A gate that has never been seen to fail is not known to work.

Follows #749, which split the two oversized skills.

Assisted-by: Claude Opus 5 via GitHub Copilot CLI