### PR TITLE
fix(wolves): play full trailer runtime

### DIFF
--- a/docs/skills/wolves-teaser/SKILL.md
+++ b/docs/skills/wolves-teaser/SKILL.md
@@ -93,6 +93,8 @@ two 59.94 fps frames (`2 * 1001 / 60000`). The explosion blooms out of black.
 The last 26.82 seconds must cover the embed completely. Both day cards and the
 whole end card sit on the wallpaper at full-frame 16:9, with no letterbox. The
 music ends at 110.02 seconds, then the URL card holds for five silent seconds.
+The raw player must pause only after the 1:47 howl and the music fade complete.
+A wall clock then advances the transport to the full 115.02-second picture end.
 The bridge's black backing is opaque from the 88.2-second cut onward; fade the
 wallpaper images over that backing, never the whole backdrop. Fading the
 backdrop itself exposes post-cut YouTube frames during the black-to-day rise.
@@ -266,10 +268,12 @@ The progress control must seek continuously during pointer drag. A click-only
 `touch-action: none` on the track so a touch drag seeks instead of scrolling
 the page.
 
-At natural end, keep transport time at `1:50 / 1:50` while the visual clock
-holds at `TRAILER_ENDCARD_HOLD_SECONDS`, immediately before the URL card's fade.
-Do not show the poster over the ended phase; it would replace the requested
-last screen.
+The transport has two clocks. YouTube supplies 0–110.02 seconds so the 1:47
+howl and final music fade play. Pause YouTube at 110.02, then use a wall clock
+for the five-second silent URL hold. The widget must reach `1:55 / 1:55` while
+the visual clock stays at `TRAILER_ENDCARD_HOLD_SECONDS`, immediately before
+the URL card's fade. Do not show the poster over the ended phase; it would
+replace the requested last screen.
 
 ## Inline Mark Trap
 
@@ -308,6 +312,7 @@ element can collapse below the available width and wrap unexpectedly.
 - A second teaser-only transport copies `MediaWidget` markup or styles.
 - Play is available only in the fixed widget and is not obvious on initial load.
 - Fullscreen targets the iframe, causing the title, overlays, or widget to disappear.
+- The transport ends at 1:50 instead of advancing through the silent hold to 1:55.
 - Ended state shows the poster or a faded/empty end card instead of the URL.
 - Play or Seek advances behind an opaque poster, or Pause replaces the current frame.
 - The progress control jumps on click but does not track mouse or touch drag.
@@ -340,7 +345,8 @@ element can collapse below the available width and wrap unexpectedly.
       work through the external media-widget mode without restoring the poster.
 - [ ] The idle Play and Fullscreen buttons are centered and keyboard accessible;
       fullscreen owns `.wt-stage` and exposes an Exit Fullscreen label.
-- [ ] Natural end shows the fully opaque `wolves.projectbluefin.io` card while
-      the widget reads `1:50 / 1:50`; no poster is present.
+- [ ] The 1:47 howl plays before YouTube pauses at 1:50.02; the silent hold
+      advances to `1:55 / 1:55` with a fully opaque `wolves.projectbluefin.io`
+      card and no poster.
 - [ ] `src/tests/wolvesTrailerPlates.test.ts`, lint, typecheck, `test:gate`, and
       build pass.

--- a/src/WolvesTeaserApp.vue
+++ b/src/WolvesTeaserApp.vue
@@ -15,6 +15,7 @@ import {
   TRAILER_CREDIT_LINE,
   TRAILER_DURATION_SECONDS,
   TRAILER_ENDCARD_HOLD_SECONDS,
+  TRAILER_MUSIC_END_SECONDS,
   TRAILER_TITLE_LABEL,
   TRAILER_TITLE_LINE,
   TRAILER_VIDEO_ID,
@@ -36,12 +37,15 @@ const fullscreenActive = ref(false)
 let player: YoutubePlayer | null = null
 let playerReady = false
 let clockTimer: ReturnType<typeof setInterval> | null = null
+let silentHoldStartedAtMs: number | null = null
 
 type TrailerPhase = 'idle' | 'playing' | 'paused' | 'ended'
 const trailerPhase = ref<TrailerPhase>('idle')
 const now = ref(0)
 
-const visualTime = computed(() => trailerPhase.value === 'ended' ? TRAILER_ENDCARD_HOLD_SECONDS : now.value)
+const visualTime = computed(() => now.value >= TRAILER_MUSIC_END_SECONDS
+  ? TRAILER_ENDCARD_HOLD_SECONDS
+  : now.value)
 const openingBlackOpacity = computed(() => trailerOpeningBlackOpacity(visualTime.value))
 const visiblePlates = computed(() => activeTrailerPlates(visualTime.value))
 const plateById = computed(() => new Map(visiblePlates.value.map(plate => [plate.id, plate])))
@@ -104,7 +108,25 @@ function stopClock() {
   }
 }
 
+function startSilentHold(from = now.value) {
+  player?.pauseVideo?.()
+  now.value = Math.min(Math.max(from, TRAILER_MUSIC_END_SECONDS), TRAILER_DURATION_SECONDS)
+  silentHoldStartedAtMs = Date.now() - (now.value - TRAILER_MUSIC_END_SECONDS) * 1000
+}
+
 function tick() {
+  if (silentHoldStartedAtMs !== null) {
+    now.value = Math.min(
+      TRAILER_MUSIC_END_SECONDS + (Date.now() - silentHoldStartedAtMs) / 1000,
+      TRAILER_DURATION_SECONDS,
+    )
+    if (now.value >= TRAILER_DURATION_SECONDS) {
+      silentHoldStartedAtMs = null
+      trailerPhase.value = 'ended'
+      stopClock()
+    }
+    return
+  }
   if (!playerReady) {
     return
   }
@@ -112,13 +134,8 @@ function tick() {
   if (typeof t !== 'number') {
     return
   }
-  // Stop the transport at 1:50.020. The visual clock independently holds the
-  // fully visible URL card immediately before its authored fade-out.
-  if (t >= TRAILER_DURATION_SECONDS) {
-    now.value = TRAILER_DURATION_SECONDS
-    player?.pauseVideo?.()
-    trailerPhase.value = 'ended'
-    stopClock()
+  if (t >= TRAILER_MUSIC_END_SECONDS) {
+    startSilentHold(TRAILER_MUSIC_END_SECONDS)
     return
   }
   now.value = t
@@ -131,7 +148,10 @@ function startClock() {
 
 function playTrailer() {
   trailerPhase.value = 'playing'
-  if (playerReady) {
+  if (now.value >= TRAILER_MUSIC_END_SECONDS) {
+    startSilentHold(now.value)
+  }
+  else if (playerReady) {
     player?.playVideo?.()
   }
   startClock()
@@ -139,7 +159,11 @@ function playTrailer() {
 
 function toggleTrailer() {
   if (trailerPhase.value === 'playing') {
-    if (playerReady) {
+    if (silentHoldStartedAtMs !== null) {
+      tick()
+      silentHoldStartedAtMs = null
+    }
+    else if (playerReady) {
       player?.pauseVideo?.()
     }
     trailerPhase.value = 'paused'
@@ -156,16 +180,27 @@ function toggleTrailer() {
 function seekTrailer(ratio: number) {
   const target = Math.min(Math.max(ratio, 0), 1) * TRAILER_DURATION_SECONDS
   now.value = target
-  if (playerReady) {
-    player?.seekTo?.(target, true)
-  }
-  if (trailerPhase.value === 'idle' || (trailerPhase.value === 'ended' && target < TRAILER_DURATION_SECONDS)) {
+  if (trailerPhase.value === 'idle' || trailerPhase.value === 'ended') {
     trailerPhase.value = 'paused'
+  }
+  if (target >= TRAILER_MUSIC_END_SECONDS) {
+    player?.seekTo?.(TRAILER_MUSIC_END_SECONDS, true)
+    player?.pauseVideo?.()
+    silentHoldStartedAtMs = trailerPhase.value === 'playing'
+      ? Date.now() - (target - TRAILER_MUSIC_END_SECONDS) * 1000
+      : null
+  }
+  else {
+    silentHoldStartedAtMs = null
+    if (playerReady) {
+      player?.seekTo?.(target, true)
+    }
   }
 }
 
 function replayTrailer() {
   now.value = 0
+  silentHoldStartedAtMs = null
   trailerPhase.value = 'playing'
   if (playerReady) {
     player?.seekTo?.(0, true)
@@ -199,9 +234,12 @@ onMounted(async () => {
           }
           playerReady = true
           if (now.value > 0) {
-            target.seekTo?.(now.value, true)
+            target.seekTo?.(Math.min(now.value, TRAILER_MUSIC_END_SECONDS), true)
           }
-          if (trailerPhase.value === 'playing') {
+          if (trailerPhase.value === 'playing' && now.value >= TRAILER_MUSIC_END_SECONDS) {
+            startSilentHold(now.value)
+          }
+          else if (trailerPhase.value === 'playing') {
             target.playVideo?.()
           }
         },
@@ -212,10 +250,7 @@ onMounted(async () => {
       // browser verification can jump the trailer clock instead of watching
       // 110 seconds of footage on every run.
       ;(window as any).__wolvesTeaser = {
-        seekTo: (s: number) => {
-          player?.seekTo?.(s, true)
-          now.value = s
-        },
+        seekTo: (s: number) => seekTrailer(s / TRAILER_DURATION_SECONDS),
         now: () => now.value,
         segment: () => segment.value,
       }
@@ -233,6 +268,7 @@ onBeforeUnmount(() => {
   player?.destroy?.()
   player = null
   playerReady = false
+  silentHoldStartedAtMs = null
 })
 </script>
 

--- a/src/data/wolves-trailer-plates.ts
+++ b/src/data/wolves-trailer-plates.ts
@@ -30,10 +30,12 @@
  */
 export const TRAILER_VIDEO_ID = 'O0lyFqLr3Cc'
 
-/** The source music and embedded player stop at the approved 1:50.020 mark. */
-export const TRAILER_DURATION_SECONDS = 110.02
+/** The source music stops after the howl and its approved fade. */
+export const TRAILER_MUSIC_END_SECONDS = 110.02
 /** The delivered picture holds the URL for five silent seconds after the music. */
-export const TRAILER_CUT_DURATION_SECONDS = 115.02
+export const TRAILER_DURATION_SECONDS = 115.02
+/** Compatibility name for records that describe picture rather than transport. */
+export const TRAILER_CUT_DURATION_SECONDS = TRAILER_DURATION_SECONDS
 
 /**
  * Segment boundaries, from `scripts/build_trailer1.py`:

--- a/src/tests/wolvesTeaserApp.test.ts
+++ b/src/tests/wolvesTeaserApp.test.ts
@@ -3,6 +3,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import MediaWidget from '@/components/wolves/cinematic/MediaWidget.vue'
 import {
+  TRAILER_DURATION_SECONDS,
+  TRAILER_MUSIC_END_SECONDS,
   TRAILER_PICTURE_END_SECONDS,
   TRAILER_PICTURE_REVEAL_FADE_SECONDS,
   TRAILER_PICTURE_REVEAL_SECONDS,
@@ -60,6 +62,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  vi.useRealTimers()
   delete (window as typeof window & { __wolvesTeaser?: TeaserHarness }).__wolvesTeaser
 })
 
@@ -173,8 +176,27 @@ describe('wolves teaser transport', () => {
     expect(wrapper.find('.wt-poster').exists()).toBe(false)
 
     youtube.ready()
-    expect(youtube.latest()!.seekTo).toHaveBeenCalledWith(55.01, true)
+    expect(youtube.latest()!.seekTo).toHaveBeenCalledWith(TRAILER_DURATION_SECONDS / 2, true)
     expect(youtube.latest()!.playVideo).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  it('plays through the howl, then advances a silent five-second URL hold', async () => {
+    vi.useFakeTimers()
+    const wrapper = shallowMount(WolvesTeaserApp)
+    await flushPromises()
+    youtube.ready()
+    await wrapper.get('.wt-convenience-play').trigger('click')
+
+    youtube.latest()!.currentTime = TRAILER_MUSIC_END_SECONDS
+    await vi.advanceTimersByTimeAsync(100)
+    expect(youtube.latest()!.pauseVideo).toHaveBeenCalled()
+    expect(wrapper.getComponent(MediaWidget).props('duration')).toBe(TRAILER_DURATION_SECONDS)
+    expect(wrapper.getComponent(MediaWidget).props('elapsed')).toBeCloseTo(TRAILER_MUSIC_END_SECONDS, 2)
+
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(wrapper.getComponent(MediaWidget).props('elapsed')).toBeCloseTo(TRAILER_DURATION_SECONDS, 2)
+    expect(wrapper.getComponent(MediaWidget).props('playing')).toBe(false)
     wrapper.unmount()
   })
 

--- a/src/tests/wolvesTrailerPlates.test.ts
+++ b/src/tests/wolvesTrailerPlates.test.ts
@@ -11,6 +11,7 @@ import {
   TRAILER_DURATION_SECONDS,
   TRAILER_ENDCARD_HOLD_SECONDS,
   TRAILER_HEADING_YIELD_SECONDS,
+  TRAILER_MUSIC_END_SECONDS,
   TRAILER_PICTURE_END_SECONDS,
   TRAILER_PICTURE_REVEAL_FADE_SECONDS,
   TRAILER_PICTURE_REVEAL_SECONDS,
@@ -30,15 +31,16 @@ import {
 describe('wolves trailer plates', () => {
   it('keeps the music at 1:50.020 and the picture through 1:55.020', () => {
     expect(TRAILER_VIDEO_ID).toBe('O0lyFqLr3Cc')
-    expect(TRAILER_DURATION_SECONDS).toBe(110.02)
-    expect(TRAILER_CUT_DURATION_SECONDS).toBe(115.02)
+    expect(TRAILER_MUSIC_END_SECONDS).toBe(110.02)
+    expect(TRAILER_DURATION_SECONDS).toBe(115.02)
+    expect(TRAILER_CUT_DURATION_SECONDS).toBe(TRAILER_DURATION_SECONDS)
   })
 
   it('shows nothing before the main title and after the cut ends', () => {
     expect(activeTrailerPlates(0)).toEqual([])
     expect(activeTrailerPlates(10.9)).toEqual([])
-    expect(activeTrailerPlates(TRAILER_DURATION_SECONDS).map(p => p.id)).toEqual(['endcard-event', 'endcard-cta'])
-    expect(activeTrailerPlates(TRAILER_CUT_DURATION_SECONDS)).toEqual([])
+    expect(activeTrailerPlates(TRAILER_MUSIC_END_SECONDS).map(p => p.id)).toEqual(['endcard-event', 'endcard-cta'])
+    expect(activeTrailerPlates(TRAILER_DURATION_SECONDS)).toEqual([])
     expect(activeTrailerPlates(Number.NaN)).toEqual([])
   })
 


### PR DESCRIPTION
## Fix
- keep YouTube playing through the 1:47 climatic howl and music fade
- pause source audio at 1:50.020
- advance the transport through the five-second silent URL hold
- end at the full 1:55.020 picture runtime
- keep the URL fully visible throughout the silent hold

## Verification
- focused Vitest: 35 passed
- lint, typecheck, test gate, and build passed
- Chromium at 1:47: player still playing, no pause calls
- Chromium at 1:50: source paused and silent hold started
- Chromium at 1:55: widget reads 1:55 / 1:55, URL visible, poster absent, zero page errors

Design surface touched under the owner’s direct instruction to restore the full runtime and climatic howl.