### PR TITLE
fix(wolves): make seek slider draggable

### DIFF
--- a/docs/skills/wolves-teaser/SKILL.md
+++ b/docs/skills/wolves-teaser/SKILL.md
@@ -246,6 +246,11 @@ centered **Play** and **Fullscreen** convenience buttons. Fullscreen the entire
 the fullscreen tree. Hide the standfirst there and fit the 16:9 player to the
 remaining viewport.
 
+The progress control must seek continuously during pointer drag. A click-only
+`div` with `role="slider"` is not a working slider. Use pointer capture from
+`pointerdown` through `pointerup` or `pointercancel`, and set `touch-action:
+none` on the track so a touch drag seeks instead of scrolling the page.
+
 At natural end, keep transport time at `1:50 / 1:50` while the visual clock
 holds at `TRAILER_ENDCARD_HOLD_SECONDS`, immediately before the URL card's fade.
 Do not show the poster over the ended phase; it would replace the requested
@@ -288,6 +293,7 @@ element can collapse below the available width and wrap unexpectedly.
 - Play is available only in the fixed widget and is not obvious on initial load.
 - Fullscreen targets the iframe, causing the title, overlays, or widget to disappear.
 - Ended state shows the poster or a faded/empty end card instead of the URL.
+- The progress control jumps on click but does not track mouse or touch drag.
 - The iframe accepts pointer events.
 - The page heading and the authored title card are legible at the same time, or
   the poster names the film.
@@ -311,9 +317,9 @@ element can collapse below the available width and wrap unexpectedly.
 - [ ] No horizontal scroll exists at 1920×1080 or 390×844.
 - [ ] A 16:9 iframe is centred at 134.328% height inside the clipped 1920:804
       aperture and has `pointer-events: none`.
-- [ ] Playback, pause, replay, and seek work through the external media-widget
-      mode; the 8-second start/seek cover and paused poster leave no YouTube
-      chrome visible.
+- [ ] Playback, pause, replay, click seek, keyboard seek, and pointer-drag seek
+      work through the external media-widget mode; the 8-second start/seek cover
+      and paused poster leave no YouTube chrome visible.
 - [ ] Idle/paused Play and Fullscreen buttons are centered and keyboard accessible;
       fullscreen owns `.wt-stage` and exposes an Exit Fullscreen label.
 - [ ] Natural end shows the fully opaque `wolves.projectbluefin.io` card while

--- a/docs/skills/wolves-teaser/SKILL.md
+++ b/docs/skills/wolves-teaser/SKILL.md
@@ -189,10 +189,12 @@ chrome without masking or cropping the film itself.
 
 Set `pointer-events: none` on the iframe. Playback belongs to the site's media
 widget; allowing pointer hover over the cross-origin iframe asks YouTube to
-paint chrome again, and the page cannot style it away. YouTube also paints a
-centre play/pause glyph briefly after API playback starts. Keep the opaque
-poster over the iframe for the first 8 seconds (and whenever paused); reveal it
-before the first authored plate at 11 seconds.
+paint chrome again, and the page cannot style it away. The opaque poster is an
+entry surface only: remove it as soon as playback starts and never restore it
+for pause or seek. Covering the player while its clock advances makes Play and
+Seek look broken, and replacing a paused frame with poster art hides the video.
+A transient YouTube centre glyph is less destructive than hiding the requested
+frame.
 
 `new YT.Player(div, …)` replaces the host div with the iframe. Target the
 resulting iframe through the wrapper's `:deep(iframe)` rule.
@@ -240,16 +242,24 @@ Do not copy the widget markup or stylesheet into the teaser. A visual copy
 immediately drifts from the show and creates two transport accessibility
 surfaces to maintain.
 
-The widget is the ongoing transport, but the idle/paused poster also carries
-centered **Play** and **Fullscreen** convenience buttons. Fullscreen the entire
-`.wt-stage`, not the iframe, so title, authored overlays, and widget remain in
-the fullscreen tree. Hide the standfirst there and fit the 16:9 player to the
-remaining viewport.
+The widget is the ongoing transport, while the idle poster carries centered
+**Play** and **Fullscreen** convenience buttons. Once entered, pause, resume,
+and seek stay in the widget so the video frame remains visible. Fullscreen the
+entire `.wt-stage`, not the iframe, so title, authored overlays, and widget
+remain in the fullscreen tree. Hide the standfirst there and fit the 16:9
+player to the remaining viewport.
+
+Treat Play and Seek as user intent even when the IFrame API or player is still
+loading. The button appears before `onReady`, so queue intent in teaser state;
+on readiness, restore the requested time and start only if the phase is still
+playing. Calling `playVideo()` on a missing or not-ready player loses the click.
 
 The progress control must seek continuously during pointer drag. A click-only
 `div` with `role="slider"` is not a working slider. Use pointer capture from
-`pointerdown` through `pointerup` or `pointercancel`, and set `touch-action:
-none` on the track so a touch drag seeks instead of scrolling the page.
+`pointerdown` through `pointerup` or `pointercancel`, seek on the final
+`pointerup` coordinate rather than trusting the last move event, and set
+`touch-action: none` on the track so a touch drag seeks instead of scrolling
+the page.
 
 At natural end, keep transport time at `1:50 / 1:50` while the visual clock
 holds at `TRAILER_ENDCARD_HOLD_SECONDS`, immediately before the URL card's fade.
@@ -293,6 +303,7 @@ element can collapse below the available width and wrap unexpectedly.
 - Play is available only in the fixed widget and is not obvious on initial load.
 - Fullscreen targets the iframe, causing the title, overlays, or widget to disappear.
 - Ended state shows the poster or a faded/empty end card instead of the URL.
+- Play or Seek advances behind an opaque poster, or Pause replaces the current frame.
 - The progress control jumps on click but does not track mouse or touch drag.
 - The iframe accepts pointer events.
 - The page heading and the authored title card are legible at the same time, or
@@ -318,9 +329,8 @@ element can collapse below the available width and wrap unexpectedly.
 - [ ] A 16:9 iframe is centred at 134.328% height inside the clipped 1920:804
       aperture and has `pointer-events: none`.
 - [ ] Playback, pause, replay, click seek, keyboard seek, and pointer-drag seek
-      work through the external media-widget mode; the 8-second start/seek cover
-      and paused poster leave no YouTube chrome visible.
-- [ ] Idle/paused Play and Fullscreen buttons are centered and keyboard accessible;
+      work through the external media-widget mode without restoring the poster.
+- [ ] The idle Play and Fullscreen buttons are centered and keyboard accessible;
       fullscreen owns `.wt-stage` and exposes an Exit Fullscreen label.
 - [ ] Natural end shows the fully opaque `wolves.projectbluefin.io` card while
       the widget reads `1:50 / 1:50`; no poster is present.

--- a/docs/superpowers/specs/2026-08-18-wolves-teaser-transport-design.md
+++ b/docs/superpowers/specs/2026-08-18-wolves-teaser-transport-design.md
@@ -9,9 +9,10 @@ Hide YouTube's title/share/logo chrome and use the existing Wolves music-widget 
 - The page owns a 16:9 frame and a clipped 1920:804 picture viewport.
 - A 16:9 YouTube iframe is centred inside that picture viewport. YouTube's own letterbox bars—and the chrome painted into them—fall outside the clipped viewport.
 - The iframe receives no pointer events, so hover cannot restore YouTube controls.
-- The opaque poster covers YouTube's transient centre glyph for the first 8 seconds after play/seek and whenever paused; it clears before the first authored plate at 11 seconds.
+- The opaque poster is an entry surface only. It clears immediately when Play or Seek is requested and does not return while playing, seeking, or paused; preserving the requested video frame takes precedence over hiding YouTube's transient centre glyph.
 - `MediaWidget.vue` remains store-backed by default. Optional external playback props let the teaser provide title, artwork, elapsed time, duration, playing state, and progress without mutating the cinematic store.
-- The teaser widget emits play/pause and seek to `WolvesTeaserApp.vue`.
+- The teaser widget emits play/pause and seek to `WolvesTeaserApp.vue`; the progress slider tracks pointer drags through pointer capture.
+- Play and Seek intent is retained until the YouTube player fires `onReady`; late readiness after unmount is ignored.
 - Previous/next controls are hidden for the single trailer.
 - The central Watch/Replay buttons are removed. The poster remains until the widget starts playback.
 - The widget is visible while idle or ended and auto-hides during playback.
@@ -28,5 +29,5 @@ Hide YouTube's title/share/logo chrome and use the existing Wolves music-widget 
 - Existing `wolvesMediaWidget` tests remain green.
 - New tests pin external title/artwork/time/progress/play state and hidden skip controls.
 - Chromium proves the iframe is 16:9, clipped by the 1920:804 viewport, and pointer-inert.
-- Chromium proves widget play/pause/seek controls the teaser clock.
+- Chromium proves widget play/pause/pointer-drag seek controls the teaser clock without restoring the poster.
 - Desktop and mobile bounds remain valid.

--- a/src/WolvesTeaserApp.vue
+++ b/src/WolvesTeaserApp.vue
@@ -33,21 +33,14 @@ const stageHost = ref<HTMLElement | null>(null)
 const playerHost = ref<HTMLElement | null>(null)
 const fullscreenActive = ref(false)
 let player: YoutubePlayer | null = null
+let playerReady = false
 let clockTimer: ReturnType<typeof setInterval> | null = null
 
 type TrailerPhase = 'idle' | 'playing' | 'paused' | 'ended'
 const trailerPhase = ref<TrailerPhase>('idle')
 const now = ref(0)
-const videoRevealed = ref(false)
-const YOUTUBE_CHROME_SETTLE_MS = 8000
-let revealTimer: ReturnType<typeof setTimeout> | null = null
 
 const visualTime = computed(() => trailerPhase.value === 'ended' ? TRAILER_ENDCARD_HOLD_SECONDS : now.value)
-const posterVisible = computed(() =>
-  trailerPhase.value === 'idle'
-  || trailerPhase.value === 'paused'
-  || (trailerPhase.value === 'playing' && !videoRevealed.value),
-)
 const visiblePlates = computed(() => activeTrailerPlates(visualTime.value))
 const plateById = computed(() => new Map(visiblePlates.value.map(plate => [plate.id, plate])))
 
@@ -109,18 +102,10 @@ function stopClock() {
   }
 }
 
-function hideUntilYoutubeChromeSettles() {
-  videoRevealed.value = false
-  if (revealTimer) {
-    clearTimeout(revealTimer)
-  }
-  revealTimer = setTimeout(() => {
-    videoRevealed.value = true
-    revealTimer = null
-  }, YOUTUBE_CHROME_SETTLE_MS)
-}
-
 function tick() {
+  if (!playerReady) {
+    return
+  }
   const t = player?.getCurrentTime?.()
   if (typeof t !== 'number') {
     return
@@ -131,7 +116,6 @@ function tick() {
     now.value = TRAILER_DURATION_SECONDS
     player?.pauseVideo?.()
     trailerPhase.value = 'ended'
-    videoRevealed.value = false
     stopClock()
     return
   }
@@ -145,20 +129,18 @@ function startClock() {
 
 function playTrailer() {
   trailerPhase.value = 'playing'
-  hideUntilYoutubeChromeSettles()
-  player?.playVideo?.()
+  if (playerReady) {
+    player?.playVideo?.()
+  }
   startClock()
 }
 
 function toggleTrailer() {
   if (trailerPhase.value === 'playing') {
-    player?.pauseVideo?.()
-    trailerPhase.value = 'paused'
-    videoRevealed.value = false
-    if (revealTimer) {
-      clearTimeout(revealTimer)
-      revealTimer = null
+    if (playerReady) {
+      player?.pauseVideo?.()
     }
+    trailerPhase.value = 'paused'
     stopClock()
     return
   }
@@ -172,11 +154,10 @@ function toggleTrailer() {
 function seekTrailer(ratio: number) {
   const target = Math.min(Math.max(ratio, 0), 1) * TRAILER_DURATION_SECONDS
   now.value = target
-  player?.seekTo?.(target, true)
-  if (trailerPhase.value === 'playing') {
-    hideUntilYoutubeChromeSettles()
+  if (playerReady) {
+    player?.seekTo?.(target, true)
   }
-  if (trailerPhase.value === 'ended' && target < TRAILER_DURATION_SECONDS) {
+  if (trailerPhase.value === 'idle' || (trailerPhase.value === 'ended' && target < TRAILER_DURATION_SECONDS)) {
     trailerPhase.value = 'paused'
   }
 }
@@ -184,9 +165,10 @@ function seekTrailer(ratio: number) {
 function replayTrailer() {
   now.value = 0
   trailerPhase.value = 'playing'
-  hideUntilYoutubeChromeSettles()
-  player?.seekTo?.(0, true)
-  player?.playVideo?.()
+  if (playerReady) {
+    player?.seekTo?.(0, true)
+    player?.playVideo?.()
+  }
   startClock()
 }
 
@@ -208,6 +190,20 @@ onMounted(async () => {
     player = new Player(playerHost.value, {
       videoId: TRAILER_VIDEO_ID,
       playerVars: getChromeFreeYoutubePlayerVars({ autoplay: 0 }),
+      events: {
+        onReady: ({ target }: { target: YoutubePlayer }) => {
+          if (player !== target) {
+            return
+          }
+          playerReady = true
+          if (now.value > 0) {
+            target.seekTo?.(now.value, true)
+          }
+          if (trailerPhase.value === 'playing') {
+            target.playVideo?.()
+          }
+        },
+      },
     })
     if (import.meta.env.DEV) {
       // Same contract as the main app's __wolvesCinematic: a harness hook so
@@ -232,11 +228,9 @@ onMounted(async () => {
 onBeforeUnmount(() => {
   document.removeEventListener('fullscreenchange', syncFullscreen)
   stopClock()
-  if (revealTimer) {
-    clearTimeout(revealTimer)
-  }
   player?.destroy?.()
   player = null
+  playerReady = false
 })
 </script>
 
@@ -278,12 +272,12 @@ onBeforeUnmount(() => {
           </div>
         </div>
 
-        <div v-if="posterVisible" class="wt-poster">
+        <div v-if="trailerPhase === 'idle'" class="wt-poster">
           <span class="wc-label wt-poster-kicker">TRAILER 1</span>
-          <div v-if="trailerPhase === 'idle' || trailerPhase === 'paused'" class="wt-convenience-controls">
+          <div class="wt-convenience-controls">
             <button class="wt-convenience-play wc-cta--primary" type="button" @click="toggleTrailer">
               <span aria-hidden="true">▶</span>
-              {{ trailerPhase === 'paused' ? 'Resume' : 'Play' }}
+              Play
             </button>
             <button class="wt-convenience-fullscreen" type="button" @click="toggleFullscreen">
               <span aria-hidden="true">⛶</span>

--- a/src/components/wolves/cinematic/MediaWidget.vue
+++ b/src/components/wolves/cinematic/MediaWidget.vue
@@ -202,6 +202,7 @@ function endSeek(event: PointerEvent) {
   if (event.pointerId !== seekPointerId) {
     return
   }
+  seekToClientX(event.clientX)
   if (progressEl.value?.hasPointerCapture(event.pointerId)) {
     progressEl.value.releasePointerCapture(event.pointerId)
   }

--- a/src/components/wolves/cinematic/MediaWidget.vue
+++ b/src/components/wolves/cinematic/MediaWidget.vue
@@ -173,12 +173,39 @@ onBeforeUnmount(() => {
   window.removeEventListener('touchstart', resetAutoHide)
 })
 
-function handleSeek(event: MouseEvent) {
+let seekPointerId: number | null = null
+
+function seekToClientX(clientX: number) {
   const rect = progressEl.value?.getBoundingClientRect()
   if (!rect || rect.width <= 0) {
     return
   }
-  emit('seek', (event.clientX - rect.left) / rect.width)
+  emit('seek', Math.min(Math.max((clientX - rect.left) / rect.width, 0), 1))
+}
+
+function beginSeek(event: PointerEvent) {
+  if (event.button !== 0) {
+    return
+  }
+  seekPointerId = event.pointerId
+  progressEl.value?.setPointerCapture(event.pointerId)
+  seekToClientX(event.clientX)
+}
+
+function continueSeek(event: PointerEvent) {
+  if (event.pointerId === seekPointerId) {
+    seekToClientX(event.clientX)
+  }
+}
+
+function endSeek(event: PointerEvent) {
+  if (event.pointerId !== seekPointerId) {
+    return
+  }
+  if (progressEl.value?.hasPointerCapture(event.pointerId)) {
+    progressEl.value.releasePointerCapture(event.pointerId)
+  }
+  seekPointerId = null
 }
 
 function handleSeekKeydown(event: KeyboardEvent) {
@@ -253,7 +280,10 @@ function handleVoiceOverChange(event: Event) {
         aria-valuemin="0"
         aria-valuemax="100"
         tabindex="0"
-        @click="handleSeek"
+        @pointerdown="beginSeek"
+        @pointermove="continueSeek"
+        @pointerup="endSeek"
+        @pointercancel="endSeek"
         @keydown="handleSeekKeydown"
       >
         <span class="wc-widget-progress-ascii" aria-hidden="true">
@@ -438,7 +468,7 @@ function handleVoiceOverChange(event: Event) {
   align-items: center;
   height: 32px;
   cursor: pointer;
-  touch-action: manipulation;
+  touch-action: none;
   -webkit-tap-highlight-color: transparent;
 }
 

--- a/src/tests/wolvesMediaWidget.test.ts
+++ b/src/tests/wolvesMediaWidget.test.ts
@@ -135,7 +135,6 @@ describe('media widget', () => {
     element.releasePointerCapture = vi.fn()
 
     await slider.trigger('pointerdown', { clientX: 200, pointerId: 7, button: 0 })
-    await slider.trigger('pointermove', { clientX: 400, pointerId: 7 })
     await slider.trigger('pointerup', { clientX: 400, pointerId: 7 })
 
     expect(wrapper.emitted('seek')).toEqual([[0.25], [0.75]])

--- a/src/tests/wolvesMediaWidget.test.ts
+++ b/src/tests/wolvesMediaWidget.test.ts
@@ -113,6 +113,36 @@ describe('media widget', () => {
     expect(store.segmentElapsed).toBe(0)
   })
 
+  it('seeks continuously while the progress slider is dragged', async () => {
+    const wrapper = mount(MediaWidget, {
+      props: { elapsed: 0, duration: 110 },
+    })
+    const slider = wrapper.get('.wc-widget-progress')
+    const element = slider.element as HTMLElement
+    element.getBoundingClientRect = vi.fn(() => ({
+      x: 100,
+      y: 0,
+      left: 100,
+      top: 0,
+      right: 500,
+      bottom: 32,
+      width: 400,
+      height: 32,
+      toJSON: () => ({}),
+    }))
+    element.setPointerCapture = vi.fn()
+    element.hasPointerCapture = vi.fn(() => true)
+    element.releasePointerCapture = vi.fn()
+
+    await slider.trigger('pointerdown', { clientX: 200, pointerId: 7, button: 0 })
+    await slider.trigger('pointermove', { clientX: 400, pointerId: 7 })
+    await slider.trigger('pointerup', { clientX: 400, pointerId: 7 })
+
+    expect(wrapper.emitted('seek')).toEqual([[0.25], [0.75]])
+    expect(element.setPointerCapture).toHaveBeenCalledWith(7)
+    expect(element.releasePointerCapture).toHaveBeenCalledWith(7)
+  })
+
   it('shows the plain authored title, not a catalogue credit, for the Director\'s Cut', () => {
     const store = useCinematicStore()
     store.loadExperience(WOLVES_DIRECTORS_CUT_EXPERIENCE)

--- a/src/tests/wolvesTeaserApp.test.ts
+++ b/src/tests/wolvesTeaserApp.test.ts
@@ -1,29 +1,47 @@
-import { flushPromises, mount } from '@vue/test-utils'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount, shallowMount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
+import MediaWidget from '@/components/wolves/cinematic/MediaWidget.vue'
 import { TRAILER_PICTURE_END_SECONDS } from '@/data/wolves-trailer-plates'
 import WolvesTeaserApp from '@/WolvesTeaserApp.vue'
+
+const youtube = vi.hoisted(() => {
+  let onReady: ((event: { target: FakePlayer }) => void) | undefined
+
+  class FakePlayer {
+    static latest: FakePlayer | undefined
+
+    currentTime = 0
+    destroy = vi.fn()
+    getCurrentTime = vi.fn(() => this.currentTime)
+    pauseVideo = vi.fn()
+    playVideo = vi.fn()
+    seekTo = vi.fn((seconds: number) => { this.currentTime = seconds })
+
+    constructor(_element: Element, options: { events?: { onReady?: typeof onReady } }) {
+      FakePlayer.latest = this
+      onReady = options.events?.onReady
+    }
+  }
+
+  return {
+    Player: FakePlayer,
+    load: vi.fn<() => Promise<void>>(),
+    latest: () => FakePlayer.latest,
+    ready: () => FakePlayer.latest && onReady?.({ target: FakePlayer.latest }),
+    reset: () => {
+      FakePlayer.latest = undefined
+      onReady = undefined
+    },
+  }
+})
 
 vi.mock('@/composables/useYoutubeIframeApi', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/composables/useYoutubeIframeApi')>()
   return {
     ...actual,
-    loadYoutubeIframeApi: () => Promise.resolve(),
-    getYoutubePlayerConstructor: () => class FakePlayer {
-      currentTime = 0
-
-      seekTo(seconds: number) {
-        this.currentTime = seconds
-      }
-
-      getCurrentTime() {
-        return this.currentTime
-      }
-
-      playVideo() {}
-      pauseVideo() {}
-      destroy() {}
-    },
+    getYoutubePlayerConstructor: () => youtube.Player,
+    loadYoutubeIframeApi: youtube.load,
   }
 })
 
@@ -31,11 +49,17 @@ interface TeaserHarness {
   seekTo: (seconds: number) => void
 }
 
-describe('wolves teaser bridge', () => {
-  afterEach(() => {
-    delete (window as typeof window & { __wolvesTeaser?: TeaserHarness }).__wolvesTeaser
-  })
+beforeEach(() => {
+  youtube.reset()
+  youtube.load.mockReset()
+  youtube.load.mockResolvedValue()
+})
 
+afterEach(() => {
+  delete (window as typeof window & { __wolvesTeaser?: TeaserHarness }).__wolvesTeaser
+})
+
+describe('wolves teaser bridge', () => {
   it('keeps an opaque black backing over the YouTube picture while the wolf-day wallpaper rises', async () => {
     const wrapper = mount(WolvesTeaserApp, {
       global: {
@@ -82,6 +106,76 @@ describe('wolves teaser bridge', () => {
     expect(Number(wallpaperGroup.element.style.opacity)).toBeCloseTo(0.5, 5)
     expect(night.element.style.opacity).toBe('1')
 
+    wrapper.unmount()
+  })
+})
+
+describe('wolves teaser transport', () => {
+  it('honours Play when the YouTube player becomes ready after the click', async () => {
+    let finishLoading!: () => void
+    youtube.load.mockImplementationOnce(() => new Promise<void>((resolve) => {
+      finishLoading = resolve
+    }))
+    const wrapper = shallowMount(WolvesTeaserApp)
+
+    await wrapper.get('.wt-convenience-play').trigger('click')
+    expect(youtube.latest()).toBeUndefined()
+
+    finishLoading()
+    await flushPromises()
+    expect(youtube.latest()!.playVideo).not.toHaveBeenCalled()
+
+    youtube.ready()
+    await nextTick()
+
+    expect(youtube.latest()!.playVideo).toHaveBeenCalledOnce()
+    expect(wrapper.find('.wt-poster').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('reveals an idle seek and applies it when the player becomes ready', async () => {
+    const wrapper = shallowMount(WolvesTeaserApp)
+    await flushPromises()
+
+    wrapper.getComponent(MediaWidget).vm.$emit('seek', 0.5)
+    await nextTick()
+    expect(wrapper.find('.wt-poster').exists()).toBe(false)
+
+    youtube.ready()
+    expect(youtube.latest()!.seekTo).toHaveBeenCalledWith(55.01, true)
+    expect(youtube.latest()!.playVideo).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  it('ignores a late player-ready event after unmount', async () => {
+    const wrapper = shallowMount(WolvesTeaserApp)
+    await flushPromises()
+    await wrapper.get('.wt-convenience-play').trigger('click')
+
+    wrapper.unmount()
+    youtube.ready()
+
+    expect(youtube.latest()!.destroy).toHaveBeenCalledOnce()
+    expect(youtube.latest()!.playVideo).not.toHaveBeenCalled()
+  })
+
+  it('keeps the video visible while playing, seeking, and paused', async () => {
+    const wrapper = shallowMount(WolvesTeaserApp)
+    await flushPromises()
+    youtube.ready()
+
+    expect(wrapper.find('.wt-poster').exists()).toBe(true)
+
+    await wrapper.get('.wt-convenience-play').trigger('click')
+    expect(wrapper.find('.wt-poster').exists()).toBe(false)
+
+    wrapper.getComponent(MediaWidget).vm.$emit('seek', 0.5)
+    await nextTick()
+    expect(wrapper.find('.wt-poster').exists()).toBe(false)
+
+    wrapper.getComponent(MediaWidget).vm.$emit('togglePlay')
+    await nextTick()
+    expect(wrapper.find('.wt-poster').exists()).toBe(false)
     wrapper.unmount()
   })
 })


### PR DESCRIPTION
## Root cause
The unfinished `fix-wolves-teaser-transport` worktree showed this was not only a drag bug. Three failures combined:

1. the progress control had only a click handler, not pointer drag;
2. Play and Seek intent was discarded before the YouTube player fired `onReady`;
3. the opaque poster returned over sought and paused frames, making successful seeks look broken.

## Fix
- recover the complete unfinished teaser transport implementation and tests
- capture pointer drag and seek through the final pointer-up coordinate
- retain seek/play intent until the player is ready
- keep the requested video frame visible after seek and pause
- add component tests for drag, delayed readiness, idle seek, pause, and late readiness after unmount

## Verification
- focused Vitest: 11 passed
- `npm run lint` — passed
- `npm run typecheck` — passed
- `npm run test:gate` — no new failures
- `CI=true npm run test:run -- --coverage` — 1016 passed, 1 skipped
- `npm run build` — passed
- Chromium delayed-ready drag 20% → 80% — player restored to 88.016s, Play resumed, poster stayed absent, zero page errors

Design surface touched under the owner’s direct request to repair the seek slider.