### PR TITLE
feat(wolves): play the delivered Trailer 1.1 render

### DIFF
--- a/docs/skills/wolves-teaser/SKILL.md
+++ b/docs/skills/wolves-teaser/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wolves-teaser
-description: Use when changing the `/wolves/` teaser hero, Trailer 1 player, browser-rendered trailer plates, poster, bridge, end card, or trailer fidelity tests.
+description: Use when changing the `/wolves/` teaser hero, Trailer 1 player, the delivered-render embed, poster, ended URL card, or trailer fidelity tests.
 metadata:
   context7-sources:
     - /websites/tailwindcss
@@ -11,13 +11,17 @@ metadata:
 ## Overview
 
 Keep `/wolves/` faithful to the owner-authored Trailer 1 cut while preserving
-its role as a teaser website. The page owns a chromeless YouTube iframe, the
-browser-rendered plate treatment, the day-to-night wallpaper bridge, the end
-card, and links into `/wolves/experience/`.
+its role as a teaser website. The page owns a chromeless YouTube iframe that
+plays the owner's delivered render of the cut — every plate, the bridge, and
+the end card are burned into the video — plus three browser jobs around it:
+the page heading's yield, an opening black mask, and one browser-drawn URL
+card that covers YouTube's endscreen after the cut ends. Below the stage, the
+page links into `/wolves/experience/`.
 
 The trailer design is not derivable from one manifest. Its copy and timing,
 visual treatment, composition, and rendered result live in separate
-`destiny-vids` sources. Read all of them before changing the recreation.
+`destiny-vids` sources, and the playable picture is the owner's own YouTube
+upload. Read the sources before changing what the records describe.
 
 ## When to Use
 
@@ -27,8 +31,8 @@ Use this skill when changing:
 - `src/components/wolves/WolvesTrailerLine.vue`
 - `src/data/wolves-trailer-plates.ts`
 - `src/tests/wolvesTrailerPlates.test.ts`
-- the teaser poster, hero placement, player geometry, plate styling, bridge,
-  end card, or trailer-specific assets
+- the teaser poster, hero placement, player geometry, the ended URL card, or
+  trailer-specific assets
 
 ## When NOT to Use
 
@@ -43,17 +47,24 @@ Use this skill when changing:
 
 ## Core Process
 
-1. Read the authoritative `destiny-vids` sources listed below.
-2. Re-port copy and timing; never reword or nudge the owner's record locally.
-3. Reproduce card design from the card templates, not from the timing manifest.
-4. Preserve the three-picture composition and iframe/frame geometry.
-5. Pin timing, treatments, segments, and lossless tokenisation in
+1. Read the authoritative sources listed below.
+2. The embed is the owner's delivered render. Never redraw its plates in the
+   browser while it plays — a browser plate over the burned-in plate is a
+   double-draw and a defect.
+3. Keep `wolves-trailer-plates.ts` as the authored record; never reword or
+   nudge the owner's copy locally. The records drive the heading yield, the
+   opening black mask, and the ended URL card.
+4. Pin timing, treatments, segments, and lossless tokenisation in
    `wolvesTrailerPlates.test.ts`.
-6. Drive the dev-only `window.__wolvesTeaser` harness to the reference beats.
-7. Compare desktop and mobile bounds against the rendered cut.
-8. Run lint, typecheck, focused tests, `test:gate`, and build.
+5. Drive the dev-only `window.__wolvesTeaser` harness to the reference beats.
+6. Compare desktop and mobile against the render at the same timestamps.
+7. Run lint, typecheck, focused tests, `test:gate`, and build.
 
 ## Sources of Truth
+
+The playable picture is the owner's own upload: YouTube `iHXBTH_fwB0`,
+"Wolves Trailer Final" — the delivered 4K60 render of Trailer 1.1. Verify any
+swap beat by beat against the authored schedule before trusting it.
 
 All paths in this table are relative to `~/src/destiny-vids`.
 
@@ -71,71 +82,47 @@ The manifest carries windows and copy. It does **not** carry the design. A
 manifest-only implementation can be numerically correct and still look nothing
 like the film.
 
-## The Cut Is Three Pictures
+## The Cut Is the Delivered Render
 
-The real trailer is three concatenated segments, not one video with overlays:
+The render is full-frame 16:9 throughout, 114.998 s against an authored
+115.02 s, with music and every plate burned in. Its three segments:
 
 | Window | Picture |
 |---|---|
-| 0 → 88.2 | Nightwish video, letterboxed 2.39:1 into 16:9; black through 12.2 |
-| 88.2 → 102.2 | March Bluefin wallpaper, day fading to night |
-| 102.2 → 115.02 | March Bluefin night wallpaper, as the end-card poster |
+| 0 → 88.2 | the picture; black through 12.2 |
+| 88.2 → 102.2 | day falling into night |
+| 102.2 → 115.02 | the night scene as the end-card poster |
 
-`BRIDGE_MONTH = 3`; the local assets are:
+Because the render carries the cut, the browser draws nothing over the playing
+video. The three remaining browser jobs:
 
-- `public/img/wallpapers/bluefin-03-day.webp`
-- `public/img/wallpapers/bluefin-03-night.webp`
+- **Opening black mask.** Keep an opaque black gate over the player through
+  `BURST = 12.200`, cleared across exactly two 59.94 fps frames
+  (`2 * 1001 / 60000`). The render opens on the same black, so the mask hides
+  YouTube's startup chrome and is pixel-identical to the cut beneath it.
+- **Heading yield.** The page `h1` still steps aside before the render's own
+  title card (see "The Title Lands Once").
+- **Ended URL card.** When the cut ends, YouTube paints an endscreen over the
+  faded-to-black last frame. Cover it with the teaser's held URL card — the
+  March night wallpaper (`public/img/wallpapers/bluefin-03-night.webp`) under
+  the browser-drawn event rows and the `wolves.projectbluefin.io` CTA — in the
+  same treatment the cut's own end card uses. The end-card records' opacities
+  all resolve to 1 at `TRAILER_ENDCARD_HOLD_SECONDS` (113.82), so the ended
+  overlay is a fully arrived frame, never a mid-fade one.
 
-The raw Nightwish upload is not the authored opening. Keep an opaque black gate
-over the complete player through `BURST = 12.200`, then clear it across exactly
-two 59.94 fps frames (`2 * 1001 / 60000`). The explosion blooms out of black.
-
-The last 26.82 seconds must cover the embed completely. Both day cards and the
-whole end card sit on the wallpaper at full-frame 16:9, with no letterbox. The
-music ends at 110.02 seconds, then the URL card holds for five silent seconds.
-The raw player must pause only after the 1:47 howl and the music fade complete.
-A wall clock then advances the transport to the full 115.02-second picture end.
-The bridge's black backing is opaque from the 88.2-second cut onward; fade the
-wallpaper images over that backing, never the whole backdrop. Fading the
-backdrop itself exposes post-cut YouTube frames during the black-to-day rise.
-
-The bridge's five authored legs are:
-
-| Leg | Seconds |
-|---|---:|
-| black → day | 1.4 |
-| day hold | 1.0 |
-| day → night | 4.4 |
-| night hold | 1.4 |
-| night → black | 5.8 |
-
-They total 14.0 seconds and open and close on black.
+End detection is redundant on purpose: the `onStateChange` ENDED event **and**
+a clock tolerance (`getCurrentTime()` within 0.05 s of the 115.02 s duration),
+because the encode stops at 114.998 s and the event may never fire.
 
 ## Coordinate Mapping and Sizing
 
-Cards are authored at 1920×1080. The 1920×804 picture occupies y=138..942 in
-the letterboxed frame.
-
-- Wallpaper segments are full-frame; percentages map directly.
-- Main title is centred at y=540, so it remains 50%.
-- Day cards use `top: 58%` directly because they are on the full-frame
-  wallpaper, not the letterboxed picture.
-- Book anchor `[1030,443]` maps to `left: 53.6%; top: 41%` in the 16:9 frame.
-- The second book record keeps source anchor `[1000,470]` but its rendered PNG
-  has no alpha pixels; it is timing metadata, not a visible box.
-
-All plate type sizes key off **player width**. Every card clamp resolves to its
-maximum at 1920px. Put `container-type: inline-size` on the player and express
-plate sizes in `cqw`, where 1cqw is 1% of frame width.
+Only the ended URL card is browser-drawn. Its type sizes key off **player
+width**: every card clamp resolves to its maximum at 1920px, so the player
+carries `container-type: inline-size` and card sizes are expressed in `cqw`,
+where 1cqw is 1% of frame width.
 
 | Element | Card value | px at 1920 | cqw |
 |---|---|---:|---:|
-| title | `clamp(3.2rem,5.8vw,4.9rem)` | 78.4 | 4.0833 |
-| eyebrow | `clamp(1.8rem,3vw,2.6rem)` | 41.6 | 2.1667 |
-| subtitle | `clamp(1.5rem,2.4vw,2.1rem)` | 33.6 | 1.75 |
-| credits | `1.5rem` | 24 | 1.25 |
-| day-card line | `clamp(2.8rem,5vw,5.2rem)` | 83.2 | 4.3333 |
-| book line | `3.8rem` | 60.8 | 3.1667 |
 | poster CTA | `clamp(2.8rem,5vw,5.2rem)` | 83.2 | 4.3333 |
 | poster title | `clamp(1.7rem,2.5vw,2.45rem)` | 39.2 | 2.0417 |
 | poster subtitle | `clamp(1.1rem,1.7vw,1.5rem)` | 24 | 1.25 |
@@ -145,6 +132,9 @@ The card root is 16px. `wolves-cinematic.scss` sets the site's root near 10px,
 so never copy `rem` values across directly; convert through the px column.
 
 ## Authored Treatments
+
+These rules govern the ended URL card and any future browser-drawn plate; the
+render's own plates already carry them.
 
 1. **Every B/b and F/f is blue** at `#4285f4`, the Bluefin wordmark blue.
    It is not `--wc-gold` (`#60a5fa`), which is a UI token. Do not apply this
@@ -170,6 +160,10 @@ authored token unless the owner asks to reproduce the render host's fallback.
 
 ## Plate Schedule
 
+These windows are burned into the render; the records remain the authored
+description and drive the heading yield (`maintitle`) and the ended URL card
+(`endcard-*`). The book and day-card records no longer have browser elements.
+
 | ID | Window | Notes |
 |---|---|---|
 | `maintitle-a` | 11.0–15.4 | title only; credits hidden |
@@ -181,17 +175,16 @@ authored token unless the owner asks to reproduce the render host's fallback.
 | `endcard-event` | 102.2–115.02 | title, subtitle, hairline |
 | `endcard-cta` | 105.2–115.02 | CTA and tags over the event card |
 
-The book box is opaque `rgb(4 10 20)`, with a 4px `#60a5fa` left border,
-3px radius, `1.35rem 2rem` card-root padding, line-height 1.7, and max-width
-82%. It is not rotated and hard-cuts; it must hide the printed page beneath it.
-
 ## Iframe Geometry
 
-The player is the delivered 16:9 frame. Inside it, `.wt-player-frame` is the
-clipped 1920:804 picture aperture. Centre a **16:9 iframe** inside that aperture:
-its height is 134.328% of the aperture, so YouTube's own top and bottom
-letterbox bars fall outside the clipped area. That hides the title/share/logo
-chrome without masking or cropping the film itself.
+The player is the delivered 16:9 frame and the render fills it edge to edge:
+`.wt-player-frame` is `inset: 0` and the iframe is 100% × 100%. There is no
+aperture — an earlier recreation embedded a letterboxed 2.39:1 music video and
+clipped YouTube's chrome into a 1920:804 aperture, and that geometry went away
+with that source. Verify a new source's actual frame before reviving it: a 200
+from the dev server is not proof (the SPA fallback answers 200 for missing
+assets), and a container's 16:9 says nothing about baked bars — extract frames
+and look.
 
 Set `pointer-events: none` on the iframe. Playback belongs to the site's media
 widget; allowing pointer hover over the cross-origin iframe asks YouTube to
@@ -201,7 +194,7 @@ for pause or seek. Covering the player while its clock advances makes Play and
 Seek look broken, and replacing a paused frame with poster art hides the video.
 A transient YouTube centre glyph is less destructive than hiding the requested
 frame. This rule applies to the poster, not the authored black gate. The black
-gate still covers the raw upload until the 12.2-second explosion bloom.
+gate still covers the embed until the 12.2-second reveal.
 
 `new YT.Player(div, …)` replaces the host div with the iframe. Target the
 resulting iframe through the wrapper's `:deep(iframe)` rule.
@@ -268,12 +261,12 @@ The progress control must seek continuously during pointer drag. A click-only
 `touch-action: none` on the track so a touch drag seeks instead of scrolling
 the page.
 
-The transport has two clocks. YouTube supplies 0–110.02 seconds so the 1:47
-howl and final music fade play. Pause YouTube at 110.02, then use a wall clock
-for the five-second silent URL hold. The widget must reach `1:55 / 1:55` while
-the visual clock stays at `TRAILER_ENDCARD_HOLD_SECONDS`, immediately before
-the URL card's fade. Do not show the poster over the ended phase; it would
-replace the requested last screen.
+The transport clock is YouTube's own for the full 115.02-second runtime: the
+render carries the music, the howl, and the five-second URL hold itself, so
+there is no synthetic silent hold. The widget reaches `1:55 / 1:55` as the
+video ends, and the ended phase freezes the URL card at
+`TRAILER_ENDCARD_HOLD_SECONDS` over YouTube's endscreen. Do not show the poster
+over the ended phase; it would replace the requested last screen.
 
 ## Inline Mark Trap
 
@@ -293,7 +286,8 @@ element can collapse below the available width and wrap unexpectedly.
 | Rationalization | Reality |
 |---|---|
 | "The timing manifest is authoritative, so it is enough." | It has no plate design and no three-picture composition. Read the cards and builder. |
-| "The iframe should match the 1920:804 aperture." | Chrome then paints over the picture. Use a clipped aperture around a centred 16:9 iframe. |
+| "The browser should keep drawing its plates over the new video." | The render has every plate burned in; a browser copy is a double-draw. |
+| "The new video is 16:9, so the old aperture math still applies." | Container aspect says nothing about baked bars. Extract frames and measure. |
 | "A dark scrim makes the words safer." | The owner explicitly removed it. Use the authored glyph halo. |
 | "The helm is just an image; default image CSS is fine." | Preflight makes it block-level and breaks the word. |
 | "The title looks centred." | Measure line count and bounds; visual inspection missed the three-line helm break. |
@@ -301,23 +295,25 @@ element can collapse below the available width and wrap unexpectedly.
 
 ## Red Flags
 
-- The raw Nightwish upload is visible before the 12.2-second explosion bloom.
-- The embed remains visible after 88.2 seconds.
-- Day cards appear over the music video instead of the March wallpaper.
+- YouTube startup chrome is visible before the 12.2-second reveal.
+- A browser-drawn plate appears over the playing render (double-draw).
+- The video is swapped for a different upload without beat-by-beat frame
+  verification against the authored schedule.
 - Plate type uses Michroma.
 - A plate has a full-card translucent background.
 - An empty `book-b` record renders as a collapsed box.
 - The title or *Extinction* wraps only when the helm is present.
-- YouTube chrome occupies the frame's black bars or overlays the picture.
+- YouTube chrome or its endscreen overlays the picture; the ended phase must
+  cover it with the opaque URL card.
 - A second teaser-only transport copies `MediaWidget` markup or styles.
 - Play is available only in the fixed widget and is not obvious on initial load.
 - Fullscreen targets the iframe, causing the title, overlays, or widget to disappear.
-- The transport ends at 1:50 instead of advancing through the silent hold to 1:55.
+- The transport parks at 1:50 or ends early instead of reaching 1:55 / 1:55.
 - Ended state shows the poster or a faded/empty end card instead of the URL.
 - Play or Seek advances behind an opaque poster, or Pause replaces the current frame.
 - The progress control jumps on click but does not track mouse or touch drag.
 - The iframe accepts pointer events.
-- The page heading and the authored title card are legible at the same time, or
+- The page heading and the render's title card are legible at the same time, or
   the poster names the film.
 - The heading is hidden with `display`/`v-if`, moving the frame up the page.
 - The event title's B/F is recoloured, or the CTA's b/f is blue.
@@ -327,26 +323,22 @@ element can collapse below the available width and wrap unexpectedly.
 
 - [ ] After Play, the complete player is pixel-black at 0 and 12.19 seconds;
       black opacity is 0.5 halfway through the two-frame reveal and 0 afterward.
-- [ ] Compare the browser against `renders/trailer-1.mp4` at 16, 29, 91, and
-      107 seconds through `window.__wolvesTeaser.seekTo()`.
-- [ ] Exactly one surface spells the film title at 0, 12, 18, 24, and 107
-      seconds, measured from folded opacity and bounds, not by eye.
+- [ ] The browser adds nothing over the render at 13, 30, 95, 104, and 108
+      seconds, driven there with `window.__wolvesTeaser.seekTo()` — no lockup,
+      no backdrop, no day card.
+- [ ] Exactly one surface spells the film title at 0, 12, and 18 seconds,
+      measured from folded opacity and bounds, not by eye.
 - [ ] The heading's box is unchanged across the yield at 1920×1080 and 390×844.
-- [ ] Main title occupies exactly one computed line-height.
-- [ ] Book box centre is 53.6% / 41% for `book-a`; transparent `book-b`
-      produces no `.wt-book` element.
-- [ ] Both day cards report the same vertical centre; only one has a helm, so a
-      mismatch means the inline mark is wrapping.
 - [ ] Player is fully above the fold on desktop and mobile.
 - [ ] No horizontal scroll exists at 1920×1080 or 390×844.
-- [ ] A 16:9 iframe is centred at 134.328% height inside the clipped 1920:804
-      aperture and has `pointer-events: none`.
+- [ ] The iframe fills the 16:9 frame edge to edge and has
+      `pointer-events: none`.
 - [ ] Playback, pause, replay, click seek, keyboard seek, and pointer-drag seek
       work through the external media-widget mode without restoring the poster.
 - [ ] The idle Play and Fullscreen buttons are centered and keyboard accessible;
       fullscreen owns `.wt-stage` and exposes an Exit Fullscreen label.
-- [ ] The 1:47 howl plays before YouTube pauses at 1:50.02; the silent hold
-      advances to `1:55 / 1:55` with a fully opaque `wolves.projectbluefin.io`
-      card and no poster.
-- [ ] `src/tests/wolvesTrailerPlates.test.ts`, lint, typecheck, `test:gate`, and
-      build pass.
+- [ ] The transport reaches `1:55 / 1:55`; the ended phase shows a fully opaque
+      `wolves.projectbluefin.io` card over the night wallpaper, with no YouTube
+      endscreen and no poster.
+- [ ] `src/tests/wolvesTeaserApp.test.ts`, `src/tests/wolvesTrailerPlates.test.ts`,
+      lint, typecheck, `test:gate`, and build pass.

--- a/src/WolvesTeaserApp.vue
+++ b/src/WolvesTeaserApp.vue
@@ -7,19 +7,13 @@ import MediaWidget from '@/components/wolves/cinematic/MediaWidget.vue'
 import WolvesBackCatalogue from '@/components/wolves/WolvesBackCatalogue.vue'
 import WolvesHelmLine from '@/components/wolves/WolvesHelmLine.vue'
 import WolvesTrailerLine from '@/components/wolves/WolvesTrailerLine.vue'
-import { getChromeFreeYoutubePlayerVars, getYoutubePlayerConstructor, loadYoutubeIframeApi } from '@/composables/useYoutubeIframeApi'
+import { getChromeFreeYoutubePlayerVars, getYoutubePlayerConstructor, getYoutubePlayerState, loadYoutubeIframeApi } from '@/composables/useYoutubeIframeApi'
 import {
   activeTrailerPlates,
   TRAILER_BRIDGE_MONTH,
-  TRAILER_CREDIT_JOIN_SECONDS,
-  TRAILER_CREDIT_LINE,
   TRAILER_DURATION_SECONDS,
   TRAILER_ENDCARD_HOLD_SECONDS,
-  TRAILER_MUSIC_END_SECONDS,
-  TRAILER_TITLE_LABEL,
-  TRAILER_TITLE_LINE,
   TRAILER_VIDEO_ID,
-  trailerBridgeState,
   trailerHeadingOpacity,
   trailerOpeningBlackOpacity,
   trailerPlateOpacity,
@@ -28,7 +22,6 @@ import {
 
 const base = import.meta.env.BASE_URL
 const heroBackground = `${base}img/wallpapers/wolves/people/Always There.webp`
-const dayWallpaper = `${base}img/wallpapers/bluefin-${TRAILER_BRIDGE_MONTH}-day.webp`
 const nightWallpaper = `${base}img/wallpapers/bluefin-${TRAILER_BRIDGE_MONTH}-night.webp`
 
 const stageHost = ref<HTMLElement | null>(null)
@@ -37,13 +30,15 @@ const fullscreenActive = ref(false)
 let player: YoutubePlayer | null = null
 let playerReady = false
 let clockTimer: ReturnType<typeof setInterval> | null = null
-let silentHoldStartedAtMs: number | null = null
 
 type TrailerPhase = 'idle' | 'playing' | 'paused' | 'ended'
 const trailerPhase = ref<TrailerPhase>('idle')
 const now = ref(0)
 
-const visualTime = computed(() => now.value >= TRAILER_MUSIC_END_SECONDS
+// While the cut plays, the render itself carries every plate; the authored
+// records matter again only once it has ended and the URL card freezes over
+// YouTube's endscreen.
+const visualTime = computed(() => trailerPhase.value === 'ended'
   ? TRAILER_ENDCARD_HOLD_SECONDS
   : now.value)
 const openingBlackOpacity = computed(() => trailerOpeningBlackOpacity(visualTime.value))
@@ -60,28 +55,13 @@ function opacityOf(id: string): number {
   return found ? trailerPlateOpacity(found, visualTime.value) : 0
 }
 
-const creditVisible = computed(() => visualTime.value >= TRAILER_CREDIT_JOIN_SECONDS)
-
 // The page heading steps aside before the cut's own main title arrives, so the
 // film's name is only ever on screen once. See trailerHeadingOpacity().
 const headingOpacity = computed(() =>
   trailerHeadingOpacity(visualTime.value, { playing: trailerPhase.value === 'playing' }))
 
-// The cut leaves the music video at 88.2 s and never returns to it: the day
-// cards and the end card play over the March Bluefin wallpaper at full frame.
+// Exposed for the dev harness; the render carries the segments itself.
 const segment = computed(() => trailerSegmentAt(visualTime.value))
-const bridge = computed(() => trailerBridgeState(visualTime.value))
-
-// Both book plates are boxes on the same page; each carries its own anchor,
-// which the delivered cut walks with the camera.
-const bookPlates = computed(() => visiblePlates.value.filter(p => p.kind === 'bookline'))
-const dayCards = computed(() => visiblePlates.value.filter(p => p.kind === 'daycard'))
-
-/** Seat a plate by its anchor in the 1920x1080 authoring frame. */
-function anchorStyle(anchored: TrailerPlate) {
-  const [x, y] = anchored.anchor ?? [960, 540]
-  return { left: `${(x / 1920) * 100}%`, top: `${(y / 1080) * 100}%` }
-}
 
 function syncFullscreen() {
   fullscreenActive.value = document.fullscreenElement === stageHost.value
@@ -108,25 +88,13 @@ function stopClock() {
   }
 }
 
-function startSilentHold(from = now.value) {
-  player?.pauseVideo?.()
-  now.value = Math.min(Math.max(from, TRAILER_MUSIC_END_SECONDS), TRAILER_DURATION_SECONDS)
-  silentHoldStartedAtMs = Date.now() - (now.value - TRAILER_MUSIC_END_SECONDS) * 1000
+function endTrailer() {
+  now.value = TRAILER_DURATION_SECONDS
+  trailerPhase.value = 'ended'
+  stopClock()
 }
 
 function tick() {
-  if (silentHoldStartedAtMs !== null) {
-    now.value = Math.min(
-      TRAILER_MUSIC_END_SECONDS + (Date.now() - silentHoldStartedAtMs) / 1000,
-      TRAILER_DURATION_SECONDS,
-    )
-    if (now.value >= TRAILER_DURATION_SECONDS) {
-      silentHoldStartedAtMs = null
-      trailerPhase.value = 'ended'
-      stopClock()
-    }
-    return
-  }
   if (!playerReady) {
     return
   }
@@ -134,8 +102,11 @@ function tick() {
   if (typeof t !== 'number') {
     return
   }
-  if (t >= TRAILER_MUSIC_END_SECONDS) {
-    startSilentHold(TRAILER_MUSIC_END_SECONDS)
+  // The encode runs 114.998 s against an authored 115.02 s, so getCurrentTime
+  // caps just short of the duration and the ENDED event may never fire. The
+  // clock closes out the cut with a small tolerance.
+  if (t >= TRAILER_DURATION_SECONDS - 0.05) {
+    endTrailer()
     return
   }
   now.value = t
@@ -148,10 +119,7 @@ function startClock() {
 
 function playTrailer() {
   trailerPhase.value = 'playing'
-  if (now.value >= TRAILER_MUSIC_END_SECONDS) {
-    startSilentHold(now.value)
-  }
-  else if (playerReady) {
+  if (playerReady) {
     player?.playVideo?.()
   }
   startClock()
@@ -159,11 +127,7 @@ function playTrailer() {
 
 function toggleTrailer() {
   if (trailerPhase.value === 'playing') {
-    if (silentHoldStartedAtMs !== null) {
-      tick()
-      silentHoldStartedAtMs = null
-    }
-    else if (playerReady) {
+    if (playerReady) {
       player?.pauseVideo?.()
     }
     trailerPhase.value = 'paused'
@@ -183,24 +147,13 @@ function seekTrailer(ratio: number) {
   if (trailerPhase.value === 'idle' || trailerPhase.value === 'ended') {
     trailerPhase.value = 'paused'
   }
-  if (target >= TRAILER_MUSIC_END_SECONDS) {
-    player?.seekTo?.(TRAILER_MUSIC_END_SECONDS, true)
-    player?.pauseVideo?.()
-    silentHoldStartedAtMs = trailerPhase.value === 'playing'
-      ? Date.now() - (target - TRAILER_MUSIC_END_SECONDS) * 1000
-      : null
-  }
-  else {
-    silentHoldStartedAtMs = null
-    if (playerReady) {
-      player?.seekTo?.(target, true)
-    }
+  if (playerReady) {
+    player?.seekTo?.(target, true)
   }
 }
 
 function replayTrailer() {
   now.value = 0
-  silentHoldStartedAtMs = null
   trailerPhase.value = 'playing'
   if (playerReady) {
     player?.seekTo?.(0, true)
@@ -234,13 +187,15 @@ onMounted(async () => {
           }
           playerReady = true
           if (now.value > 0) {
-            target.seekTo?.(Math.min(now.value, TRAILER_MUSIC_END_SECONDS), true)
+            target.seekTo?.(now.value, true)
           }
-          if (trailerPhase.value === 'playing' && now.value >= TRAILER_MUSIC_END_SECONDS) {
-            startSilentHold(now.value)
-          }
-          else if (trailerPhase.value === 'playing') {
+          if (trailerPhase.value === 'playing') {
             target.playVideo?.()
+          }
+        },
+        onStateChange: ({ data }: { data: number }) => {
+          if (data === getYoutubePlayerState().ENDED && trailerPhase.value === 'playing') {
+            endTrailer()
           }
         },
       },
@@ -268,7 +223,6 @@ onBeforeUnmount(() => {
   player?.destroy?.()
   player = null
   playerReady = false
-  silentHoldStartedAtMs = null
 })
 </script>
 
@@ -282,15 +236,14 @@ onBeforeUnmount(() => {
         Seven Days to the Wolves
       </h1>
       <div class="wt-player wc-plate" data-wolves-trailer>
-        <!-- The delivered frame is 16:9 with the 2.39:1 picture letterboxed
-             inside it, so the embed is given a 16:9 box and YouTube pillars
-             the source itself. Every card coordinate then maps 1:1. -->
+        <!-- The delivered render is full-frame 16:9 with every plate burned
+             in, so the embed simply fills the frame. -->
         <div class="wt-player-frame">
           <div ref="playerHost" class="wt-player-host" />
         </div>
 
-        <!-- The raw Nightwish upload is not the authored opening. The delivered
-             cut holds black until the explosion blooms at 12.2 seconds. -->
+        <!-- The delivered cut holds black until 12.2 seconds; this mask keeps
+             YouTube's startup chrome out of the frame until the reveal. -->
         <div
           v-if="openingBlackOpacity > 0"
           class="wt-opening-black"
@@ -298,25 +251,15 @@ onBeforeUnmount(() => {
           aria-hidden="true"
         />
 
-        <!-- Segments two and three: the March wallpaper, day falling into
-             night, covering the picture for the last 21.8 s. -->
+        <!-- Once the cut has ended, cover YouTube's endscreen with the
+             authored final frame: the March night wallpaper under the URL
+             card. -->
         <div
-          v-if="segment !== 'picture'"
+          v-if="trailerPhase === 'ended'"
           class="wt-backdrop"
           aria-hidden="true"
         >
-          <div
-            class="wt-backdrop-images"
-            :style="{ opacity: segment === 'bridge' ? bridge.opacity : 1 }"
-          >
-            <img class="wt-backdrop-img" :src="dayWallpaper" alt="">
-            <img
-              class="wt-backdrop-img"
-              :src="nightWallpaper"
-              alt=""
-              :style="{ opacity: segment === 'bridge' ? bridge.nightMix : 1 }"
-            >
-          </div>
+          <img class="wt-backdrop-img" :src="nightWallpaper" alt="">
         </div>
 
         <div v-if="trailerPhase === 'idle'" class="wt-poster">
@@ -334,56 +277,10 @@ onBeforeUnmount(() => {
         </div>
 
         <div class="wt-overlays" aria-hidden="true">
-          <!-- THE MAIN TITLE. One lockup across both authored beats: the
-               credit row always occupies its space, so the title cannot jump
-               when the credits arrive. -->
-          <div
-            v-if="plate('maintitle')"
-            class="wt-lockup"
-            :style="{ opacity: opacityOf('maintitle') }"
-          >
-            <span class="wt-eyebrow">
-              <WolvesTrailerLine :text="TRAILER_TITLE_LABEL" />
-            </span>
-            <span class="wt-title">
-              <WolvesTrailerLine :text="TRAILER_TITLE_LINE" mark-word="wolves" />
-            </span>
-            <div class="wt-rule" />
-            <div class="wt-credits" :class="{ 'is-shown': creditVisible }">
-              <WolvesTrailerLine :text="TRAILER_CREDIT_LINE" />
-            </div>
-          </div>
-
-          <!-- THE BOOK BOX. Opaque, never dissolved, and seated by its anchor
-               so it covers the book's printed words. -->
-          <div
-            v-for="book in bookPlates"
-            :key="book.id"
-            class="wt-book"
-            :style="anchorStyle(book)"
-          >
-            <p v-for="line in book.lines ?? []" :key="line" class="wt-book-line">
-              {{ line }}
-            </p>
-          </div>
-
-          <!-- THE DAY CARDS, on the wallpaper, low in the frame so the type
-               sits in the shadowed meadow rather than the bright horizon. -->
-          <div
-            v-for="card in dayCards"
-            :key="card.id"
-            class="wt-daycard"
-            :style="{ opacity: trailerPlateOpacity(card, visualTime) }"
-          >
-            <p class="wt-daycard-line">
-              <WolvesTrailerLine :text="card.title ?? ''" mark-word="Extinction" />
-            </p>
-          </div>
-
-          <!-- THE END CARD. One poster: the event rows arrive first and the
-               call to action joins them, seated where the full poster puts
-               it rather than jumping upward. -->
-          <div v-if="segment === 'endcard'" class="wt-lockup wt-lockup--poster">
+          <!-- THE END CARD. Drawn by the browser only after the cut has
+               ended, so YouTube's endscreen never replaces the authored URL
+               card. While the render plays it carries every plate itself. -->
+          <div v-if="trailerPhase === 'ended'" class="wt-lockup wt-lockup--poster">
             <template v-if="plate('endcard-event')">
               <span class="wt-poster-event" :style="{ opacity: opacityOf('endcard-event') }">
                 <!-- KubeCon and CloudNativeCon are Linux Foundation marks and
@@ -497,8 +394,7 @@ onBeforeUnmount(() => {
 .wt-player {
   position: relative;
 
-  // The delivered frame. The picture inside it is 2.39:1 and letterboxes
-  // itself, exactly as the render does.
+  // The delivered frame; the render fills it edge to edge.
   aspect-ratio: 16 / 9;
 
   // Height-capped so title, frame, and standfirst all clear the fold.
@@ -512,28 +408,19 @@ onBeforeUnmount(() => {
   container-type: inline-size;
 }
 
-/* The wrapper is the 2.39:1 PICTURE aperture. The iframe inside it is 16:9:
-   YouTube puts its title/share/logo chrome into that iframe's letterbox bars,
-   which fall outside this clipped aperture. Pointer events stay on our widget,
-   so hover can never ask YouTube to paint the chrome again. */
+/* The wrapper holds the embed. Pointer events stay on our widget, so hover
+   can never ask YouTube to paint its chrome. */
 .wt-player-frame {
   position: absolute;
-  left: 0;
-  right: 0;
-  top: 50%;
+  inset: 0;
   overflow: hidden;
-  transform: translateY(-50%);
-  aspect-ratio: 1920 / 804;
 
-  // YT.Player replaces the host div with the iframe in place. A 16:9 iframe is
-  // 134.328% as tall as this 1920:804 aperture; centring clips both bars.
+  // YT.Player replaces the host div with the iframe in place.
   :deep(iframe) {
     position: absolute;
-    top: 50%;
-    left: 0;
+    inset: 0;
     width: 100%;
-    height: 134.328%;
-    transform: translateY(-50%);
+    height: 100%;
     pointer-events: none;
   }
 }
@@ -546,13 +433,9 @@ onBeforeUnmount(() => {
   background: #000;
 }
 
-.wt-backdrop-images,
 .wt-backdrop-img {
   position: absolute;
   inset: 0;
-}
-
-.wt-backdrop-img {
   width: 100%;
   height: 100%;
   object-fit: cover;
@@ -643,7 +526,10 @@ onBeforeUnmount(() => {
 }
 
 /* ---------------------------------------------------------------------------
-   THE LOCKUP.
+   THE END CARD POSTER.
+
+   The background does the darkening: the transparent card sits over the March
+   night wallpaper. There is no local panel under this text.
 
    Copied back from the card that copied it from this site: destiny-vids'
    cards/maintitle.html took .wolves-intro-overlay-text-slim and the
@@ -679,31 +565,6 @@ onBeforeUnmount(() => {
     0 0 60px rgb(0 0 0 / 55%);
 }
 
-.wt-eyebrow {
-  width: 100%;
-  font-size: 2.1667cqw;
-  font-weight: 400;
-  letter-spacing: 0.04em;
-  color: #cbd5e1;
-  text-transform: uppercase;
-  margin-bottom: 1.1667cqw;
-}
-
-/* The title is one authored line and must stay one: an inline image is a break
-   opportunity, so without this the helm throws "LVES" onto its own line. The
-   width is stated rather than left to fit-content, which collapses a flex item
-   containing a replaced element to less than the room available. */
-.wt-title {
-  width: 100%;
-  white-space: nowrap;
-  font-size: 4.0833cqw;
-  font-weight: 900;
-  letter-spacing: 0.12em;
-  line-height: 1.1;
-  color: #fff;
-  text-transform: uppercase;
-}
-
 .wt-rule {
   width: 34%;
   height: 1px;
@@ -711,96 +572,6 @@ onBeforeUnmount(() => {
   background: rgb(96 165 250 / 28%);
 }
 
-/* The credit slot always occupies its space, so the staged pair cannot shift
-   the title when the credits arrive. Visibility, never display. */
-.wt-credits {
-  width: 100%;
-  margin-top: 1.5cqw;
-  font-family: var(--wc-font-mono);
-  font-size: 1.25cqw;
-  letter-spacing: 0.24em;
-  color: #cbd5e1;
-  visibility: hidden;
-}
-
-.wt-credits.is-shown {
-  visibility: visible;
-}
-
-/* ---------------------------------------------------------------------------
-   THE BOOK BOX.
-
-   A card, not a fake piece of printed book type: quiet charcoal, one Bluefin
-   edge, and the existing type. Opaque and hard-cut — the book's printed lyric
-   stayed legible through a translucent panel, which is a second set of words
-   behind ours (destiny-vids #276, #277).
---------------------------------------------------------------------------- */
-.wt-book {
-  position: absolute;
-  transform: translate(-50%, -50%);
-  width: max-content;
-  max-width: 82cqw;
-  padding: 1.125cqw 1.6667cqw;
-  background: rgb(4 10 20);
-  border-left: 0.2083cqw solid #60a5fa;
-  border-radius: 3px;
-  box-shadow:
-    0 0 4px rgb(0 0 0 / 92%),
-    0 0 24px rgb(0 0 0 / 72%);
-}
-
-.wt-book-line {
-  margin: 0;
-  font-family: var(--wc-font-display);
-  font-size: 3.1667cqw;
-  font-weight: 600;
-  line-height: 1.7;
-  letter-spacing: 0.05em;
-  color: #f4f6f8;
-  text-align: center;
-  text-shadow:
-    0 0 4px rgb(0 0 0 / 95%),
-    0 2px 10px rgb(0 0 0 / 90%),
-    0 0 28px rgb(0 0 0 / 75%),
-    0 0 60px rgb(0 0 0 / 55%);
-}
-
-/* ---------------------------------------------------------------------------
-   THE DAY CARDS.
-
-   `top: 58%` is measured, not nudged: it lands the type in the shadowed flower
-   meadow rather than across March's bright dawn horizon, and no lower, because
-   66% put the line across the foreground wolf's head.
---------------------------------------------------------------------------- */
-.wt-daycard {
-  position: absolute;
-  left: 10%;
-  top: 58%;
-  width: 80%;
-  color: #f4f6f8;
-  text-align: center;
-  font-family: var(--wc-font-display);
-  text-shadow:
-    0 0 4px rgb(0 0 0 / 95%),
-    0 2px 10px rgb(0 0 0 / 90%),
-    0 0 28px rgb(0 0 0 / 75%);
-}
-
-.wt-daycard-line {
-  margin: 0.4583cqw 0;
-  color: #fff;
-  font-size: 4.3333cqw;
-  font-weight: 900;
-  letter-spacing: 0.045em;
-  line-height: 1.05;
-}
-
-/* ---------------------------------------------------------------------------
-   THE END CARD POSTER.
-
-   The background does the darkening: the transparent card sits over the March
-   night wallpaper. There is no local panel under this text.
---------------------------------------------------------------------------- */
 .wt-lockup--poster {
   width: 92%;
 }

--- a/src/data/wolves-trailer-plates.ts
+++ b/src/data/wolves-trailer-plates.ts
@@ -1,34 +1,38 @@
 /**
- * Trailer 1 — the teaser's recreation of the owner's cut.
+ * Trailer 1 — the owner's delivered cut, played directly.
  *
- * PROVENANCE: this is a web recreation of the owner's cut "Trailer 1.1"
+ * PROVENANCE: the teaser embeds the owner's own render of "Trailer 1.1"
  * (delivered 2026-08-18), whose authoritative record is the destiny-vids repo
  * at `stories/trailer-1-plates.json`, with the plate DESIGN authored in
  * `cards/maintitle.html`, `cards/bookline.html` and `cards/daycard.html` and
- * the composition in `scripts/build_trailer1.py`. Every string below is
- * owner-authored copy reproduced VERBATIM — do not reword, re-case, or "fix"
- * any of it here; change the source manifest and re-port instead.
+ * the composition in `scripts/build_trailer1.py`. The teaser used to recreate
+ * this cut in the browser over a third-party music-video upload; it now plays
+ * the delivered render, which has every plate, the bridge, and the end card
+ * burned in. The records below remain the authored description of the cut —
+ * they drive the heading yield, the opening black mask, and the URL card that
+ * covers YouTube's endscreen — and every string is owner-authored copy
+ * reproduced VERBATIM: do not reword, re-case, or "fix" any of it here;
+ * change the source manifest and re-port instead.
  *
- * THE CUT IS THREE SEGMENTS, NOT ONE VIDEO WITH OVERLAYS. This is the thing
- * the first recreation got wrong: it played the music video for the full
- * 1:50 and drew every plate on top of it. The delivered trailer leaves the
- * music video at 88.2 s and never returns to it.
+ * THE CUT IS THREE SEGMENTS, NOT ONE VIDEO WITH OVERLAYS. The delivered
+ * trailer leaves the picture at 88.2 s and never returns to it.
  *
- *   0      -> 88.2    the music video, letterboxed 2.39:1 into a 16:9 frame
- *   88.2   -> 102.2   the March Bluefin wallpaper, day falling into night
- *   102.2  -> 115.02  the March Bluefin night wallpaper, as a poster end card
+ *   0      -> 88.2    the picture
+ *   88.2   -> 102.2   day falling into night
+ *   102.2  -> 115.02  the night scene as a poster end card
  *
- * So both day cards and the whole end card sit on the wallpaper at FULL
- * frame, with no letterbox — which is also why they carry no scrim: the
- * owner had it removed ("remove the black translucent box around the words")
- * and the contrast is carried by a halo on the glyphs instead.
+ * Both day cards and the whole end card sit on the scene at FULL frame, with
+ * no letterbox — which is also why they carry no scrim: the owner had it
+ * removed ("remove the black translucent box around the words") and the
+ * contrast is carried by a halo on the glyphs instead.
  */
 
 /**
- * The picture the teaser embeds. NOT the destiny-vids ingest, and deliberately
+ * The picture the teaser embeds: the owner's delivered 4K60 render of the
+ * cut, "Wolves Trailer Final". NOT the destiny-vids ingest, and deliberately
  * left as it was found — the video is the owner's call, not this file's.
  */
-export const TRAILER_VIDEO_ID = 'O0lyFqLr3Cc'
+export const TRAILER_VIDEO_ID = 'iHXBTH_fwB0'
 
 /** The source music stops after the howl and its approved fade. */
 export const TRAILER_MUSIC_END_SECONDS = 110.02

--- a/src/tests/wolvesTeaserApp.test.ts
+++ b/src/tests/wolvesTeaserApp.test.ts
@@ -2,9 +2,9 @@ import { flushPromises, mount, shallowMount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import MediaWidget from '@/components/wolves/cinematic/MediaWidget.vue'
+import { getYoutubePlayerState } from '@/composables/useYoutubeIframeApi'
 import {
   TRAILER_DURATION_SECONDS,
-  TRAILER_MUSIC_END_SECONDS,
   TRAILER_PICTURE_END_SECONDS,
   TRAILER_PICTURE_REVEAL_FADE_SECONDS,
   TRAILER_PICTURE_REVEAL_SECONDS,
@@ -13,6 +13,7 @@ import WolvesTeaserApp from '@/WolvesTeaserApp.vue'
 
 const youtube = vi.hoisted(() => {
   let onReady: ((event: { target: FakePlayer }) => void) | undefined
+  let onStateChange: ((event: { data: number }) => void) | undefined
 
   class FakePlayer {
     static latest: FakePlayer | undefined
@@ -24,9 +25,13 @@ const youtube = vi.hoisted(() => {
     playVideo = vi.fn()
     seekTo = vi.fn((seconds: number) => { this.currentTime = seconds })
 
-    constructor(_element: Element, options: { events?: { onReady?: typeof onReady } }) {
+    constructor(
+      _element: Element,
+      options: { events?: { onReady?: typeof onReady, onStateChange?: typeof onStateChange } },
+    ) {
       FakePlayer.latest = this
       onReady = options.events?.onReady
+      onStateChange = options.events?.onStateChange
     }
   }
 
@@ -35,9 +40,11 @@ const youtube = vi.hoisted(() => {
     load: vi.fn<() => Promise<void>>(),
     latest: () => FakePlayer.latest,
     ready: () => FakePlayer.latest && onReady?.({ target: FakePlayer.latest }),
+    stateChange: (data: number) => onStateChange?.({ data }),
     reset: () => {
       FakePlayer.latest = undefined
       onReady = undefined
+      onStateChange = undefined
     },
   }
 })
@@ -67,7 +74,7 @@ afterEach(() => {
 })
 
 describe('wolves teaser bridge', () => {
-  it('covers Nightwish with black until the authored explosion bloom', async () => {
+  it('holds black over the embed until the authored reveal', async () => {
     const wrapper = mount(WolvesTeaserApp, {
       global: {
         stubs: {
@@ -94,7 +101,8 @@ describe('wolves teaser bridge', () => {
     wrapper.unmount()
   })
 
-  it('keeps an opaque black backing over the YouTube picture while the wolf-day wallpaper rises', async () => {
+  it('draws no browser plates over the render, covering the endscreen only after the cut ends', async () => {
+    vi.useFakeTimers()
     const wrapper = mount(WolvesTeaserApp, {
       global: {
         stubs: {
@@ -105,40 +113,28 @@ describe('wolves teaser bridge', () => {
       },
     })
     await flushPromises()
+    youtube.ready()
 
     const harness = (window as typeof window & { __wolvesTeaser: TeaserHarness }).__wolvesTeaser
-    harness.seekTo(TRAILER_PICTURE_END_SECONDS - 0.01)
-    await nextTick()
-    expect(wrapper.find('.wt-backdrop').exists()).toBe(false)
+    await wrapper.get('.wt-convenience-play').trigger('click')
 
-    harness.seekTo(TRAILER_PICTURE_END_SECONDS)
+    // The render carries every plate itself: at no beat — title, book lines,
+    // day cards, or the baked end card — may the browser draw its own copy.
+    for (const t of [TRAILER_PICTURE_REVEAL_SECONDS + 1, 30, TRAILER_PICTURE_END_SECONDS, 95, 104, 108]) {
+      harness.seekTo(t)
+      await nextTick()
+      expect(wrapper.find('.wt-lockup').exists()).toBe(false)
+      expect(wrapper.find('.wt-backdrop').exists()).toBe(false)
+    }
+
+    youtube.latest()!.currentTime = TRAILER_DURATION_SECONDS - 0.02
+    await vi.advanceTimersByTimeAsync(100)
     await nextTick()
 
     const backdrop = wrapper.get<HTMLElement>('.wt-backdrop')
-    const wallpaperGroup = wrapper.get<HTMLElement>('.wt-backdrop-images')
-    const [day, night] = wrapper.findAll<HTMLElement>('.wt-backdrop-img')
     expect(backdrop.element.style.opacity).toBe('')
-    expect(wallpaperGroup.element.style.opacity).toBe('0')
-    expect(day.element.style.opacity).toBe('')
-    expect(night.element.style.opacity).toBe('0')
-
-    harness.seekTo(TRAILER_PICTURE_END_SECONDS + 0.6)
-    await nextTick()
-
-    expect(Number(wallpaperGroup.element.style.opacity)).toBeCloseTo(0.6 / 1.4, 5)
-    expect(night.element.style.opacity).toBe('0')
-
-    harness.seekTo(TRAILER_PICTURE_END_SECONDS + 4.6)
-    await nextTick()
-
-    expect(wallpaperGroup.element.style.opacity).toBe('1')
-    expect(Number(night.element.style.opacity)).toBeCloseTo(0.5, 5)
-
-    harness.seekTo(TRAILER_PICTURE_END_SECONDS + 11.1)
-    await nextTick()
-
-    expect(Number(wallpaperGroup.element.style.opacity)).toBeCloseTo(0.5, 5)
-    expect(night.element.style.opacity).toBe('1')
+    expect(wrapper.findAll<HTMLElement>('.wt-backdrop-img')).toHaveLength(1)
+    expect(wrapper.find('.wt-lockup--poster').exists()).toBe(true)
 
     wrapper.unmount()
   })
@@ -181,21 +177,35 @@ describe('wolves teaser transport', () => {
     wrapper.unmount()
   })
 
-  it('plays through the howl, then advances a silent five-second URL hold', async () => {
+  it('plays the delivered render to its authored end, then holds the URL card', async () => {
     vi.useFakeTimers()
     const wrapper = shallowMount(WolvesTeaserApp)
     await flushPromises()
     youtube.ready()
     await wrapper.get('.wt-convenience-play').trigger('click')
 
-    youtube.latest()!.currentTime = TRAILER_MUSIC_END_SECONDS
+    // The encode ends a hair short of the authored duration; the clock closes
+    // out the cut without ever pausing the video for a synthetic hold.
+    youtube.latest()!.currentTime = TRAILER_DURATION_SECONDS - 0.02
     await vi.advanceTimersByTimeAsync(100)
-    expect(youtube.latest()!.pauseVideo).toHaveBeenCalled()
+    expect(youtube.latest()!.pauseVideo).not.toHaveBeenCalled()
     expect(wrapper.getComponent(MediaWidget).props('duration')).toBe(TRAILER_DURATION_SECONDS)
-    expect(wrapper.getComponent(MediaWidget).props('elapsed')).toBeCloseTo(TRAILER_MUSIC_END_SECONDS, 2)
+    expect(wrapper.getComponent(MediaWidget).props('elapsed')).toBe(TRAILER_DURATION_SECONDS)
+    expect(wrapper.getComponent(MediaWidget).props('playing')).toBe(false)
+    wrapper.unmount()
+  })
 
-    await vi.advanceTimersByTimeAsync(5000)
-    expect(wrapper.getComponent(MediaWidget).props('elapsed')).toBeCloseTo(TRAILER_DURATION_SECONDS, 2)
+  it('ends the cut when the player reports ENDED', async () => {
+    vi.useFakeTimers()
+    const wrapper = shallowMount(WolvesTeaserApp)
+    await flushPromises()
+    youtube.ready()
+    await wrapper.get('.wt-convenience-play').trigger('click')
+
+    youtube.stateChange(getYoutubePlayerState().ENDED)
+    await nextTick()
+
+    expect(wrapper.getComponent(MediaWidget).props('elapsed')).toBe(TRAILER_DURATION_SECONDS)
     expect(wrapper.getComponent(MediaWidget).props('playing')).toBe(false)
     wrapper.unmount()
   })

--- a/src/tests/wolvesTrailerPlates.test.ts
+++ b/src/tests/wolvesTrailerPlates.test.ts
@@ -30,7 +30,7 @@ import {
 // recut, re-port the manifest — do not nudge these numbers to make a test pass.
 describe('wolves trailer plates', () => {
   it('keeps the music at 1:50.020 and the picture through 1:55.020', () => {
-    expect(TRAILER_VIDEO_ID).toBe('O0lyFqLr3Cc')
+    expect(TRAILER_VIDEO_ID).toBe('iHXBTH_fwB0')
     expect(TRAILER_MUSIC_END_SECONDS).toBe(110.02)
     expect(TRAILER_DURATION_SECONDS).toBe(115.02)
     expect(TRAILER_CUT_DURATION_SECONDS).toBe(TRAILER_DURATION_SECONDS)

--- a/wolves/README.md
+++ b/wolves/README.md
@@ -4,7 +4,7 @@
 
 **Agents edit content. Agents never edit design.**
 
-`/wolves/` is the teaser page (hero, Trailer 1 recreation, back catalogue).
+`/wolves/` is the teaser page (hero, Trailer 1, back catalogue).
 The shipped fullscreen experience lives at `/wolves/experience/` — moved there
 2026-08-17 when the teaser took the front door. Content work on the experience
 uses the sources listed in `docs/reference/wolves-runtime.md`. Do not change
@@ -14,14 +14,16 @@ behavior for a content request.
 ## Runtime
 
 - Teaser entry: `wolves/index.html` → `src/wolves-teaser-main.ts` →
-  `src/WolvesTeaserApp.vue`. Trailer plate schedule:
+  `src/WolvesTeaserApp.vue`. The teaser embeds the owner's delivered render of
+  Trailer 1 (YouTube `iHXBTH_fwB0`, "Wolves Trailer Final") — the cut's plates,
+  bridge, and end card are burned in, and the browser only masks the opening
+  black, yields the page heading, and holds the URL card over YouTube's
+  endscreen. The authored record of the cut stays in
   `src/data/wolves-trailer-plates.ts` (ported verbatim from destiny-vids
   `stories/trailer-1-plates.json`; re-port on a recut, never reword here).
-  Plate DESIGN comes from destiny-vids `cards/*.html`, not from that manifest,
-  and the cut is three pictures: the embed stops at 88.2s and the March
-  wallpaper carries the day cards and end card. Line treatments (blue B/F, the
-  seared `|`, the Kubernetes helm as an O) live in
-  `src/components/wolves/WolvesTrailerLine.vue`.
+  Plate DESIGN comes from destiny-vids `cards/*.html`, not from that manifest.
+  Line treatments (blue B/F, the seared `|`, the Kubernetes helm as an O) live
+  in `src/components/wolves/WolvesTrailerLine.vue`.
 - Experience entry: `wolves/experience/index.html`
 - Mount: `src/wolves-main.ts` and `src/WolvesApp.vue`
 - State: `src/stores/cinematic.ts`


### PR DESCRIPTION
## What

Swaps the `/wolves/` teaser's source video from the third-party Nightwish upload (`O0lyFqLr3Cc`) to the delivered 4K60 render [`iHXBTH_fwB0`](https://www.youtube.com/watch?v=iHXBTH_fwB0) (114.998s) of the authored Trailer 1.1 cut.

Because the render has every plate, the bridge, and the end card **burned in**, the teaser no longer recreates the cut in the browser — doing so would double-draw every plate over the rendered ones. The chromeless YouTube iframe now plays the render full-frame (verified by frame extraction: the render is 16:9 edge-to-edge throughout, no baked letterbox).

## Design surface

Touched under the owner's direct request to swap in the higher-quality render ("swapping out the source video with this higher quality one, ensure it matches"). What the browser still draws:

1. **Opening-black mask** until 12.2s — hides YouTube startup chrome; the render's own opening is black, so pixel-identical.
2. **Heading yield** — the page h1 steps aside for the burned-in main title (driven by the `maintitle` record at 11.0s).
3. **Ended-phase URL card** — night wallpaper + `wolves.projectbluefin.io` lockup covers YouTube's endscreen.

Removed: silent-hold machinery, mid-cut overlays (maintitle lockup, book plates, day cards), aperture CSS, segment geometry switching. The full plate schedule in `wolves-trailer-plates.ts` is kept intact as the authored record of the cut.

End detection is redundant on purpose: clock tolerance (`>= 115.02 - 0.05`, since the encode is 114.998s and `getCurrentTime()` caps short) **plus** the `onStateChange` ENDED event.

## Verification

- Focused vitest: 36/36 pass (`wolvesTeaserApp.test.ts` 8, `wolvesTrailerPlates.test.ts` 28)
- `npm run lint`, `npm run typecheck`, `npm run build` — green
- `npm run test:gate` — no new failures (baseline 0)
- Browser verification against real YouTube at `http://projectbluefin.io.localhost:5173/wolves/` (Playwright): **22/22 assertions** — idle poster, no browser plates at beats 13/30/95/104/108, heading yields by 13s, natural end pins the clock at 115.02, ended shows the URL card over the night wallpaper, no double-draw, desktop + mobile above fold, no horizontal scroll
- Screenshots in `/var/tmp/website-agent/v-*.png` (beat-13: burned-in title, no browser lockup; beat-95: "Survival is the Exception" plate; ended: URL card)

## Self-improvement

`docs/skills/wolves-teaser/SKILL.md` rewritten for the delivered-render architecture (same commit, per contract); `wolves/README.md` runtime description updated.

Assisted-by: Kimi K3 via GitHub Copilot CLI