### PR TITLE
fix(wolves): point the teaser at the re-staged Trailer 1 render

### DIFF
--- a/docs/skills/wolves-teaser/SKILL.md
+++ b/docs/skills/wolves-teaser/SKILL.md
@@ -62,7 +62,7 @@ Use this skill when changing:
 
 ## Sources of Truth
 
-The playable picture is the owner's own upload: YouTube `iHXBTH_fwB0`,
+The playable picture is the owner's own upload: YouTube `2zDT_6Xs2Wo`,
 "Wolves Trailer Final" — the delivered 4K60 render of Trailer 1.1. Verify any
 swap beat by beat against the authored schedule before trusting it.
 

--- a/src/data/wolves-trailer-plates.ts
+++ b/src/data/wolves-trailer-plates.ts
@@ -2,7 +2,7 @@
  * Trailer 1 — the owner's delivered cut, played directly.
  *
  * PROVENANCE: the teaser embeds the owner's own render of "Trailer 1.1"
- * (delivered 2026-08-18), whose authoritative record is the destiny-vids repo
+ * (delivered 2026-08-22), whose authoritative record is the destiny-vids repo
  * at `stories/trailer-1-plates.json`, with the plate DESIGN authored in
  * `cards/maintitle.html`, `cards/bookline.html` and `cards/daycard.html` and
  * the composition in `scripts/build_trailer1.py`. The teaser used to recreate
@@ -32,7 +32,7 @@
  * cut, "Wolves Trailer Final". NOT the destiny-vids ingest, and deliberately
  * left as it was found — the video is the owner's call, not this file's.
  */
-export const TRAILER_VIDEO_ID = 'iHXBTH_fwB0'
+export const TRAILER_VIDEO_ID = '2zDT_6Xs2Wo'
 
 /** The source music stops after the howl and its approved fade. */
 export const TRAILER_MUSIC_END_SECONDS = 110.02
@@ -82,7 +82,7 @@ export const TRAILER_ENDCARD_HOLD_SECONDS = TRAILER_CUT_DURATION_SECONDS - TRAIL
  * at the second beat (maintitle-b). The title must not move when it does, so
  * the credit row always occupies its space.
  */
-export const TRAILER_CREDIT_JOIN_SECONDS = 15.4
+export const TRAILER_CREDIT_JOIN_SECONDS = 12.2
 
 /** Authored casing preserved: the card uppercases in CSS, as the film does. */
 export const TRAILER_TITLE_LABEL = 'PROJECT BLUEFIN'
@@ -124,10 +124,10 @@ export const TRAILER_PLATES: readonly TrailerPlate[] = [
   {
     id: 'maintitle',
     kind: 'maintitle',
-    // maintitle-a 11.0+4.4 and maintitle-b 15.4+7.2 are one continuous title
+    // maintitle-a 7.0+5.2 and maintitle-b 12.2+10.4 are one continuous title
     // presence in the cut; the credit line appears mid-way (see
     // TRAILER_CREDIT_JOIN_SECONDS).
-    start: 11.0,
+    start: 7.0,
     end: 22.6,
     title: TRAILER_TITLE_LINE,
     lines: [TRAILER_CREDIT_LINE],
@@ -284,9 +284,9 @@ export function trailerPlateOpacity(plate: TrailerPlate, timeSeconds: number): n
  * THE PAGE HEADING YIELDS TO THE PICTURE.
  *
  * The teaser page carries the film's name in an `h1` above the frame, and the
- * cut carries the same four words in its own main-title card at 11.0 s. Both
+ * cut carries the same four words in its own main-title card at 7.0 s. Both
  * were on screen at once, so the title card revealed a title the audience had
- * already been reading for eleven seconds — the reveal had nothing left to
+ * already been reading for seconds — the reveal had nothing left to
  * reveal, and the page read as if it were stuttering.
  *
  * A theater darkens before the title hits. The heading is therefore fully down

--- a/src/tests/wolvesTrailerPlates.test.ts
+++ b/src/tests/wolvesTrailerPlates.test.ts
@@ -30,7 +30,7 @@ import {
 // recut, re-port the manifest — do not nudge these numbers to make a test pass.
 describe('wolves trailer plates', () => {
   it('keeps the music at 1:50.020 and the picture through 1:55.020', () => {
-    expect(TRAILER_VIDEO_ID).toBe('iHXBTH_fwB0')
+    expect(TRAILER_VIDEO_ID).toBe('2zDT_6Xs2Wo')
     expect(TRAILER_MUSIC_END_SECONDS).toBe(110.02)
     expect(TRAILER_DURATION_SECONDS).toBe(115.02)
     expect(TRAILER_CUT_DURATION_SECONDS).toBe(TRAILER_DURATION_SECONDS)
@@ -38,14 +38,14 @@ describe('wolves trailer plates', () => {
 
   it('shows nothing before the main title and after the cut ends', () => {
     expect(activeTrailerPlates(0)).toEqual([])
-    expect(activeTrailerPlates(10.9)).toEqual([])
+    expect(activeTrailerPlates(6.9)).toEqual([])
     expect(activeTrailerPlates(TRAILER_MUSIC_END_SECONDS).map(p => p.id)).toEqual(['endcard-event', 'endcard-cta'])
     expect(activeTrailerPlates(TRAILER_DURATION_SECONDS)).toEqual([])
     expect(activeTrailerPlates(Number.NaN)).toEqual([])
   })
 
   it('holds the main title across both authored beats', () => {
-    expect(activeTrailerPlates(11).map(p => p.id)).toEqual(['maintitle'])
+    expect(activeTrailerPlates(7).map(p => p.id)).toEqual(['maintitle'])
     expect(activeTrailerPlates(TRAILER_CREDIT_JOIN_SECONDS).map(p => p.id)).toEqual(['maintitle'])
     expect(activeTrailerPlates(22.6).map(p => p.id)).toEqual([])
   })

--- a/wolves/README.md
+++ b/wolves/README.md
@@ -15,7 +15,7 @@ behavior for a content request.
 
 - Teaser entry: `wolves/index.html` → `src/wolves-teaser-main.ts` →
   `src/WolvesTeaserApp.vue`. The teaser embeds the owner's delivered render of
-  Trailer 1 (YouTube `iHXBTH_fwB0`, "Wolves Trailer Final") — the cut's plates,
+  Trailer 1 (YouTube `2zDT_6Xs2Wo`, "Wolves Trailer Final") — the cut's plates,
   bridge, and end card are burned in, and the browser only masks the opening
   black, yields the page heading, and holds the URL card over YouTube's
   endscreen. The authored record of the cut stays in


### PR DESCRIPTION
The live teaser plays an upload whose title staging was transplanted from the prologue, which was measured against a picture that starts at 0.000 s. Trailer 1's source opens on **12.200 s of black** before the burst, so the title sat on black from 2.000 and the credit pair only joined at 15.400 — three seconds *after* the bloom, which read on screen as the film starting over.

Fixed upstream in [castrojo/destiny-vids#313](https://github.com/castrojo/destiny-vids/pull/313): the card now rises at 7.000 and the credit pair arrives **with** the burst at 12.200. `TITLE_OUT` holds at 22.600, still clear of the 24.880 book cut. Verified frame-by-frame on a fresh 4K master, audio re-corrected to −1.1 dBTP.

## What changed here

Every segment boundary is unchanged — picture 88.2, bridge 102.2, total 115.02 — so only the title records move:

| | before | after |
|---|---|---|
| `TRAILER_VIDEO_ID` | `iHXBTH_fwB0` | `2zDT_6Xs2Wo` |
| `maintitle.start` | 11.0 | 7.0 |
| `TRAILER_CREDIT_JOIN_SECONDS` | 15.4 | 12.2 |

Re-ported from the source manifest rather than reworded, per this file's own contract. The two test probes move with the boundary they describe, not to make a test pass: *'nothing before the main title'* is sampled at 6.9, and the title's first beat at 7.0.

1025 tests pass; eslint clean on both changed files.

## One thing worth an owner's eye (not blocking)

`trailerOpeningBlackOpacity` paints solid black over 0 → 12.2 s to keep YouTube's startup chrome out of the frame. That mask is why the broken cut *looked fine on the site* — it hid the whole mis-staged opening. It now also hides the new title rise at 7.0 s, so the teaser still reveals the title at the bloom rather than out of the void. That's an editorial call about the page, not the cut, so it is left exactly as it was.