### PR TITLE
fix(wolves): hold trailer URL after music

### DIFF
--- a/docs/skills/wolves-teaser/SKILL.md
+++ b/docs/skills/wolves-teaser/SKILL.md
@@ -79,15 +79,16 @@ The real trailer is three concatenated segments, not one video with overlays:
 |---|---|
 | 0 → 88.2 | Nightwish video, letterboxed 2.39:1 into 16:9 |
 | 88.2 → 102.2 | March Bluefin wallpaper, day fading to night |
-| 102.2 → 110.02 | March Bluefin night wallpaper, as the end-card poster |
+| 102.2 → 115.02 | March Bluefin night wallpaper, as the end-card poster |
 
 `BRIDGE_MONTH = 3`; the local assets are:
 
 - `public/img/wallpapers/bluefin-03-day.webp`
 - `public/img/wallpapers/bluefin-03-night.webp`
 
-The last 21.8 seconds must cover the embed completely. Both day cards and the
-whole end card sit on the wallpaper at full-frame 16:9, with no letterbox.
+The last 26.82 seconds must cover the embed completely. Both day cards and the
+whole end card sit on the wallpaper at full-frame 16:9, with no letterbox. The
+music ends at 110.02 seconds, then the URL card holds for five silent seconds.
 The bridge's black backing is opaque from the 88.2-second cut onward; fade the
 wallpaper images over that backing, never the whole backdrop. Fading the
 backdrop itself exposes post-cut YouTube frames during the black-to-day rise.
@@ -171,8 +172,8 @@ authored token unless the owner asks to reproduce the render host's fallback.
 | `book-b` | 31.0–34.9 | transparent timing continuation at `[1000,470]`; never render |
 | `daycard-extinction` | 88.8–93.8 | fade in 0.4; fade out 0.5 |
 | `daycard-survival` | 94.4–100.6 | fade in 0.5; fade out 0.6 |
-| `endcard-event` | 102.2–110.02 | title, subtitle, hairline |
-| `endcard-cta` | 105.2–110.02 | CTA and tags over the event card |
+| `endcard-event` | 102.2–115.02 | title, subtitle, hairline |
+| `endcard-cta` | 105.2–115.02 | CTA and tags over the event card |
 
 The book box is opaque `rgb(4 10 20)`, with a 4px `#60a5fa` left border,
 3px radius, `1.35rem 2rem` card-root padding, line-height 1.7, and max-width

--- a/src/data/wolves-trailer-plates.ts
+++ b/src/data/wolves-trailer-plates.ts
@@ -1,8 +1,8 @@
 /**
  * Trailer 1 — the teaser's recreation of the owner's cut.
  *
- * PROVENANCE: this is a web recreation of the owner's cut "Trailer 1.0"
- * (delivered 2026-08-17), whose authoritative record is the destiny-vids repo
+ * PROVENANCE: this is a web recreation of the owner's cut "Trailer 1.1"
+ * (delivered 2026-08-18), whose authoritative record is the destiny-vids repo
  * at `stories/trailer-1-plates.json`, with the plate DESIGN authored in
  * `cards/maintitle.html`, `cards/bookline.html` and `cards/daycard.html` and
  * the composition in `scripts/build_trailer1.py`. Every string below is
@@ -16,7 +16,7 @@
  *
  *   0      -> 88.2    the music video, letterboxed 2.39:1 into a 16:9 frame
  *   88.2   -> 102.2   the March Bluefin wallpaper, day falling into night
- *   102.2  -> 110.02  the March Bluefin night wallpaper, as a poster end card
+ *   102.2  -> 115.02  the March Bluefin night wallpaper, as a poster end card
  *
  * So both day cards and the whole end card sit on the wallpaper at FULL
  * frame, with no letterbox — which is also why they carry no scrim: the
@@ -30,12 +30,14 @@
  */
 export const TRAILER_VIDEO_ID = 'O0lyFqLr3Cc'
 
-/** The trailer is exactly 1:50.020; the player pauses (not ends) at this mark. */
+/** The source music and embedded player stop at the approved 1:50.020 mark. */
 export const TRAILER_DURATION_SECONDS = 110.02
+/** The delivered picture holds the URL for five silent seconds after the music. */
+export const TRAILER_CUT_DURATION_SECONDS = 115.02
 
 /**
  * Segment boundaries, from `scripts/build_trailer1.py`:
- * picture 88.200 + bridge 14.000 + end card 7.820 = 110.020.
+ * picture 88.200 + bridge 14.000 + end card 12.820 = 115.020.
  */
 export const TRAILER_PICTURE_END_SECONDS = 88.2
 export const TRAILER_BRIDGE_END_SECONDS = 102.2
@@ -63,7 +65,7 @@ export const TRAILER_ENDCARD_CTA_IN = 3.1
 export const TRAILER_ENDCARD_CTA_FADE = 0.6
 export const TRAILER_ENDCARD_FADE = 1.2
 /** Freeze the completed teaser immediately before the URL card fades out. */
-export const TRAILER_ENDCARD_HOLD_SECONDS = TRAILER_DURATION_SECONDS - TRAILER_ENDCARD_FADE
+export const TRAILER_ENDCARD_HOLD_SECONDS = TRAILER_CUT_DURATION_SECONDS - TRAILER_ENDCARD_FADE
 
 /**
  * The title plate stays up across both authored beats; the credit line joins
@@ -172,7 +174,7 @@ export const TRAILER_PLATES: readonly TrailerPlate[] = [
     id: 'endcard-event',
     kind: 'endcard-event',
     start: TRAILER_BRIDGE_END_SECONDS + TRAILER_ENDCARD_EVENT_IN,
-    end: TRAILER_DURATION_SECONDS,
+    end: TRAILER_CUT_DURATION_SECONDS,
     title: 'KubeCon | CloudNativeCon North America',
     subtitle: 'Salt Lake City, Utah',
     fadeIn: TRAILER_ENDCARD_EVENT_FADE,
@@ -184,7 +186,7 @@ export const TRAILER_PLATES: readonly TrailerPlate[] = [
     id: 'endcard-cta',
     kind: 'endcard-cta',
     start: TRAILER_BRIDGE_END_SECONDS + TRAILER_ENDCARD_CTA_IN,
-    end: TRAILER_DURATION_SECONDS,
+    end: TRAILER_CUT_DURATION_SECONDS,
     title: 'wolves.projectbluefin.io',
     tags: ['#KubeCon', '#CloudNativeCon', '#7wolves'],
     fadeIn: TRAILER_ENDCARD_CTA_FADE,

--- a/src/tests/wolvesTrailerPlates.test.ts
+++ b/src/tests/wolvesTrailerPlates.test.ts
@@ -7,6 +7,7 @@ import {
   TRAILER_BRIDGE_LEGS,
   TRAILER_CREDIT_JOIN_SECONDS,
   TRAILER_CREDIT_LINE,
+  TRAILER_CUT_DURATION_SECONDS,
   TRAILER_DURATION_SECONDS,
   TRAILER_ENDCARD_HOLD_SECONDS,
   TRAILER_HEADING_YIELD_SECONDS,
@@ -21,18 +22,20 @@ import {
 } from '@/data/wolves-trailer-plates'
 
 // These windows are the owner's cut (destiny-vids stories/trailer-1-plates.json
-// and scripts/build_trailer1.py, "Trailer 1.0", 2026-08-17). If the cut is
+// and scripts/build_trailer1.py, "Trailer 1.1", 2026-08-18). If the cut is
 // recut, re-port the manifest — do not nudge these numbers to make a test pass.
 describe('wolves trailer plates', () => {
-  it('runs for exactly 1:50.020', () => {
+  it('keeps the music at 1:50.020 and the picture through 1:55.020', () => {
     expect(TRAILER_VIDEO_ID).toBe('O0lyFqLr3Cc')
     expect(TRAILER_DURATION_SECONDS).toBe(110.02)
+    expect(TRAILER_CUT_DURATION_SECONDS).toBe(115.02)
   })
 
   it('shows nothing before the main title and after the cut ends', () => {
     expect(activeTrailerPlates(0)).toEqual([])
     expect(activeTrailerPlates(10.9)).toEqual([])
-    expect(activeTrailerPlates(TRAILER_DURATION_SECONDS)).toEqual([])
+    expect(activeTrailerPlates(TRAILER_DURATION_SECONDS).map(p => p.id)).toEqual(['endcard-event', 'endcard-cta'])
+    expect(activeTrailerPlates(TRAILER_CUT_DURATION_SECONDS)).toEqual([])
     expect(activeTrailerPlates(Number.NaN)).toEqual([])
   })
 
@@ -124,6 +127,7 @@ describe('wolves trailer plates', () => {
     expect(activeTrailerPlates(104).map(p => p.id)).toEqual(['endcard-event'])
     expect(activeTrailerPlates(106).map(p => p.id)).toEqual(['endcard-event', 'endcard-cta'])
     expect(activeTrailerPlates(109.9).map(p => p.id)).toEqual(['endcard-event', 'endcard-cta'])
+    expect(activeTrailerPlates(112.5).map(p => p.id)).toEqual(['endcard-event', 'endcard-cta'])
   })
 
   it('holds the finished teaser where the URL card is fully visible', () => {


### PR DESCRIPTION
## Summary
- keep the embedded music transport at 1:50.020
- extend the authored end-card timeline to 1:55.020
- freeze the web recreation on the fully visible URL card during the silent hold
- update the Wolves teaser skill timing record

## Verification
- `npx vitest run src/tests/wolvesTrailerPlates.test.ts` — 27 passed
- `npm run lint` — passed
- `npm run typecheck` — passed
- `npm run test:gate` — no new failures
- `npm run build` — passed
- Chromium `/wolves/` smoke — trailer present, zero page errors

Design surface touched under the owner’s direct request to update the website with the revised trailer timing.