### PR TITLE
fix(wolves): point Trailer 1 at the re-staged, re-uploaded render

### DIFF
--- a/docs/skills/wolves-teaser/SKILL.md
+++ b/docs/skills/wolves-teaser/SKILL.md
@@ -62,8 +62,8 @@ Use this skill when changing:
 
 ## Sources of Truth
 
-The playable picture is the owner's own upload: YouTube `iHXBTH_fwB0`,
-"Wolves Trailer Final" — the delivered 4K60 render of Trailer 1.1. Verify any
+The playable picture is the owner's own upload: YouTube `u-ZWdKcHyXM`,
+"Seven Days to the Wolves" (the re-upload of "Wolves Trailer Final") — the delivered 4K60 render of Trailer 1.1. Verify any
 swap beat by beat against the authored schedule before trusting it.
 
 All paths in this table are relative to `~/src/destiny-vids`.

--- a/src/data/wolves-trailer-plates.ts
+++ b/src/data/wolves-trailer-plates.ts
@@ -32,7 +32,7 @@
  * cut, "Wolves Trailer Final". NOT the destiny-vids ingest, and deliberately
  * left as it was found — the video is the owner's call, not this file's.
  */
-export const TRAILER_VIDEO_ID = 'iHXBTH_fwB0'
+export const TRAILER_VIDEO_ID = 'u-ZWdKcHyXM'
 
 /** The source music stops after the howl and its approved fade. */
 export const TRAILER_MUSIC_END_SECONDS = 110.02

--- a/src/data/wolves-trailer-plates.ts
+++ b/src/data/wolves-trailer-plates.ts
@@ -2,7 +2,7 @@
  * Trailer 1 — the owner's delivered cut, played directly.
  *
  * PROVENANCE: the teaser embeds the owner's own render of "Trailer 1.1"
- * (delivered 2026-08-18), whose authoritative record is the destiny-vids repo
+ * (delivered 2026-08-22), whose authoritative record is the destiny-vids repo
  * at `stories/trailer-1-plates.json`, with the plate DESIGN authored in
  * `cards/maintitle.html`, `cards/bookline.html` and `cards/daycard.html` and
  * the composition in `scripts/build_trailer1.py`. The teaser used to recreate
@@ -82,7 +82,7 @@ export const TRAILER_ENDCARD_HOLD_SECONDS = TRAILER_CUT_DURATION_SECONDS - TRAIL
  * at the second beat (maintitle-b). The title must not move when it does, so
  * the credit row always occupies its space.
  */
-export const TRAILER_CREDIT_JOIN_SECONDS = 15.4
+export const TRAILER_CREDIT_JOIN_SECONDS = 12.2
 
 /** Authored casing preserved: the card uppercases in CSS, as the film does. */
 export const TRAILER_TITLE_LABEL = 'PROJECT BLUEFIN'
@@ -124,10 +124,10 @@ export const TRAILER_PLATES: readonly TrailerPlate[] = [
   {
     id: 'maintitle',
     kind: 'maintitle',
-    // maintitle-a 11.0+4.4 and maintitle-b 15.4+7.2 are one continuous title
+    // maintitle-a 7.0+5.2 and maintitle-b 12.2+10.4 are one continuous title
     // presence in the cut; the credit line appears mid-way (see
     // TRAILER_CREDIT_JOIN_SECONDS).
-    start: 11.0,
+    start: 7.0,
     end: 22.6,
     title: TRAILER_TITLE_LINE,
     lines: [TRAILER_CREDIT_LINE],
@@ -284,9 +284,9 @@ export function trailerPlateOpacity(plate: TrailerPlate, timeSeconds: number): n
  * THE PAGE HEADING YIELDS TO THE PICTURE.
  *
  * The teaser page carries the film's name in an `h1` above the frame, and the
- * cut carries the same four words in its own main-title card at 11.0 s. Both
+ * cut carries the same four words in its own main-title card at 7.0 s. Both
  * were on screen at once, so the title card revealed a title the audience had
- * already been reading for eleven seconds — the reveal had nothing left to
+ * already been reading for seconds — the reveal had nothing left to
  * reveal, and the page read as if it were stuttering.
  *
  * A theater darkens before the title hits. The heading is therefore fully down

--- a/src/tests/wolvesTrailerPlates.test.ts
+++ b/src/tests/wolvesTrailerPlates.test.ts
@@ -30,7 +30,7 @@ import {
 // recut, re-port the manifest — do not nudge these numbers to make a test pass.
 describe('wolves trailer plates', () => {
   it('keeps the music at 1:50.020 and the picture through 1:55.020', () => {
-    expect(TRAILER_VIDEO_ID).toBe('iHXBTH_fwB0')
+    expect(TRAILER_VIDEO_ID).toBe('u-ZWdKcHyXM')
     expect(TRAILER_MUSIC_END_SECONDS).toBe(110.02)
     expect(TRAILER_DURATION_SECONDS).toBe(115.02)
     expect(TRAILER_CUT_DURATION_SECONDS).toBe(TRAILER_DURATION_SECONDS)

--- a/src/tests/wolvesTrailerPlates.test.ts
+++ b/src/tests/wolvesTrailerPlates.test.ts
@@ -38,14 +38,14 @@ describe('wolves trailer plates', () => {
 
   it('shows nothing before the main title and after the cut ends', () => {
     expect(activeTrailerPlates(0)).toEqual([])
-    expect(activeTrailerPlates(10.9)).toEqual([])
+    expect(activeTrailerPlates(6.9)).toEqual([])
     expect(activeTrailerPlates(TRAILER_MUSIC_END_SECONDS).map(p => p.id)).toEqual(['endcard-event', 'endcard-cta'])
     expect(activeTrailerPlates(TRAILER_DURATION_SECONDS)).toEqual([])
     expect(activeTrailerPlates(Number.NaN)).toEqual([])
   })
 
   it('holds the main title across both authored beats', () => {
-    expect(activeTrailerPlates(11).map(p => p.id)).toEqual(['maintitle'])
+    expect(activeTrailerPlates(7).map(p => p.id)).toEqual(['maintitle'])
     expect(activeTrailerPlates(TRAILER_CREDIT_JOIN_SECONDS).map(p => p.id)).toEqual(['maintitle'])
     expect(activeTrailerPlates(22.6).map(p => p.id)).toEqual([])
   })

--- a/wolves/README.md
+++ b/wolves/README.md
@@ -15,7 +15,7 @@ behavior for a content request.
 
 - Teaser entry: `wolves/index.html` → `src/wolves-teaser-main.ts` →
   `src/WolvesTeaserApp.vue`. The teaser embeds the owner's delivered render of
-  Trailer 1 (YouTube `iHXBTH_fwB0`, "Wolves Trailer Final") — the cut's plates,
+  Trailer 1 (YouTube `u-ZWdKcHyXM`, "Seven Days to the Wolves") — the cut's plates,
   bridge, and end card are burned in, and the browser only masks the opening
   black, yields the page heading, and holds the URL card over YouTube's
   endscreen. The authored record of the cut stays in


### PR DESCRIPTION
## Problem

The teaser's Trailer 1 embed stopped playing: the delivered render upload (`iHXBTH_fwB0`, swapped in by #756) was removed from YouTube — the player API reports "removed by the uploader" and oEmbed 404s, so the teaser frame never plays.

## Fix

The owner re-uploaded the cut as `u-ZWdKcHyXM` ("Seven Days to the Wolves"). This PR:

1. Swaps `TRAILER_VIDEO_ID` to the new upload (data record, test, teaser docs).
2. Carries forward the re-staged title timing from the closed #757 (`d5800ddd`): the current render is the re-staged master from castrojo/destiny-vids#313 — title card rises at 7.0 s (was 11.0), credit pair arrives with the burst at 12.2 s (was 15.4). Without this, the heading-yield timing is measured against a picture that starts 12.2 s late.

## Validation

- `npx vitest run src/tests/wolvesTrailerPlates.test.ts` — 28/28 pass
- Headless Chromium against `/wolves/`: embed iframe loads `u-ZWdKcHyXM`, thumbnail serves `200 image/jpeg`, zero YouTube request failures
- oEmbed for the new ID: 200, "Seven Days to the Wolves #7wolves #hireawolf" by Jorge Castro