### PR TITLE
fix(wolves): restore authored black opening

### DIFF
--- a/docs/skills/wolves-teaser/SKILL.md
+++ b/docs/skills/wolves-teaser/SKILL.md
@@ -77,7 +77,7 @@ The real trailer is three concatenated segments, not one video with overlays:
 
 | Window | Picture |
 |---|---|
-| 0 → 88.2 | Nightwish video, letterboxed 2.39:1 into 16:9 |
+| 0 → 88.2 | Nightwish video, letterboxed 2.39:1 into 16:9; black through 12.2 |
 | 88.2 → 102.2 | March Bluefin wallpaper, day fading to night |
 | 102.2 → 115.02 | March Bluefin night wallpaper, as the end-card poster |
 
@@ -85,6 +85,10 @@ The real trailer is three concatenated segments, not one video with overlays:
 
 - `public/img/wallpapers/bluefin-03-day.webp`
 - `public/img/wallpapers/bluefin-03-night.webp`
+
+The raw Nightwish upload is not the authored opening. Keep an opaque black gate
+over the complete player through `BURST = 12.200`, then clear it across exactly
+two 59.94 fps frames (`2 * 1001 / 60000`). The explosion blooms out of black.
 
 The last 26.82 seconds must cover the embed completely. Both day cards and the
 whole end card sit on the wallpaper at full-frame 16:9, with no letterbox. The
@@ -194,7 +198,8 @@ entry surface only: remove it as soon as playback starts and never restore it
 for pause or seek. Covering the player while its clock advances makes Play and
 Seek look broken, and replacing a paused frame with poster art hides the video.
 A transient YouTube centre glyph is less destructive than hiding the requested
-frame.
+frame. This rule applies to the poster, not the authored black gate. The black
+gate still covers the raw upload until the 12.2-second explosion bloom.
 
 `new YT.Player(div, …)` replaces the host div with the iframe. Target the
 resulting iframe through the wrapper's `:deep(iframe)` rule.
@@ -292,6 +297,7 @@ element can collapse below the available width and wrap unexpectedly.
 
 ## Red Flags
 
+- The raw Nightwish upload is visible before the 12.2-second explosion bloom.
 - The embed remains visible after 88.2 seconds.
 - Day cards appear over the music video instead of the March wallpaper.
 - Plate type uses Michroma.
@@ -314,6 +320,8 @@ element can collapse below the available width and wrap unexpectedly.
 
 ## Verification
 
+- [ ] After Play, the complete player is pixel-black at 0 and 12.19 seconds;
+      black opacity is 0.5 halfway through the two-frame reveal and 0 afterward.
 - [ ] Compare the browser against `renders/trailer-1.mp4` at 16, 29, 91, and
       107 seconds through `window.__wolvesTeaser.seekTo()`.
 - [ ] Exactly one surface spells the film title at 0, 12, 18, 24, and 107

--- a/src/WolvesTeaserApp.vue
+++ b/src/WolvesTeaserApp.vue
@@ -20,6 +20,7 @@ import {
   TRAILER_VIDEO_ID,
   trailerBridgeState,
   trailerHeadingOpacity,
+  trailerOpeningBlackOpacity,
   trailerPlateOpacity,
   trailerSegmentAt,
 } from '@/data/wolves-trailer-plates'
@@ -41,6 +42,7 @@ const trailerPhase = ref<TrailerPhase>('idle')
 const now = ref(0)
 
 const visualTime = computed(() => trailerPhase.value === 'ended' ? TRAILER_ENDCARD_HOLD_SECONDS : now.value)
+const openingBlackOpacity = computed(() => trailerOpeningBlackOpacity(visualTime.value))
 const visiblePlates = computed(() => activeTrailerPlates(visualTime.value))
 const plateById = computed(() => new Map(visiblePlates.value.map(plate => [plate.id, plate])))
 
@@ -250,6 +252,15 @@ onBeforeUnmount(() => {
         <div class="wt-player-frame">
           <div ref="playerHost" class="wt-player-host" />
         </div>
+
+        <!-- The raw Nightwish upload is not the authored opening. The delivered
+             cut holds black until the explosion blooms at 12.2 seconds. -->
+        <div
+          v-if="openingBlackOpacity > 0"
+          class="wt-opening-black"
+          :style="{ opacity: openingBlackOpacity }"
+          aria-hidden="true"
+        />
 
         <!-- Segments two and three: the March wallpaper, day falling into
              night, covering the picture for the last 21.8 s. -->
@@ -491,6 +502,7 @@ onBeforeUnmount(() => {
   }
 }
 
+.wt-opening-black,
 .wt-backdrop {
   position: absolute;
   inset: 0;

--- a/src/data/wolves-trailer-plates.ts
+++ b/src/data/wolves-trailer-plates.ts
@@ -41,6 +41,10 @@ export const TRAILER_CUT_DURATION_SECONDS = 115.02
  */
 export const TRAILER_PICTURE_END_SECONDS = 88.2
 export const TRAILER_BRIDGE_END_SECONDS = 102.2
+/** The source picture stays black until the explosion blooms out of it. */
+export const TRAILER_PICTURE_REVEAL_SECONDS = 12.2
+/** Two 59.94 fps frames, matching the delivered trailer's opening gate. */
+export const TRAILER_PICTURE_REVEAL_FADE_SECONDS = 2 * 1001 / 60000
 
 /** `BRIDGE_MONTH = 3` — the owner named `03-bluefin-day`. */
 export const TRAILER_BRIDGE_MONTH = '03'
@@ -207,6 +211,19 @@ export function activeTrailerPlates(timeSeconds: number): TrailerPlate[] {
 }
 
 export type TrailerSegment = 'picture' | 'bridge' | 'endcard'
+
+/** Black cover over the raw Nightwish picture before the authored burst. */
+export function trailerOpeningBlackOpacity(timeSeconds: number): number {
+  if (!Number.isFinite(timeSeconds) || timeSeconds <= TRAILER_PICTURE_REVEAL_SECONDS) {
+    return 1
+  }
+  if (timeSeconds >= TRAILER_PICTURE_REVEAL_SECONDS + TRAILER_PICTURE_REVEAL_FADE_SECONDS) {
+    return 0
+  }
+  return 1 - (
+    timeSeconds - TRAILER_PICTURE_REVEAL_SECONDS
+  ) / TRAILER_PICTURE_REVEAL_FADE_SECONDS
+}
 
 /** Which of the cut's three pictures is on screen at a given timestamp. */
 export function trailerSegmentAt(timeSeconds: number): TrailerSegment {

--- a/src/tests/wolvesTeaserApp.test.ts
+++ b/src/tests/wolvesTeaserApp.test.ts
@@ -2,7 +2,11 @@ import { flushPromises, mount, shallowMount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import MediaWidget from '@/components/wolves/cinematic/MediaWidget.vue'
-import { TRAILER_PICTURE_END_SECONDS } from '@/data/wolves-trailer-plates'
+import {
+  TRAILER_PICTURE_END_SECONDS,
+  TRAILER_PICTURE_REVEAL_FADE_SECONDS,
+  TRAILER_PICTURE_REVEAL_SECONDS,
+} from '@/data/wolves-trailer-plates'
 import WolvesTeaserApp from '@/WolvesTeaserApp.vue'
 
 const youtube = vi.hoisted(() => {
@@ -60,6 +64,33 @@ afterEach(() => {
 })
 
 describe('wolves teaser bridge', () => {
+  it('covers Nightwish with black until the authored explosion bloom', async () => {
+    const wrapper = mount(WolvesTeaserApp, {
+      global: {
+        stubs: {
+          MediaWidget: true,
+          WolvesBackCatalogue: true,
+          WolvesTrailerLine: true,
+        },
+      },
+    })
+    await flushPromises()
+    const harness = (window as typeof window & { __wolvesTeaser: TeaserHarness }).__wolvesTeaser
+
+    harness.seekTo(TRAILER_PICTURE_REVEAL_SECONDS - 0.01)
+    await nextTick()
+    expect(wrapper.get<HTMLElement>('.wt-opening-black').element.style.opacity).toBe('1')
+
+    harness.seekTo(TRAILER_PICTURE_REVEAL_SECONDS + TRAILER_PICTURE_REVEAL_FADE_SECONDS / 2)
+    await nextTick()
+    expect(Number(wrapper.get<HTMLElement>('.wt-opening-black').element.style.opacity)).toBeCloseTo(0.5, 5)
+
+    harness.seekTo(TRAILER_PICTURE_REVEAL_SECONDS + TRAILER_PICTURE_REVEAL_FADE_SECONDS)
+    await nextTick()
+    expect(wrapper.find('.wt-opening-black').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
   it('keeps an opaque black backing over the YouTube picture while the wolf-day wallpaper rises', async () => {
     const wrapper = mount(WolvesTeaserApp, {
       global: {

--- a/src/tests/wolvesTrailerPlates.test.ts
+++ b/src/tests/wolvesTrailerPlates.test.ts
@@ -12,11 +12,14 @@ import {
   TRAILER_ENDCARD_HOLD_SECONDS,
   TRAILER_HEADING_YIELD_SECONDS,
   TRAILER_PICTURE_END_SECONDS,
+  TRAILER_PICTURE_REVEAL_FADE_SECONDS,
+  TRAILER_PICTURE_REVEAL_SECONDS,
   TRAILER_PLATES,
   TRAILER_TITLE_LABEL,
   TRAILER_VIDEO_ID,
   trailerBridgeState,
   trailerHeadingOpacity,
+  trailerOpeningBlackOpacity,
   trailerPlateOpacity,
   trailerSegmentAt,
 } from '@/data/wolves-trailer-plates'
@@ -140,6 +143,18 @@ describe('wolves trailer plates', () => {
 // The cut is three concatenated pictures, not one video with overlays. The
 // first recreation missed this and drew the last 21.8 s over the music video.
 describe('wolves trailer segments', () => {
+  it('holds the opening black until the authored explosion bloom', () => {
+    expect(TRAILER_PICTURE_REVEAL_SECONDS).toBe(12.2)
+    expect(trailerOpeningBlackOpacity(0)).toBe(1)
+    expect(trailerOpeningBlackOpacity(TRAILER_PICTURE_REVEAL_SECONDS)).toBe(1)
+    expect(trailerOpeningBlackOpacity(
+      TRAILER_PICTURE_REVEAL_SECONDS + TRAILER_PICTURE_REVEAL_FADE_SECONDS / 2,
+    )).toBeCloseTo(0.5, 5)
+    expect(trailerOpeningBlackOpacity(
+      TRAILER_PICTURE_REVEAL_SECONDS + TRAILER_PICTURE_REVEAL_FADE_SECONDS,
+    )).toBe(0)
+  })
+
   it('leaves the music video at 88.2 and never returns to it', () => {
     expect(trailerSegmentAt(0)).toBe('picture')
     expect(trailerSegmentAt(88.19)).toBe('picture')


### PR DESCRIPTION
## Fix
- cover the raw Nightwish upload with opaque black through the authored 12.200-second burst
- clear black across the same two 59.94 fps frames as the delivered trailer
- preserve seek dragging and delayed-player readiness from #752

## Verification
- focused Vitest: 34 passed
- lint, typecheck, test gate, and build passed
- Chromium after Play: complete player pixel-black at time zero
- Chromium clock checks: opacity 1 before 12.2s, 0.5 halfway through the two-frame bloom, then removed
- zero page errors

Design surface touched under the owner’s direct instruction to restore the black opening.